### PR TITLE
Clear input after files emit

### DIFF
--- a/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.ts
+++ b/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.ts
@@ -51,6 +51,7 @@ export class FileDragDropComponent implements OnInit {
     }
     if (files.length > 0) {
       this.uploadFiles.emit(files);
+      this.fileUpload.nativeElement.value = '';
     }
   }
 }


### PR DESCRIPTION
* Input fires on change event, selecting the same file twice does not fire a change event
* Clear input after we emit so the same file can be selected twice