### PR TITLE
Turn off buffer logs

### DIFF
--- a/services/apps/alcs/src/main.ts
+++ b/services/apps/alcs/src/main.ts
@@ -98,7 +98,7 @@ async function bootstrap() {
     AlcsModule,
     new FastifyAdapter(),
     {
-      bufferLogs: true,
+      bufferLogs: false,
     },
   );
   app.useLogger(app.get(Logger));

--- a/services/apps/portal/src/main.ts
+++ b/services/apps/portal/src/main.ts
@@ -72,7 +72,7 @@ async function bootstrap() {
     PortalModule,
     new FastifyAdapter(),
     {
-      bufferLogs: true,
+      bufferLogs: false,
     },
   );
   app.useLogger(app.get(Logger));


### PR DESCRIPTION
* Do not buffer logs, this meant that logs were being held until the Logger finished initializing, turn off buffer so that it prints sooner (although not in correct format)