### PR TITLE
Add role guard to ensure users have roles

### DIFF
--- a/alcs-api/src/common/authorization/authorization.controller.spec.ts
+++ b/alcs-api/src/common/authorization/authorization.controller.spec.ts
@@ -42,10 +42,7 @@ describe('AuthorizationController', () => {
 
     controller = module.get<AuthorizationController>(AuthorizationController);
 
-    mockService.exchangeCodeForToken.mockResolvedValue({
-      token: mockToken,
-      roles: [AUTH_ROLE.LUP],
-    });
+    mockService.exchangeCodeForToken.mockResolvedValue(mockToken);
     mockService.refreshToken.mockResolvedValue(mockToken);
   });
 
@@ -62,23 +59,6 @@ describe('AuthorizationController', () => {
     expect(res.status).toHaveBeenCalledWith(302);
     expect(res.redirect).toHaveBeenCalledWith(
       `${frontEndUrl}/authorized?t=${fakeToken}&r=${fakeRefreshToken}`,
-    );
-  });
-
-  it('should set noroles flag when user has no roles', async () => {
-    mockService.exchangeCodeForToken.mockResolvedValue({
-      token: mockToken,
-      roles: [],
-    });
-
-    const res = createMock<FastifyReply>();
-    await controller.handleAuth('code', res);
-
-    const frontEndUrl = config.get('FRONTEND_ROOT');
-
-    expect(res.status).toHaveBeenCalledWith(302);
-    expect(res.redirect).toHaveBeenCalledWith(
-      `${frontEndUrl}/authorized?t=${fakeToken}&r=${fakeRefreshToken}&noroles=true`,
     );
   });
 

--- a/alcs-api/src/common/authorization/authorization.controller.ts
+++ b/alcs-api/src/common/authorization/authorization.controller.ts
@@ -17,21 +17,16 @@ export class AuthorizationController {
   @Public()
   async handleAuth(@Query('code') authCode: string, @Res() res: FastifyReply) {
     try {
-      const { token, roles } =
-        await this.authorizationService.exchangeCodeForToken(authCode);
+      const token = await this.authorizationService.exchangeCodeForToken(
+        authCode,
+      );
 
       const frontEndUrl = this.config.get('FRONTEND_ROOT');
 
       res.status(302);
-      if (roles && roles.length > 0) {
-        res.redirect(
-          `${frontEndUrl}/authorized?t=${token.access_token}&r=${token.refresh_token}`,
-        );
-      } else {
-        res.redirect(
-          `${frontEndUrl}/authorized?t=${token.access_token}&r=${token.refresh_token}&noroles=true`,
-        );
-      }
+      res.redirect(
+        `${frontEndUrl}/authorized?t=${token.access_token}&r=${token.refresh_token}`,
+      );
     } catch (e) {
       console.log(e);
     }

--- a/alcs-api/src/common/authorization/authorization.service.spec.ts
+++ b/alcs-api/src/common/authorization/authorization.service.spec.ts
@@ -71,7 +71,7 @@ describe('AuthorizationService', () => {
   });
 
   it('should call out to keycloak when exchanging a code for token', async () => {
-    const { token } = await service.exchangeCodeForToken('fake-code');
+    const token = await service.exchangeCodeForToken('fake-code');
 
     expect(token).toEqual({ id_token: fakeToken });
     expect(mockHttpService.post).toHaveBeenCalled();

--- a/alcs-api/src/common/authorization/authorization.service.ts
+++ b/alcs-api/src/common/authorization/authorization.service.ts
@@ -101,10 +101,7 @@ export class AuthorizationService {
 
       this.registerUser(decodedToken);
 
-      return {
-        token: res.data,
-        roles: decodedToken.client_roles,
-      };
+      return res.data;
     } else {
       throw new UnauthorizedException();
     }

--- a/alcs-frontend/src/app/app-routing.module.ts
+++ b/alcs-frontend/src/app/app-routing.module.ts
@@ -5,21 +5,22 @@ import { NotFoundComponent } from './features/errors/not-found/not-found.compone
 import { LoginComponent } from './features/login/login.component';
 import { ProvisionComponent } from './features/provision/provision.component';
 import { AuthGuard } from './services/authentication/auth.guard';
+import { HasRolesGuard } from './services/authentication/hasRoles.guard';
 
 const routes: Routes = [
   {
     path: 'board',
-    canActivate: [AuthGuard],
+    canActivate: [HasRolesGuard],
     loadChildren: () => import('./features/board/board.module').then((m) => m.BoardModule),
   },
   {
     path: 'home',
-    canActivate: [AuthGuard],
+    canActivate: [HasRolesGuard],
     loadChildren: () => import('./features/home/home.module').then((m) => m.HomeModule),
   },
   {
     path: 'application',
-    canActivate: [AuthGuard],
+    canActivate: [HasRolesGuard],
     loadChildren: () => import('./features/application/application.module').then((m) => m.ApplicationModule),
   },
   {
@@ -33,6 +34,7 @@ const routes: Routes = [
   {
     path: 'provision',
     component: ProvisionComponent,
+    canActivate: [AuthGuard],
   },
   { path: '', redirectTo: '/login', pathMatch: 'full' },
   { path: '**', component: NotFoundComponent },

--- a/alcs-frontend/src/app/features/authorization/authorization.component.ts
+++ b/alcs-frontend/src/app/features/authorization/authorization.component.ts
@@ -13,15 +13,11 @@ export class AuthorizationComponent implements OnInit {
   async ngOnInit() {
     const token = this.route.snapshot.queryParamMap.get('t');
     const refreshToken = this.route.snapshot.queryParamMap.get('r');
-    const noRoles = this.route.snapshot.queryParamMap.get('noroles');
     if (token && refreshToken) {
       await this.authService.setTokens(token, refreshToken);
 
       const targetUrl = localStorage.getItem('targetUrl');
-
-      if (noRoles) {
-        await this.router.navigateByUrl('/provision');
-      } else if (targetUrl) {
+      if (targetUrl) {
         window.location.href = targetUrl;
       } else {
         await this.router.navigateByUrl(environment.homeUrl);

--- a/alcs-frontend/src/app/features/home/home.component.html
+++ b/alcs-frontend/src/app/features/home/home.component.html
@@ -1,6 +1,5 @@
 <div class="welcome-title">
   <h1>Welcome {{ currentUser.name }} to ALCS</h1>
-
 </div>
 <div>
   <app-assigned></app-assigned>

--- a/alcs-frontend/src/app/features/home/home.component.spec.ts
+++ b/alcs-frontend/src/app/features/home/home.component.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthenticationService } from '../../services/authentication/authentication.service';
@@ -12,6 +13,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     mockAuthService = jasmine.createSpyObj<AuthenticationService>('AuthenticationService', ['getCurrentUser']);
+    mockAuthService.$currentUser = new EventEmitter();
 
     mockAuthService.getCurrentUser.and.returnValue({
       name: 'agent',

--- a/alcs-frontend/src/app/features/home/home.component.ts
+++ b/alcs-frontend/src/app/features/home/home.component.ts
@@ -12,6 +12,11 @@ export class HomeComponent implements OnInit {
   constructor(private authService: AuthenticationService) {}
 
   ngOnInit(): void {
-    this.currentUser = this.authService.getCurrentUser();
+    this.currentUser = this.authService.getCurrentUser()!;
+    this.authService.$currentUser.subscribe((currentUser) => {
+      if (currentUser) {
+        this.currentUser = currentUser;
+      }
+    });
   }
 }

--- a/alcs-frontend/src/app/services/authentication/authentication.service.ts
+++ b/alcs-frontend/src/app/services/authentication/authentication.service.ts
@@ -10,6 +10,7 @@ const REFRESH_TOKEN_KEY = 'refresh_token';
 export interface ICurrentUser {
   name: string;
   email: string;
+  client_roles?: string[];
 }
 
 @Injectable({
@@ -19,13 +20,13 @@ export class AuthenticationService {
   private token: string | undefined;
   private refreshToken: string | undefined;
   private expires: number | undefined;
-  isInitialized = false;
-  currentUser!: ICurrentUser;
 
-  isAuthenticated = new EventEmitter<boolean>();
+  isInitialized = false;
+  $currentUser = new EventEmitter<ICurrentUser>();
+  currentUser: ICurrentUser | undefined;
 
   constructor(private http: HttpClient) {
-    this.isAuthenticated.emit(false);
+    this.$currentUser.emit(undefined);
   }
 
   async setTokens(token: string, refreshToken: string) {
@@ -39,7 +40,7 @@ export class AuthenticationService {
 
     //Convert to MS for JS consistency
     this.expires = decodedToken.exp! * 1000;
-    this.isAuthenticated.emit(true);
+    this.$currentUser.emit(this.currentUser);
   }
 
   clearTokens() {

--- a/alcs-frontend/src/app/services/authentication/hasRoles.guard.spec.ts
+++ b/alcs-frontend/src/app/services/authentication/hasRoles.guard.spec.ts
@@ -1,0 +1,61 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AuthenticationService, ICurrentUser } from './authentication.service';
+import { HasRolesGuard } from './hasRoles.guard';
+
+describe('HasRolesGuard', () => {
+  let guard: HasRolesGuard;
+  let mockAuthService: jasmine.SpyObj<AuthenticationService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    mockAuthService = jasmine.createSpyObj<AuthenticationService>('AuthenticationService', [
+      'getToken',
+      'getCurrentUser',
+    ]);
+
+    mockAuthService.getToken.and.resolveTo('valid-token');
+
+    mockRouter = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        {
+          provide: AuthenticationService,
+          useValue: mockAuthService,
+        },
+        {
+          provide: Router,
+          useValue: mockRouter,
+        },
+      ],
+    });
+    guard = TestBed.inject(HasRolesGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should allow activation when a token is present', async () => {
+    const canActivate = await guard.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot);
+    expect(canActivate).toBeTrue();
+  });
+
+  it('should redirect to login when there is no token', async () => {
+    mockAuthService.getToken.and.resolveTo(undefined);
+    const canActivate = await guard.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot);
+    expect(canActivate).toBeFalse();
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/login');
+  });
+
+  it('should redirect to provision when user has no roles', async () => {
+    mockAuthService.getCurrentUser.and.returnValue({} as ICurrentUser);
+    const canActivate = await guard.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot);
+    expect(canActivate).toBeFalse();
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/provision');
+  });
+});

--- a/alcs-frontend/src/app/services/authentication/hasRoles.guard.ts
+++ b/alcs-frontend/src/app/services/authentication/hasRoles.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthenticationService } from './authentication.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HasRolesGuard implements CanActivate {
+  constructor(private authenticationService: AuthenticationService, private router: Router) {}
+
+  async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
+    const hasToken = await this.authenticationService.getToken();
+    const currentUser = await this.authenticationService.getCurrentUser();
+    if (!hasToken) {
+      this.router.navigateByUrl('/login');
+      return false;
+    }
+
+    if (currentUser && !currentUser.client_roles) {
+      this.router.navigateByUrl('/provision');
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/alcs-frontend/src/app/shared/header/header.component.html
+++ b/alcs-frontend/src/app/shared/header/header.component.html
@@ -7,14 +7,14 @@
         </a>
       </div>
       <div class="col right">
-        <div>
+        <div *ngIf="currentUser">
           <a [routerLink]="homeUrl">
             <button class="menu-item">Home</button>
           </a>
         </div>
       </div>
       <div class="col">
-        <button class="menu-item" [matMenuTriggerFor]="menu">Boards ▾</button>
+        <button  *ngIf="currentUser" class="menu-item" [matMenuTriggerFor]="menu">Boards ▾</button>
         <mat-menu #menu="matMenu">
           <div class="board-item menu-item" *ngFor="let dm of sortedDecisionMakers" (click)="onSelectBoard(dm.code)">
             <app-favorite-button

--- a/alcs-frontend/src/app/shared/header/header.component.html
+++ b/alcs-frontend/src/app/shared/header/header.component.html
@@ -7,14 +7,14 @@
         </a>
       </div>
       <div class="col right">
-        <div *ngIf="currentUser">
+        <div *ngIf="hasRoles">
           <a [routerLink]="homeUrl">
             <button class="menu-item">Home</button>
           </a>
         </div>
       </div>
       <div class="col">
-        <button  *ngIf="currentUser" class="menu-item" [matMenuTriggerFor]="menu">Boards ▾</button>
+        <button *ngIf="hasRoles" class="menu-item" [matMenuTriggerFor]="menu">Boards ▾</button>
         <mat-menu #menu="matMenu">
           <div class="board-item menu-item" *ngFor="let dm of sortedDecisionMakers" (click)="onSelectBoard(dm.code)">
             <app-favorite-button
@@ -28,8 +28,8 @@
           </div>
         </mat-menu>
       </div>
-      <div *ngIf="currentUserProfile" class="col right">
-        <app-notifications></app-notifications>
+      <div *ngIf="currentUser" class="col right">
+        <app-notifications *ngIf="hasRoles"></app-notifications>
         <button mat-flat-button color="primary" (click)="onLogout()">
           <mat-icon>logout</mat-icon>
           Logout

--- a/alcs-frontend/src/app/shared/header/header.component.ts
+++ b/alcs-frontend/src/app/shared/header/header.component.ts
@@ -19,6 +19,7 @@ export class HeaderComponent implements OnInit {
   homeUrl = environment.homeUrl;
   currentUserProfile?: UserDto;
   currentUser?: ICurrentUser;
+  hasRoles = false;
   sortedDecisionMakers: ApplicationDecisionMakerDto[] = [];
   notifications: NotificationDto[] = [];
 
@@ -33,8 +34,10 @@ export class HeaderComponent implements OnInit {
 
   ngOnInit(): void {
     this.authService.$currentUser.subscribe((currentUser) => {
-      if (currentUser && !!currentUser.client_roles) {
-        this.currentUser = currentUser;
+      this.currentUser = currentUser;
+      this.hasRoles = !!currentUser.client_roles;
+
+      if (this.hasRoles) {
         this.userService.fetchUsers();
         this.applicationService.setup();
         this.loadNotifications();

--- a/alcs-frontend/src/app/shared/header/header.component.ts
+++ b/alcs-frontend/src/app/shared/header/header.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
 import { ApplicationDecisionMakerDto } from '../../services/application/application-code.dto';
 import { ApplicationService } from '../../services/application/application.service';
-import { AuthenticationService } from '../../services/authentication/authentication.service';
+import { AuthenticationService, ICurrentUser } from '../../services/authentication/authentication.service';
 import { NotificationDto } from '../../services/notification/notification.dto';
 import { NotificationService } from '../../services/notification/notification.service';
 import { ToastService } from '../../services/toast/toast.service';
@@ -18,6 +18,7 @@ import { UserService } from '../../services/user/user.service';
 export class HeaderComponent implements OnInit {
   homeUrl = environment.homeUrl;
   currentUserProfile?: UserDto;
+  currentUser?: ICurrentUser;
   sortedDecisionMakers: ApplicationDecisionMakerDto[] = [];
   notifications: NotificationDto[] = [];
 
@@ -31,8 +32,9 @@ export class HeaderComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.authService.isAuthenticated.subscribe((isAuthenticated) => {
-      if (isAuthenticated) {
+    this.authService.$currentUser.subscribe((currentUser) => {
+      if (currentUser && !!currentUser.client_roles) {
+        this.currentUser = currentUser;
         this.userService.fetchUsers();
         this.applicationService.setup();
         this.loadNotifications();


### PR DESCRIPTION
* Prevent users from loading home/boards/applications if they don't have roles set
* Take users to /provision page if they have no roles
* Setup header to render minimally when user has no roles
* Remove noroles flag from backend as frontend now has the logic