### PR TITLE
Added OATS and OATS_P flag to migrated OATS data in ALCS system

### DIFF
--- a/bin/migrate-oats-data/documents/documents.py
+++ b/bin/migrate-oats-data/documents/documents.py
@@ -15,7 +15,7 @@ def compile_document_insert_query(number_of_rows_to_insert):
     documents_to_insert = ",".join(["%s"] * number_of_rows_to_insert)
     return f"""
         INSERT INTO alcs."document" (oats_document_id, file_name, oats_application_id, "source", 
-                                    audit_created_by, file_key, mime_type, tags) 
+                                    audit_created_by, file_key, mime_type, tags, "system") 
         VALUES {documents_to_insert} 
         ON CONFLICT (oats_document_id) DO UPDATE SET 
             oats_document_id = EXCLUDED.oats_document_id, 
@@ -25,7 +25,8 @@ def compile_document_insert_query(number_of_rows_to_insert):
             audit_created_by = EXCLUDED.audit_created_by, 
             file_key = EXCLUDED.file_key, 
             mime_type = EXCLUDED.mime_type,
-            tags = EXCLUDED.tags
+            tags = EXCLUDED.tags,
+            "system" = EXCLUDED."system"
     """
 
 

--- a/bin/migrate-oats-data/sql/documents/documents.sql
+++ b/bin/migrate-oats-data/sql/documents/documents.sql
@@ -3,7 +3,7 @@
 		od.alr_application_id ,
 		document_id ,
 		document_code ,
-		file_name
+		file_name , od.who_created
 		
 	from oats.oats_documents od 
 		left join oats.oats_subject_properties osp 
@@ -22,7 +22,12 @@
       'oats_etl' AS audit_created_by,
       '/migrate/' || alr_application_id || '/' || document_id || '_' || file_name AS file_key,
       'pdf' AS mime_type,
-	  '{"ORCS Classification: 85100-20"}'::text[] as tags
+	  '{"ORCS Classification: 85100-20"}'::text[] as tags,
+	  CASE
+		 WHEN who_created = 'PROXY_OATS_LOCGOV' THEN 'OATS_P'
+		 WHEN who_created = 'PROXY_OATS_APPLICANT' THEN 'OATS_P'
+		 ELSE 'OATS'
+		END AS "system"
     FROM 
       oats_documents_to_insert oti
       JOIN alcs.application a ON a.file_number = oti.alr_application_id::text


### PR DESCRIPTION
Documents created by PROXY_OATS_APPLICANT and PROXY_OATS_LOCGOV are considered to have come from the portal and given the system flag of 'OATS_P'. All other documents are assumed to have come from the oats system and given the flag of 'OATS'.