### PR TITLE
Fix disabled upload area styling in non-local env

### DIFF
--- a/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.html
+++ b/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.html
@@ -25,9 +25,12 @@
 </div>
 <div
   *ngIf="!uploadedFiles.length || allowMultiple"
-  [ngClass]="{ 'desktop-file-drag-drop': true, 'error-outline': isRequired && showErrors && !uploadedFiles.length }"
+  [ngClass]="{
+    'desktop-file-drag-drop': true,
+    'error-outline': isRequired && showErrors && !uploadedFiles.length,
+    disabled: disabled
+  }"
   dragDropFile
-  [disabled]="disabled"
   (files)="filesDropped($event)"
 >
   <button class="content" type="button" (click)="onFileUploadClicked()" [disabled]="disabled">

--- a/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.scss
+++ b/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.scss
@@ -16,7 +16,7 @@
   }
 }
 
-.desktop-file-drag-drop[ng-reflect-disabled='true'] {
+.desktop-file-drag-drop.disabled {
   background-color: rgba(colors.$grey, 0.2) !important;
   cursor: not-allowed;
 


### PR DESCRIPTION
Found out why styling wasn't applied when deployed:
* `<div>` doesn't support `disabled` attribute
* Ng-Reflect attributes only exist as dev helpers, and they won't show up in non-debug env (prod)