### PR TITLE
Clear Application when unloading application page

### DIFF
--- a/alcs-frontend/src/app/features/application/application.component.ts
+++ b/alcs-frontend/src/app/features/application/application.component.ts
@@ -155,6 +155,7 @@ export class ApplicationComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.applicationDetailService.clearApplication();
     this.destroy.next();
     this.destroy.complete();
   }

--- a/alcs-frontend/src/app/services/application/application-detail.service.ts
+++ b/alcs-frontend/src/app/services/application/application-detail.service.ts
@@ -18,6 +18,10 @@ export class ApplicationDetailService {
     this.$application.next(application);
   }
 
+  async clearApplication() {
+    this.$application.next(undefined);
+  }
+
   async updateApplication(fileNumber: string, application: UpdateApplicationDto) {
     const updatedApp = await this.applicationService.updateApplication(fileNumber, application);
     if (updatedApp) {


### PR DESCRIPTION
* Clear the application from the pipe so that any initial subscribers will receive undefined instead of the previously loaded application