### PR TITLE
User Cleanup

### DIFF
--- a/alcs-api/src/app.controller.spec.ts
+++ b/alcs-api/src/app.controller.spec.ts
@@ -1,5 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ClsService } from 'nestjs-cls';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { mockKeyCloakProviders } from './common/utils/test-helpers/mockTypes';
@@ -21,6 +22,10 @@ describe('AppController', () => {
         {
           provide: AppService,
           useValue: mockAppService,
+        },
+        {
+          provide: ClsService,
+          useValue: {},
         },
         ...mockKeyCloakProviders,
       ],

--- a/alcs-api/src/app.controller.ts
+++ b/alcs-api/src/app.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { Public, RoleGuard } from 'nest-keycloak-connect';
+import { Public } from 'nest-keycloak-connect';
 import { AppService } from './app.service';
 import { ANY_AUTH_ROLE } from './common/authorization/roles';
+import { RolesGuard } from './common/authorization/roles-guard.service';
 import { UserRoles } from './common/authorization/roles.decorator';
 import { HealthCheckDto } from './healthcheck/healthcheck.dto';
 
@@ -19,7 +20,7 @@ export class AppController {
 
   @Get('token')
   @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-  @UseGuards(RoleGuard)
+  @UseGuards(RolesGuard)
   @UserRoles(...ANY_AUTH_ROLE)
   adminRoute(): string {
     return 'Admin!';

--- a/alcs-api/src/application-reconsideration/application-reconsideration.controller.spec.ts
+++ b/alcs-api/src/application-reconsideration/application-reconsideration.controller.spec.ts
@@ -2,6 +2,7 @@ import { classes } from '@automapper/classes';
 import { AutomapperModule } from '@automapper/nestjs';
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ClsService } from 'nestjs-cls';
 import { Board } from '../board/board.entity';
 import { BoardService } from '../board/board.service';
 import { ReconsiderationProfile } from '../common/automapper/reconsideration.automapper.profile';
@@ -45,6 +46,10 @@ describe('ApplicationReconsiderationController', () => {
         {
           provide: BoardService,
           useValue: mockBoardService,
+        },
+        {
+          provide: ClsService,
+          useValue: {},
         },
         ...mockKeyCloakProviders,
       ],

--- a/alcs-api/src/application-reconsideration/application-reconsideration.controller.ts
+++ b/alcs-api/src/application-reconsideration/application-reconsideration.controller.ts
@@ -10,9 +10,9 @@ import {
 } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from 'nest-keycloak-connect';
 import { BoardService } from '../board/board.service';
 import { ROLES_ALLOWED_APPLICATIONS } from '../common/authorization/roles';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import {
   ApplicationReconsiderationCreateDto,
@@ -22,7 +22,7 @@ import { ApplicationReconsiderationService } from './application-reconsideration
 
 @Controller('application-reconsideration')
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class ApplicationReconsiderationController {
   constructor(
     private reconsiderationService: ApplicationReconsiderationService,

--- a/alcs-api/src/application/application-code/application-local-government/application-local-government.controller.ts
+++ b/alcs-api/src/application/application-code/application-local-government/application-local-government.controller.ts
@@ -3,7 +3,7 @@ import { InjectMapper } from '@automapper/nestjs';
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from '../../../common/authorization/role.guard';
+import { RolesGuard } from '../../../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../../../common/authorization/roles';
 import { UserRoles } from '../../../common/authorization/roles.decorator';
 import { ApplicationLocalGovernmentDto } from './application-local-government.dto';
@@ -11,7 +11,7 @@ import { ApplicationLocalGovernmentService } from './application-local-governmen
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('application-local-government')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class ApplicationLocalGovernmentController {
   constructor(
     private codeService: ApplicationLocalGovernmentService,

--- a/alcs-api/src/application/application-decision-meeting/application-decision-meeting.controller.ts
+++ b/alcs-api/src/application/application-decision-meeting/application-decision-meeting.controller.ts
@@ -13,7 +13,7 @@ import {
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
 import { Any } from 'typeorm';
-import { RoleGuard } from '../../common/authorization/role.guard';
+import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../../common/authorization/roles';
 import { UserRoles } from '../../common/authorization/roles.decorator';
 import { UserDto } from '../../user/user.dto';
@@ -33,7 +33,7 @@ import { ApplicationDecisionMeetingService } from './application-decision-meetin
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('application-decision-meeting')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class ApplicationDecisionMeetingController {
   constructor(
     private appDecisionMeetingService: ApplicationDecisionMeetingService,

--- a/alcs-api/src/application/application-decision/application-decision.controller.ts
+++ b/alcs-api/src/application/application-decision/application-decision.controller.ts
@@ -14,7 +14,7 @@ import {
 } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from '../../common/authorization/role.guard';
+import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../../common/authorization/roles';
 import { UserRoles } from '../../common/authorization/roles.decorator';
 import { ApplicationService } from '../application.service';
@@ -34,7 +34,7 @@ import { DecisionMakerCode } from './decision-maker/decision-maker.entity';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('application-decision')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class ApplicationDecisionController {
   constructor(
     private appDecisionService: ApplicationDecisionService,

--- a/alcs-api/src/application/application-document/application-document.controller.ts
+++ b/alcs-api/src/application/application-document/application-document.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from '../../common/authorization/role.guard';
+import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../../common/authorization/roles';
 import { UserRoles } from '../../common/authorization/roles.decorator';
 import { ApplicationDocumentDto } from './application-document.dto';
@@ -25,7 +25,7 @@ import {
 import { ApplicationDocumentService } from './application-document.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 @Controller('application-document')
 export class ApplicationDocumentController {
   constructor(

--- a/alcs-api/src/application/application-meeting/application-meeting.controller.ts
+++ b/alcs-api/src/application/application-meeting/application-meeting.controller.ts
@@ -16,7 +16,7 @@ import {
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
 import { CodeService } from '../../code/code.service';
-import { RoleGuard } from '../../common/authorization/role.guard';
+import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../../common/authorization/roles';
 import { UserRoles } from '../../common/authorization/roles.decorator';
 import { ServiceNotFoundException } from '../../common/exceptions/base.exception';
@@ -34,7 +34,7 @@ import { ApplicationMeetingService } from './application-meeting.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('application-meeting')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class ApplicationMeetingController {
   private logger = new Logger(ApplicationMeetingController.name);
 

--- a/alcs-api/src/application/application.controller.spec.ts
+++ b/alcs-api/src/application/application.controller.spec.ts
@@ -2,12 +2,12 @@ import { classes } from '@automapper/classes';
 import { AutomapperModule } from '@automapper/nestjs';
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ClsService } from 'nestjs-cls';
 import { BoardSmallDto } from '../board/board.dto';
 import { CardStatusDto } from '../card/card-status/card-status.dto';
 import { CardDto } from '../card/card.dto';
 import { Card } from '../card/card.entity';
 import { CardService } from '../card/card.service';
-import { RoleGuard } from '../common/authorization/role.guard';
 import { ApplicationProfile } from '../common/automapper/application.automapper.profile';
 import { UserProfile } from '../common/automapper/user.automapper.profile';
 import { ConfigModule } from '../common/config/config.module';
@@ -22,10 +22,6 @@ import { ApplicationController } from './application.controller';
 import { ApplicationDto, UpdateApplicationDto } from './application.dto';
 import { Application } from './application.entity';
 import { ApplicationService } from './application.service';
-
-jest.mock('../common/authorization/role.guard', () => ({
-  RoleGuard: createMock<RoleGuard>(),
-}));
 
 describe('ApplicationController', () => {
   let controller: ApplicationController;
@@ -83,6 +79,10 @@ describe('ApplicationController', () => {
         {
           provide: CardService,
           useValue: cardService,
+        },
+        {
+          provide: ClsService,
+          useValue: {},
         },
         ...mockKeyCloakProviders,
       ],

--- a/alcs-api/src/application/application.controller.ts
+++ b/alcs-api/src/application/application.controller.ts
@@ -13,7 +13,7 @@ import {
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
 import { CardService } from '../card/card.service';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { ROLES_ALLOWED_APPLICATIONS } from '../common/authorization/roles';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { CONFIG_TOKEN } from '../common/config/config.module';
@@ -29,7 +29,7 @@ import { ApplicationService } from './application.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('application')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class ApplicationController {
   constructor(
     private applicationService: ApplicationService,

--- a/alcs-api/src/board/board.controller.ts
+++ b/alcs-api/src/board/board.controller.ts
@@ -7,7 +7,7 @@ import { ApplicationReconsiderationService } from '../application-reconsideratio
 import { ApplicationService } from '../application/application.service';
 import { CardCreateDto } from '../card/card.dto';
 import { CardService } from '../card/card.service';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import {
   ANY_AUTH_ROLE,
   ROLES_ALLOWED_BOARDS,
@@ -21,7 +21,7 @@ import { BoardService } from './board.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('board')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class BoardController {
   constructor(
     private boardService: BoardService,

--- a/alcs-api/src/card/card-history/card.subscriber.spec.ts
+++ b/alcs-api/src/card/card-history/card.subscriber.spec.ts
@@ -33,7 +33,7 @@ describe('CardSubscriber', () => {
     mockUserService = createMock<UserService>();
     subscribersArray = [];
 
-    mockUserService.get.mockResolvedValue({
+    mockUserService.getByGuid.mockResolvedValue({
       uuid: 'fake-uuid',
     } as User);
     updateEvent = createMock<UpdateEvent<Card>>();
@@ -87,7 +87,7 @@ describe('CardSubscriber', () => {
   });
 
   it('should throw an error if user is not found', async () => {
-    mockUserService.get.mockResolvedValue(undefined);
+    mockUserService.getByGuid.mockResolvedValue(undefined);
 
     await expect(
       cardSubscriber.beforeUpdate(updateEvent),

--- a/alcs-api/src/card/card-history/card.subscriber.ts
+++ b/alcs-api/src/card/card-history/card.subscriber.ts
@@ -29,8 +29,8 @@ export class CardSubscriber implements EntitySubscriberInterface<Card> {
     const oldApplication = event.databaseEntity;
     const newApplication = event.entity as Card;
 
-    const userEmail = this.cls.get('userEmail');
-    const user = await this.userService.get(userEmail);
+    const userGuids = this.cls.get('userGuids');
+    const user = await this.userService.getByGuid(userGuids);
     if (!user) {
       throw new Error('User not found from token! Has their email changed?');
     }

--- a/alcs-api/src/card/card-status/card-status.controller.spec.ts
+++ b/alcs-api/src/card/card-status/card-status.controller.spec.ts
@@ -1,5 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ClsService } from 'nestjs-cls';
 import { initCardStatusMockEntity } from '../../common/utils/test-helpers/mockEntities';
 import { mockKeyCloakProviders } from '../../common/utils/test-helpers/mockTypes';
 import { CardStatusController } from './card-status.controller';
@@ -25,6 +26,10 @@ describe('CardStatusController', () => {
         {
           provide: CardStatusService,
           useValue: mockCardStatusService,
+        },
+        {
+          provide: ClsService,
+          useValue: {},
         },
         ...mockKeyCloakProviders,
       ],

--- a/alcs-api/src/card/card-status/card-status.controller.ts
+++ b/alcs-api/src/card/card-status/card-status.controller.ts
@@ -1,15 +1,15 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from 'nest-keycloak-connect';
 import { AUTH_ROLE } from '../../common/authorization/roles';
+import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { UserRoles } from '../../common/authorization/roles.decorator';
 import { CardStatusDto } from './card-status.dto';
 import { CardStatusService } from './card-status.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('card-status')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class CardStatusController {
   constructor(private cardStatusService: CardStatusService) {}
 

--- a/alcs-api/src/card/card-subtask/card-subtask.controller.ts
+++ b/alcs-api/src/card/card-subtask/card-subtask.controller.ts
@@ -14,7 +14,7 @@ import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
 import { CardSubtask } from '../../card/card-subtask/card-subtask.entity';
 import { CardSubtaskService } from '../../card/card-subtask/card-subtask.service';
-import { RoleGuard } from '../../common/authorization/role.guard';
+import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import {
   ANY_AUTH_ROLE,
   ROLES_ALLOWED_BOARDS,
@@ -25,7 +25,7 @@ import { CardService } from '../card.service';
 import { CardSubtaskDto, UpdateCardSubtaskDto } from './card-subtask.dto';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 @Controller('card-subtask')
 export class CardSubtaskController {
   constructor(

--- a/alcs-api/src/card/card.controller.spec.ts
+++ b/alcs-api/src/card/card.controller.spec.ts
@@ -1,5 +1,6 @@
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ClsService } from 'nestjs-cls';
 import { initCardMockEntity } from '../common/utils/test-helpers/mockEntities';
 import { mockKeyCloakProviders } from '../common/utils/test-helpers/mockTypes';
 import { CardController } from './card.controller';
@@ -19,8 +20,12 @@ describe('CardController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CardController],
       providers: [
-        ...mockKeyCloakProviders,
         { provide: CardService, useValue: cardService },
+        {
+          provide: ClsService,
+          useValue: {},
+        },
+        ...mockKeyCloakProviders,
       ],
     }).compile();
 

--- a/alcs-api/src/card/card.controller.ts
+++ b/alcs-api/src/card/card.controller.ts
@@ -1,14 +1,14 @@
 import { Body, Controller, Param, Patch, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from 'nest-keycloak-connect';
 import { ROLES_ALLOWED_BOARDS } from '../common/authorization/roles';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { CardUpdateDto } from './card.dto';
 import { CardService } from './card.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 @Controller('card')
 export class CardController {
   constructor(private cardService: CardService) {}

--- a/alcs-api/src/code/code.controller.ts
+++ b/alcs-api/src/code/code.controller.ts
@@ -3,12 +3,12 @@ import { InjectMapper } from '@automapper/nestjs';
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from 'nest-keycloak-connect';
 import { ReconsiderationTypeDto } from '../application-reconsideration/application-reconsideration.dto';
 import { ApplicationReconsiderationType } from '../application-reconsideration/reconsideration-type/application-reconsideration-type.entity';
 import { CardStatusDto } from '../card/card-status/card-status.dto';
 import { CardStatus } from '../card/card-status/card-status.entity';
 import { ANY_AUTH_ROLE } from '../common/authorization/roles';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { MasterCodesDto } from './application-code/application-code.dto';
 import { ApplicationRegionDto } from './application-code/application-region/application-region.dto';
@@ -19,7 +19,7 @@ import { CodeService } from './code.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('code')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class CodeController {
   constructor(
     private codeService: CodeService,

--- a/alcs-api/src/comment/comment.controller.ts
+++ b/alcs-api/src/comment/comment.controller.ts
@@ -15,7 +15,7 @@ import {
 } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { ROLES_ALLOWED_BOARDS } from '../common/authorization/roles';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { CommentDto, CreateCommentDto, UpdateCommentDto } from './comment.dto';
@@ -26,7 +26,7 @@ import { CommentMention } from './mention/comment-mention.entity';
 
 @Controller('comment')
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class CommentController {
   constructor(
     private commentService: CommentService,

--- a/alcs-api/src/commissioner/commissioner.controller.ts
+++ b/alcs-api/src/commissioner/commissioner.controller.ts
@@ -5,14 +5,14 @@ import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
 import { ApplicationDto } from '../application/application.dto';
 import { ApplicationService } from '../application/application.service';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { AUTH_ROLE } from '../common/authorization/roles';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { CommissionerApplicationDto } from './commissioner.dto';
 
 @Controller('commissioner')
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class CommissionerController {
   constructor(
     private applicationService: ApplicationService,

--- a/alcs-api/src/common/authorization/authorization.service.spec.ts
+++ b/alcs-api/src/common/authorization/authorization.service.spec.ts
@@ -45,11 +45,14 @@ describe('AuthorizationService', () => {
       } as any),
     );
 
-    mockUserService.create.mockResolvedValue(createMock<Promise<User>>());
-    mockUserService.sendNewUserRequestEmail.mockResolvedValue(
-      createMock<Promise<void>>(),
-    );
-    mockUserService.get.mockResolvedValue(null);
+    mockUserService.create.mockResolvedValue({
+      clientRoles: [],
+      bceidGuid: '',
+      displayName: '',
+    } as User);
+
+    mockUserService.getByGuid.mockResolvedValue(null);
+    mockUserService.sendNewUserRequestEmail.mockResolvedValue(null);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -89,6 +92,7 @@ describe('AuthorizationService', () => {
 
   it('should call out CreateUser and SendEmail on receiving token if user is not registered', async () => {
     await service.exchangeCodeForToken('fake-code');
+
     expect(mockUserService.create).toBeCalledTimes(1);
     expect(mockUserService.sendNewUserRequestEmail).toBeCalledTimes(1);
   });
@@ -97,13 +101,15 @@ describe('AuthorizationService', () => {
     mockUserService.create.mockResolvedValue({
       clientRoles: ['fake-role'],
     } as User);
+
     await service.exchangeCodeForToken('fake-code');
+
     expect(mockUserService.create).toBeCalledTimes(1);
     expect(mockUserService.sendNewUserRequestEmail).toBeCalledTimes(0);
   });
 
   it('should not call out CreateUser on receiving token if user is registered', async () => {
-    mockUserService.get.mockResolvedValue(createMock<User>({} as User));
+    mockUserService.getByGuid.mockResolvedValue(createMock<User>({} as User));
     mockUserService.update.mockResolvedValue(createMock<User>({} as User));
     await service.exchangeCodeForToken('fake-code');
     expect(mockUserService.create).toBeCalledTimes(0);

--- a/alcs-api/src/common/automapper/user.automapper.profile.ts
+++ b/alcs-api/src/common/automapper/user.automapper.profile.ts
@@ -3,7 +3,8 @@ import { AutomapperProfile, InjectMapper } from '@automapper/nestjs';
 import { Injectable } from '@nestjs/common';
 import {
   AssigneeDto,
-  CreateOrUpdateUserDto,
+  CreateUserDto,
+  UpdateUserDto,
   UserDto,
   UserSettingsDto,
 } from '../../user/user.dto';
@@ -17,35 +18,49 @@ export class UserProfile extends AutomapperProfile {
 
   override get profile() {
     return (mapper) => {
-      createMap(mapper, CreateOrUpdateUserDto, User);
+      createMap(mapper, UpdateUserDto, User);
       createMap(mapper, UserSettingsDto, UserSettings);
       createMap(mapper, UserSettings, UserSettingsDto);
-      createMap(mapper, UserDto, User);
+      createMap(mapper, CreateUserDto, User);
       createMap(
         mapper,
         User,
         UserDto,
         forMember(
           (ud) => ud.initials,
-          mapFrom(
-            (u) =>
-              u.givenName?.charAt(0).toUpperCase() +
-              u.familyName?.charAt(0).toUpperCase(),
-          ),
+          mapFrom((u) => {
+            if (u.givenName && u.familyName) {
+              return (
+                u.givenName?.charAt(0).toUpperCase() +
+                u.familyName?.charAt(0).toUpperCase()
+              );
+            }
+            return u.name.charAt(0);
+          }),
         ),
         forMember(
           (ud) => ud.mentionLabel,
-          mapFrom(
-            (u) =>
-              u.givenName?.charAt(0).toUpperCase() +
-              u.givenName?.slice(1) +
-              u.familyName?.charAt(0).toUpperCase() +
-              u.familyName?.slice(1),
-          ),
+          mapFrom((u) => {
+            if (u.givenName && u.familyName) {
+              return (
+                u.givenName?.charAt(0).toUpperCase() +
+                u.givenName?.slice(1) +
+                u.familyName?.charAt(0).toUpperCase() +
+                u.familyName?.slice(1)
+              );
+            } else {
+              //TODO: how do mentions work for bceid users?
+              return '';
+            }
+          }),
         ),
         forMember(
           (ud) => ud.clientRoles,
           mapFrom((u) => u.clientRoles),
+        ),
+        forMember(
+          (ud) => ud.settings,
+          mapFrom((u) => u.settings),
         ),
       );
 
@@ -55,11 +70,15 @@ export class UserProfile extends AutomapperProfile {
         AssigneeDto,
         forMember(
           (ud) => ud.initials,
-          mapFrom(
-            (u) =>
-              u.givenName?.charAt(0).toUpperCase() +
-              u.familyName?.charAt(0).toUpperCase(),
-          ),
+          mapFrom((u) => {
+            if (u.givenName && u.familyName) {
+              return (
+                u.givenName?.charAt(0).toUpperCase() +
+                u.familyName?.charAt(0).toUpperCase()
+              );
+            }
+            return u.name.charAt(0);
+          }),
         ),
       );
     };

--- a/alcs-api/src/common/entities/audit.subscriber.spec.ts
+++ b/alcs-api/src/common/entities/audit.subscriber.spec.ts
@@ -26,7 +26,7 @@ describe('AuditSubscriber', () => {
     mockUserService = createMock<UserService>();
     subscribersArray = [];
 
-    mockUserService.get.mockResolvedValue({
+    mockUserService.getByGuid.mockResolvedValue({
       uuid: fakeUserId,
     } as User);
     updateEvent = createMock<UpdateEvent<any>>();
@@ -78,7 +78,7 @@ describe('AuditSubscriber', () => {
     });
 
     it('should throw an error if user is not found in beforeUpdate', async () => {
-      mockUserService.get.mockResolvedValue(undefined);
+      mockUserService.getByGuid.mockResolvedValue(undefined);
 
       await expect(
         updatedBySubscriber.beforeInsert(updateEvent),
@@ -108,7 +108,7 @@ describe('AuditSubscriber', () => {
     });
 
     it('should throw an error if user is not found in beforeUpdate', async () => {
-      mockUserService.get.mockResolvedValue(undefined);
+      mockUserService.getByGuid.mockResolvedValue(undefined);
 
       await expect(
         updatedBySubscriber.beforeUpdate(updateEvent),

--- a/alcs-api/src/common/entities/audit.subscriber.ts
+++ b/alcs-api/src/common/entities/audit.subscriber.ts
@@ -5,7 +5,7 @@ import {
   EventSubscriber,
   UpdateEvent,
 } from 'typeorm';
-import { UserService } from '../../user/user.service';
+import { UserGuids, UserService } from '../../user/user.service';
 import { Base } from './base.entity';
 
 export const SYSTEM_ID = 'alcs-api';
@@ -25,25 +25,25 @@ export class AuditSubscriber implements EntitySubscriberInterface {
   }
 
   async beforeInsert(event: UpdateEvent<any>) {
-    const userEmail = this.cls.get('userEmail');
-    if (userEmail) {
-      event.entity.auditCreatedBy = await this.fetchUserUuid(userEmail);
+    const userGuids = this.cls.get('userGuids');
+    if (userGuids) {
+      event.entity.auditCreatedBy = await this.fetchUserUuid(userGuids);
     } else {
       event.entity.auditCreatedBy = SYSTEM_ID;
     }
   }
 
   async beforeUpdate(event: UpdateEvent<any>) {
-    const userEmail = this.cls.get('userEmail');
-    if (userEmail) {
-      event.entity.auditUpdatedBy = await this.fetchUserUuid(userEmail);
+    const userGuids = this.cls.get('userGuids');
+    if (userGuids) {
+      event.entity.auditUpdatedBy = await this.fetchUserUuid(userGuids);
     } else {
       event.entity.auditUpdatedBy = SYSTEM_ID;
     }
   }
 
-  private async fetchUserUuid(userEmail: string) {
-    const user = await this.userService.get(userEmail);
+  private async fetchUserUuid(guids: UserGuids) {
+    const user = await this.userService.getByGuid(guids);
     if (!user) {
       throw new Error('User not found from token! Has their email changed?');
     }

--- a/alcs-api/src/common/utils/test-helpers/mockEntities.ts
+++ b/alcs-api/src/common/utils/test-helpers/mockEntities.ts
@@ -164,21 +164,15 @@ const initApplicationMockEntity = (fileNumber?: string): Application => {
 const initMockUserDto = (assignee?: User): UserDto => {
   const userEntity = assignee ?? initAssigneeMockEntity();
   const userDto = new UserDto();
-  userDto.familyName = userEntity.familyName;
+  userDto.uuid = 'user-uuid';
   userDto.email = userEntity.email;
-  userDto.uuid = userEntity.uuid;
-  userDto.givenName = userEntity.givenName;
   userDto.identityProvider = userEntity.identityProvider;
   userDto.name = userEntity.name;
-  userDto.displayName = userEntity.displayName;
-  userDto.preferredUsername = userEntity.preferredUsername;
-  userDto.idirUserGuid = userEntity.idirUserGuid;
   userDto.idirUserName = userEntity.idirUserName;
   userDto.initials =
     userEntity.givenName.charAt(0).toUpperCase() +
     userEntity.familyName.charAt(0).toUpperCase();
   userDto.bceidUserName = undefined;
-  userDto.bceidGuid = undefined;
   userDto.mentionLabel =
     userEntity.givenName.charAt(0).toUpperCase() +
     userEntity.givenName.slice(1) +

--- a/alcs-api/src/home/home.controller.ts
+++ b/alcs-api/src/home/home.controller.ts
@@ -13,7 +13,7 @@ import { ApplicationService } from '../application/application.service';
 import { HomepageSubtaskDTO } from '../card/card-subtask/card-subtask.dto';
 import { CardDto } from '../card/card.dto';
 import { Card } from '../card/card.entity';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../common/authorization/roles';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { PlanningReviewDto } from '../planning-review/planning-review.dto';
@@ -24,7 +24,7 @@ import { User } from '../user/user.entity';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('home')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class HomeController {
   constructor(
     @InjectMapper() private mapper: Mapper,

--- a/alcs-api/src/notification/notification.controller.ts
+++ b/alcs-api/src/notification/notification.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE } from '../common/authorization/roles';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { NotificationDto } from './notification.dto';
@@ -20,7 +20,7 @@ import { NotificationService } from './notification.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('notification')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class NotificationController {
   constructor(
     private notificationService: NotificationService,

--- a/alcs-api/src/planning-review/planning-review.controller.ts
+++ b/alcs-api/src/planning-review/planning-review.controller.ts
@@ -1,19 +1,16 @@
 import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from 'nest-keycloak-connect';
 import { BoardService } from '../board/board.service';
-import {
-  ANY_AUTH_ROLE,
-  ROLES_ALLOWED_BOARDS,
-} from '../common/authorization/roles';
+import { ROLES_ALLOWED_BOARDS } from '../common/authorization/roles';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { UserRoles } from '../common/authorization/roles.decorator';
 import { CreatePlanningReviewDto } from './planning-review.dto';
 import { PlanningReviewService } from './planning-review.service';
 
 @Controller('planning-review')
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class PlanningReviewController {
   constructor(
     private planningReviewService: PlanningReviewService,

--- a/alcs-api/src/providers/typeorm/migrations/1666817518180-change_user_uniques.ts
+++ b/alcs-api/src/providers/typeorm/migrations/1666817518180-change_user_uniques.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class changeUserUniques1666817518180 implements MigrationInterface {
+  name = 'changeUserUniques1666817518180';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_9b4bff420dc831713caf962716" ON "user" ("idir_user_guid") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_298a928993eee3de03067af610" ON "user" ("bceid_guid") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_298a928993eee3de03067af610"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_9b4bff420dc831713caf962716"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email")`,
+    );
+  }
+}

--- a/alcs-api/src/user/user.controller.ts
+++ b/alcs-api/src/user/user.controller.ts
@@ -7,22 +7,23 @@ import {
   Get,
   MethodNotAllowedException,
   NotFoundException,
+  Param,
   Patch,
   Req,
   UseGuards,
 } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
-import { RoleGuard } from '../common/authorization/role.guard';
+import { RolesGuard } from '../common/authorization/roles-guard.service';
 import { ANY_AUTH_ROLE, AUTH_ROLE } from '../common/authorization/roles';
 import { UserRoles } from '../common/authorization/roles.decorator';
-import { CreateOrUpdateUserDto, UserDto } from './user.dto';
+import { UpdateUserDto, UserDto } from './user.dto';
 import { User } from './user.entity';
 import { UserService } from './user.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('user')
-@UseGuards(RoleGuard)
+@UseGuards(RolesGuard)
 export class UserController {
   constructor(
     private userService: UserService,
@@ -38,30 +39,32 @@ export class UserController {
 
   @Delete()
   @UserRoles(AUTH_ROLE.ADMIN)
-  deleteUser(@Body() email: string) {
-    return this.userService.delete(email);
+  async deleteUser(@Body() uuid: string) {
+    const deleted = await this.userService.delete(uuid);
+    return this.userMapper.mapAsync(deleted, User, UserDto);
   }
 
-  @Patch()
+  @Patch(':/uuid')
   @UserRoles(...ANY_AUTH_ROLE)
-  async update(@Body() user: CreateOrUpdateUserDto, @Req() req) {
-    const existingUser = await this.userService.get(user.email);
-
-    if (!existingUser) {
-      throw new NotFoundException(
-        `User with provided email not found ${user.email}`,
-      );
-    }
-
-    if (user.uuid !== req.user.entity.uuid) {
+  async update(
+    @Param('uuid') userUuid: string,
+    @Body() user: UpdateUserDto,
+    @Req() req,
+  ) {
+    if (userUuid !== req.user.entity.uuid) {
       throw new MethodNotAllowedException(
         'You can update only your user details.',
       );
     }
 
+    const existingUser = await this.userService.getByUuid(userUuid);
+    if (!existingUser) {
+      throw new NotFoundException(`User with uuid not found ${userUuid}`);
+    }
+
     const userEntity = await this.userMapper.mapAsync(
       user,
-      CreateOrUpdateUserDto,
+      UpdateUserDto,
       User,
     );
     return this.userService.update(userEntity.uuid, userEntity);

--- a/alcs-api/src/user/user.dto.ts
+++ b/alcs-api/src/user/user.dto.ts
@@ -1,87 +1,61 @@
 import { AutoMap } from '@automapper/classes';
 import { Type } from 'class-transformer';
-import {
-  IsArray,
-  IsDefined,
-  IsEmail,
-  IsOptional,
-  IsString,
-} from 'class-validator';
+import { IsDefined } from 'class-validator';
 
 export class UserSettingsDto {
+  @AutoMap()
   favoriteBoards: string[];
 }
 
-export class CreateOrUpdateUserDto {
-  @AutoMap()
-  @IsOptional()
-  uuid?: string;
-
-  @AutoMap()
-  @IsEmail()
-  email: string;
-
-  @AutoMap()
-  @IsString()
-  displayName: string;
-
-  @AutoMap()
-  @IsString()
-  identityProvider: string;
-
-  @AutoMap()
-  @IsString()
-  preferredUsername: string;
-
-  @AutoMap()
-  @IsString()
-  name?: string;
-
-  @AutoMap()
-  @IsString()
-  givenName?: string;
-
-  @AutoMap()
-  @IsString()
-  familyName?: string;
-
-  @AutoMap()
-  @IsString()
-  idirUserGuid?: string;
-
-  @AutoMap()
-  @IsString()
-  idirUserName?: string;
-
-  @AutoMap()
-  @IsString()
-  @IsOptional()
-  bceidGuid?: string;
-
-  @AutoMap()
-  @IsString()
-  @IsOptional()
-  bceidUserName?: string;
-
-  @AutoMap()
-  @IsArray()
-  @IsOptional()
-  clientRoles?: string[];
-
+export class UpdateUserDto {
   @AutoMap()
   @Type(() => UserSettingsDto)
   @IsDefined()
-  settings?: UserSettingsDto;
+  settings: UserSettingsDto;
 }
 
-export class UserDto extends CreateOrUpdateUserDto {
+export class UserDto extends UpdateUserDto {
   @AutoMap()
-  @IsString()
-  initials?: string;
+  uuid: string;
 
   @AutoMap()
-  @IsString()
+  initials: string;
+
+  @AutoMap()
   mentionLabel: string;
+
+  @AutoMap()
+  email: string;
+
+  @AutoMap()
+  name: string;
+
+  @AutoMap()
+  identityProvider: string;
+
+  @AutoMap()
+  clientRoles: string[];
+
+  @AutoMap()
+  idirUserName: string;
+
+  @AutoMap()
+  bceidUserName: string;
+}
+
+export class CreateUserDto {
+  email: string;
+  name?: string;
+  displayName: string;
+  givenName?: string;
+  familyName?: string;
+  preferredUsername: string;
+  identityProvider: string;
+  clientRoles: string[];
+  idirUserName?: string;
+  bceidUserName?: string;
+  idirUserGuid?: string;
+  bceidGuid?: string;
 }
 
 export class AssigneeDto {

--- a/alcs-api/src/user/user.entity.ts
+++ b/alcs-api/src/user/user.entity.ts
@@ -1,5 +1,5 @@
 import { AutoMap } from '@automapper/classes';
-import { Column, Entity, OneToMany } from 'typeorm';
+import { Column, Entity, Index, OneToMany } from 'typeorm';
 import { Card } from '../card/card.entity';
 import { CommentMention } from '../comment/mention/comment-mention.entity';
 import { Base } from '../common/entities/base.entity';
@@ -12,7 +12,7 @@ export class UserSettings {
 @Entity()
 export class User extends Base {
   @AutoMap()
-  @Column({ unique: true })
+  @Column()
   email: string;
 
   @AutoMap()
@@ -40,6 +40,7 @@ export class User extends Base {
   familyName: string;
 
   @AutoMap()
+  @Index({ unique: true })
   @Column({ nullable: true })
   idirUserGuid: string;
 
@@ -48,6 +49,7 @@ export class User extends Base {
   idirUserName: string;
 
   @AutoMap()
+  @Index({ unique: true })
   @Column({ nullable: true })
   bceidGuid: string;
 

--- a/alcs-api/src/user/user.service.spec.ts
+++ b/alcs-api/src/user/user.service.spec.ts
@@ -64,8 +64,8 @@ describe('UserService', () => {
     expect(users[0]).toEqual(mockUser);
   });
 
-  it('should return the user by email from the repository', async () => {
-    const user = await service.get(mockUser.email);
+  it('should return the user by uuid from the repository', async () => {
+    const user = await service.getByUuid(mockUser.uuid);
 
     expect(user).toStrictEqual(mockUser);
   });
@@ -82,14 +82,14 @@ describe('UserService', () => {
 
     it('should reject if user already exists', async () => {
       await expect(service.create(mockUser)).rejects.toMatchObject(
-        new Error(`Email already exists: ${mockUser.email}`),
+        new Error(`User already exists in the system`),
       );
     });
   });
 
   describe('deleteUser', () => {
     it('should call delete user on the repository', async () => {
-      await service.delete(mockUser.email);
+      await service.delete(mockUser.uuid);
 
       expect(repositoryMock.softRemove).toHaveBeenCalledTimes(1);
       expect(repositoryMock.softRemove).toHaveBeenCalledWith(mockUser);
@@ -98,8 +98,8 @@ describe('UserService', () => {
     it('should reject when user does not exist', async () => {
       repositoryMock.findOne.mockResolvedValue(undefined);
 
-      await expect(service.delete(mockUser.email)).rejects.toMatchObject(
-        new Error(`User with provided email not found ${mockUser.email}`),
+      await expect(service.delete(mockUser.uuid)).rejects.toMatchObject(
+        new Error(`User with provided uuid ${mockUser.uuid} was not found`),
       );
     });
   });
@@ -130,7 +130,7 @@ describe('UserService', () => {
     const prefix = env === 'production' ? '' : `[${env}]`;
     const subject = `${prefix} Access Requested to ALCS`;
     const body = `A new user ${email}: ${userIdentifier} has requested access to ALCS.<br/> 
-<a href='https://bcgov.github.io/sso-requests/my-dashboard/integrations'>CSS</a>`;
+<a href="https://bcgov.github.io/sso-requests/my-dashboard/integrations">CSS</a>`;
 
     await service.sendNewUserRequestEmail(email, userIdentifier);
 

--- a/alcs-frontend/src/app/services/user/user.dto.ts
+++ b/alcs-frontend/src/app/services/user/user.dto.ts
@@ -1,36 +1,20 @@
-export interface UserDto {
-  uuid: string;
-
-  email: string;
-
-  name: string;
-
-  displayName: string;
-
-  identityProvider: string;
-
-  preferredUsername: string;
-
-  givenName?: string;
-
-  familyName?: string;
-
-  idirUserGuid?: string;
-
-  idirUserName?: string;
-
-  bceidUserName?: string;
-
-  initials: string;
-
-  mentionLabel: string;
-
-  settings: IUserSettings;
-
-  clientRoles: string[];
+export interface UpdateUserDto {
+  settings: UserSettingsDto;
 }
 
-export interface IUserSettings {
+export interface UserDto extends UpdateUserDto {
+  uuid: string;
+  initials: string;
+  mentionLabel: string;
+  email: string;
+  name: string;
+  identityProvider: string;
+  clientRoles: string[];
+  idirUserName: string;
+  bceidUserName: string;
+}
+
+export interface UserSettingsDto {
   favoriteBoards: string[];
 }
 

--- a/alcs-frontend/src/app/services/user/user.service.ts
+++ b/alcs-frontend/src/app/services/user/user.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, combineLatestWith, firstValueFrom } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { AuthenticationService, ICurrentUser } from '../authentication/authentication.service';
 import { ToastService } from '../toast/toast.service';
-import { UserDto } from './user.dto';
+import { UpdateUserDto, UserDto } from './user.dto';
 
 @Injectable({
   providedIn: 'root',
@@ -41,7 +41,7 @@ export class UserService {
     this.$users.next(this.users);
   }
 
-  public async updateUser(user: UserDto) {
+  public async updateUser(uuid: string, user: UpdateUserDto) {
     try {
       await firstValueFrom(this.http.patch<UserDto>(`${environment.apiUrl}/user`, user));
       await this.fetchUsers();

--- a/alcs-frontend/src/app/shared/favorite-button/favorite-button.component.ts
+++ b/alcs-frontend/src/app/shared/favorite-button/favorite-button.component.ts
@@ -65,7 +65,9 @@ export class FavoriteButtonComponent implements OnInit {
     this.updateFavoriteBoardsList(this.boardCode);
 
     try {
-      await this.userService.updateUser(this.currentUserProfile);
+      await this.userService.updateUser(this.currentUserProfile.uuid, {
+        settings: this.currentUserProfile.settings,
+      });
     } catch {
       this.toastService.showErrorToast('Failed to set favourites');
     }


### PR DESCRIPTION
* Change all lookups to use either our uuid or bceidguid/idirguid
* Add constraint to ensure bceidguid and idirguid are unique
* Rename RoleGuard -> RolesGuard to ensure we are using the correct one, as there is a RoleGuard from Keycloak
* Update UserDTO to only return currently used fields
* Add new update dto to make it clear only settings can be updated
* Change user update to be consistent with other controllers, taking in uuid and dto separately