### PR TITLE
Display minimum file size to user

### DIFF
--- a/alcs-frontend/src/app/shared/pipes/fileSize.pipe.ts
+++ b/alcs-frontend/src/app/shared/pipes/fileSize.pipe.ts
@@ -5,6 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class FileSizePipe implements PipeTransform {
   transform(size: number, extension: string = 'MB') {
-    return (size / (1024 * 1024)).toFixed(2) + extension;
+    const fileSize = Math.round((size / (1024 * 1024)) * 100) / 100;
+    return Math.max(fileSize, 0.01) + extension;
   }
 }

--- a/portal-frontend/src/app/shared/pipes/fileSize.pipe.ts
+++ b/portal-frontend/src/app/shared/pipes/fileSize.pipe.ts
@@ -5,6 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class FileSizePipe implements PipeTransform {
   transform(size: number, extension: string = 'MB') {
-    return (size / (1024 * 1024)).toFixed(2) + extension;
+    const fileSize = Math.round((size / (1024 * 1024)) * 100) / 100;
+    return Math.max(fileSize, 0.01) + extension;
   }
 }


### PR DESCRIPTION
Use native JS Math functions to calculate and compare file size instead of number to string conversion for improved performance