### PR TITLE
Update Change Board to use save directly

### DIFF
--- a/services/apps/alcs/src/alcs/board/board.controller.spec.ts
+++ b/services/apps/alcs/src/alcs/board/board.controller.spec.ts
@@ -137,14 +137,7 @@ describe('BoardController', () => {
     const boardCode = 'fake-board';
     const cardUuid = 'card-uuid';
 
-    await controller.changeBoard(
-      { cardUuid, boardCode },
-      {
-        user: {
-          entity: new User(),
-        },
-      },
-    );
+    await controller.changeBoard({ cardUuid, boardCode });
 
     expect(boardService.changeBoard).toHaveBeenCalledTimes(1);
     expect(boardService.changeBoard.mock.calls[0][0]).toEqual(cardUuid);

--- a/services/apps/alcs/src/alcs/board/board.controller.ts
+++ b/services/apps/alcs/src/alcs/board/board.controller.ts
@@ -89,9 +89,8 @@ export class BoardController {
   async changeBoard(
     @Body()
     { cardUuid, boardCode }: { cardUuid: string; boardCode: string },
-    @Req() req,
   ) {
-    return this.boardService.changeBoard(cardUuid, boardCode, req.user.entity);
+    return this.boardService.changeBoard(cardUuid, boardCode);
   }
 
   @Post('/card')

--- a/services/apps/alcs/src/alcs/board/board.service.spec.ts
+++ b/services/apps/alcs/src/alcs/board/board.service.spec.ts
@@ -88,26 +88,25 @@ describe('BoardsService', () => {
       status: { code: 'fake-status' },
       board: { uuid: 'fake-board' },
     } as Card);
+    cardService.save.mockResolvedValue(new Card());
     mockRepository.findOne.mockResolvedValue(mockBoard);
     cardService.update.mockResolvedValue({} as Card);
 
-    await service.changeBoard(cardUuid, boardCode, new User());
+    await service.changeBoard(cardUuid, boardCode);
     expect(cardService.get).toHaveBeenCalledTimes(1);
     expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
-    expect(cardService.update).toHaveBeenCalledTimes(1);
+    expect(cardService.save).toHaveBeenCalledTimes(1);
 
-    const updatedCardUuid = cardService.update.mock.calls[0][1];
-    const updatedCard = cardService.update.mock.calls[0][2];
-    expect(updatedCardUuid).toEqual(cardUuid);
-    expect(updatedCard.boardUuid).toEqual(mockBoard.uuid);
-    expect(updatedCard.statusCode).toEqual(zeroOrderStatus.status.code);
+    const updatedCard = cardService.save.mock.calls[0][0];
+    expect(updatedCard.board.uuid).toEqual(mockBoard.uuid);
+    expect(updatedCard.status.code).toEqual(zeroOrderStatus.status.code);
   });
 
   it("should throw an exception when updating an card that doesn't exist", async () => {
     cardService.get.mockResolvedValue(null);
 
     await expect(
-      service.changeBoard('card-uuid', 'board-code', new User()),
+      service.changeBoard('card-uuid', 'board-code'),
     ).rejects.toMatchObject(
       new ServiceNotFoundException('Failed to find card with uuid card-uuid'),
     );
@@ -118,7 +117,7 @@ describe('BoardsService', () => {
     mockRepository.findOne.mockResolvedValue(null);
 
     await expect(
-      service.changeBoard('file-number', 'board-code', new User()),
+      service.changeBoard('file-number', 'board-code'),
     ).rejects.toMatchObject(
       new ServiceNotFoundException(`Failed to find Board with code board-code`),
     );

--- a/services/apps/alcs/src/alcs/board/board.service.ts
+++ b/services/apps/alcs/src/alcs/board/board.service.ts
@@ -52,7 +52,7 @@ export class BoardService {
     });
   }
 
-  async changeBoard(cardUuid: string, code: string, user: User) {
+  async changeBoard(cardUuid: string, code: string) {
     const card = await this.cardService.get(cardUuid);
     if (!card) {
       throw new ServiceNotFoundException(
@@ -79,14 +79,6 @@ export class BoardService {
 
     card.status = initialStatus.status;
     card.board = board;
-    return this.cardService.update(
-      user,
-      card.uuid,
-      {
-        boardUuid: card.board.uuid,
-        statusCode: card.status.code,
-      },
-      '',
-    );
+    return this.cardService.save(card);
   }
 }

--- a/services/apps/alcs/src/alcs/card/card.service.ts
+++ b/services/apps/alcs/src/alcs/card/card.service.ts
@@ -177,6 +177,11 @@ export class CardService {
     await this.cardRepository.softRemove(card);
   }
 
+  async save(card: Card) {
+    await this.cardRepository.save(card);
+    return this.get(card.uuid);
+  }
+
   async recover(uuid: string) {
     const card = await this.cardRepository.findOneOrFail({
       where: {

--- a/services/apps/alcs/src/alcs/import/import.service.spec.ts
+++ b/services/apps/alcs/src/alcs/import/import.service.spec.ts
@@ -218,7 +218,6 @@ describe('ImportService', () => {
     expect(mockBoardService.changeBoard).toHaveBeenCalledWith(
       mockApplication.cardUuid,
       'exec',
-      {},
     );
   });
 

--- a/services/apps/alcs/src/alcs/import/import.service.ts
+++ b/services/apps/alcs/src/alcs/import/import.service.ts
@@ -5,7 +5,6 @@ import * as timezone from 'dayjs/plugin/timezone';
 import * as utc from 'dayjs/plugin/utc';
 import * as fs from 'fs';
 import * as path from 'path';
-import { User } from '../../user/user.entity';
 import { ApplicationLocalGovernmentService } from '../application/application-code/application-local-government/application-local-government.service';
 import { ApplicationMeetingService } from '../application/application-meeting/application-meeting.service';
 import { ApplicationPausedService } from '../application/application-paused/application-paused.service';
@@ -193,18 +192,10 @@ export class ImportService {
             mappedRow.decisionMaker === ''
           ) {
             const boardCode = REGION_BOARD_MAP[mappedRow.region];
-            await this.boardService.changeBoard(
-              updatedApp.cardUuid,
-              boardCode,
-              new User(),
-            );
+            await this.boardService.changeBoard(updatedApp.cardUuid, boardCode);
           } else if (mappedRow.decisionMaker) {
             const boardCode = DECISION_MAKER_BOARD_MAP[mappedRow.decisionMaker];
-            await this.boardService.changeBoard(
-              updatedApp.cardUuid,
-              boardCode,
-              new User(),
-            );
+            await this.boardService.changeBoard(updatedApp.cardUuid, boardCode);
           }
         }
       } catch (e) {


### PR DESCRIPTION
* Changing the board was conflicting with the updates to notifications made earlier, since change board already has a full entity, save it directly instead of doing other stuff.