### PR TITLE
ALCS View of under/pending LFNG Review and returned applications

### DIFF
--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.spec.ts
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { ApplicationDocumentService } from '../../../../services/application/application-document/application-document.service';
-import { SubmittedApplicationOwnerDto } from '../../../../services/application/application.dto';
+import { ApplicationStatus, SubmittedApplicationOwnerDto } from '../../../../services/application/application.dto';
 
 import { ApplicationDetailsComponent } from './application-details.component';
 
@@ -45,6 +45,7 @@ describe('ApplicationDetailsComponent', () => {
       soilToPlaceVolume: null,
       soilToRemoveAverageDepth: null,
       soilToRemoveMaximumDepth: null,
+      status: {} as ApplicationStatus,
       type: '',
       updatedAt: '',
       uuid: '',

--- a/alcs-frontend/src/app/features/application/application.component.html
+++ b/alcs-frontend/src/app/features/application/application.component.html
@@ -8,7 +8,7 @@
       heading="Application"
     ></app-details-header>
     <div class="content">
-      <div *ngIf="isSubmittedAlc" class="nav">
+      <div *ngIf="isSubmittedToAlc" class="nav">
         <div *ngFor="let route of childRoutes" class="nav-link">
           <div
             *ngIf="route.portalOnly ? isApplicantSubmission : true"
@@ -22,7 +22,7 @@
           </div>
         </div>
       </div>
-      <div *ngIf="isSubmittedLfng" class="nav">
+      <div *ngIf="wasSubmittedToLfng" class="nav">
         <div *ngFor="let route of submittedLfngRoutes" class="nav-link">
           <div
             [routerLink]="route.path ? route.path : './'"
@@ -35,7 +35,7 @@
           </div>
         </div>
       </div>
-      <div *ngIf="!isSubmittedAlc && !isSubmittedLfng" class="nav">
+      <div *ngIf="!isSubmittedToAlc && !wasSubmittedToLfng" class="nav">
         <div *ngFor="let route of unsubmittedRoutes" class="nav-link">
           <div
             [routerLink]="route.path ? route.path : './'"

--- a/alcs-frontend/src/app/features/application/application.component.html
+++ b/alcs-frontend/src/app/features/application/application.component.html
@@ -22,7 +22,20 @@
           </div>
         </div>
       </div>
-      <div *ngIf="!isSubmitted" class="nav">
+      <div *ngIf="isAwaitingLfng" class="nav">
+        <div *ngFor="let route of awaitingLfngRoutes" class="nav-link">
+          <div
+            [routerLink]="route.path ? route.path : './'"
+            routerLinkActive="active"
+            [routerLinkActiveOptions]="{ exact: route.path === '' }"
+            class="nav-item nav-text"
+          >
+            <mat-icon>{{ route.icon }}</mat-icon>
+            {{ route.menuTitle }}
+          </div>
+        </div>
+      </div>
+      <div *ngIf="!isSubmitted && !isAwaitingLfng" class="nav">
         <div *ngFor="let route of unsubmittedRoutes" class="nav-link">
           <div
             [routerLink]="route.path ? route.path : './'"

--- a/alcs-frontend/src/app/features/application/application.component.html
+++ b/alcs-frontend/src/app/features/application/application.component.html
@@ -8,7 +8,7 @@
       heading="Application"
     ></app-details-header>
     <div class="content">
-      <div *ngIf="isSubmitted" class="nav">
+      <div *ngIf="isSubmittedAlc" class="nav">
         <div *ngFor="let route of childRoutes" class="nav-link">
           <div
             *ngIf="route.portalOnly ? isApplicantSubmission : true"
@@ -22,8 +22,8 @@
           </div>
         </div>
       </div>
-      <div *ngIf="isAwaitingLfng" class="nav">
-        <div *ngFor="let route of awaitingLfngRoutes" class="nav-link">
+      <div *ngIf="isSubmittedLfng" class="nav">
+        <div *ngFor="let route of submittedLfngRoutes" class="nav-link">
           <div
             [routerLink]="route.path ? route.path : './'"
             routerLinkActive="active"
@@ -35,7 +35,7 @@
           </div>
         </div>
       </div>
-      <div *ngIf="!isSubmitted && !isAwaitingLfng" class="nav">
+      <div *ngIf="!isSubmittedAlc && !isSubmittedLfng" class="nav">
         <div *ngFor="let route of unsubmittedRoutes" class="nav-link">
           <div
             [routerLink]="route.path ? route.path : './'"

--- a/alcs-frontend/src/app/features/application/application.component.spec.ts
+++ b/alcs-frontend/src/app/features/application/application.component.spec.ts
@@ -11,6 +11,7 @@ import { ApplicationReconsiderationService } from '../../services/application/ap
 import { ApplicationReviewService } from '../../services/application/application-review/application-review.service';
 import { ApplicationDto } from '../../services/application/application.dto';
 import { ApplicationService } from '../../services/application/application.service';
+import { ApplicationSubmissionService } from '../../services/application/application-submission/application-submission.service';
 
 import { ApplicationComponent } from './application.component';
 
@@ -21,6 +22,7 @@ describe('ApplicationComponent', () => {
   let mockReconsiderationService: DeepMocked<ApplicationReconsiderationService>;
   let mockModificationService: DeepMocked<ApplicationModificationService>;
   let mockReviewService: DeepMocked<ApplicationReviewService>;
+  let mockAppSubmissionService: DeepMocked<ApplicationSubmissionService>;
 
   beforeEach(async () => {
     mockAppDetailService = createMock();
@@ -33,6 +35,7 @@ describe('ApplicationComponent', () => {
     mockModificationService.$modifications = new BehaviorSubject<ApplicationModificationDto[]>([]);
 
     mockReviewService = createMock();
+    mockAppSubmissionService = createMock();
 
     await TestBed.configureTestingModule({
       providers: [
@@ -55,6 +58,10 @@ describe('ApplicationComponent', () => {
         {
           provide: ApplicationReviewService,
           useValue: mockReviewService,
+        },
+        {
+          provide: ApplicationSubmissionService,
+          useValue: mockAppSubmissionService,
         },
         {
           provide: ActivatedRoute,

--- a/alcs-frontend/src/app/features/application/application.component.ts
+++ b/alcs-frontend/src/app/features/application/application.component.ts
@@ -44,7 +44,7 @@ export const unsubmittedRoutes = [
   },
 ];
 
-export const awaitingLfngRoutes = [
+export const submittedLfngRoutes = [
   {
     path: '',
     menuTitle: 'Overview',
@@ -165,7 +165,7 @@ export class ApplicationComponent implements OnInit, OnDestroy {
   destroy = new Subject<void>();
   childRoutes = appChildRoutes;
   unsubmittedRoutes = unsubmittedRoutes;
-  awaitingLfngRoutes = awaitingLfngRoutes;
+  submittedLfngRoutes = submittedLfngRoutes;
 
   fileNumber?: string;
   application: ApplicationDto | undefined;
@@ -174,8 +174,8 @@ export class ApplicationComponent implements OnInit, OnDestroy {
   submission?: ApplicationSubmissionDto;
 
   isApplicantSubmission = false;
-  isSubmitted = false;
-  isAwaitingLfng = false;
+  isSubmittedAlc = false;
+  isSubmittedLfng = false;
 
   constructor(
     private applicationDetailService: ApplicationDetailService,
@@ -203,9 +203,9 @@ export class ApplicationComponent implements OnInit, OnDestroy {
 
         this.submission = await this.applicationSubmissionService.fetchSubmission(application.fileNumber);
 
-        this.isSubmitted = this.isApplicantSubmission ? !!application.dateSubmittedToAlc : true;
+        this.isSubmittedAlc = this.isApplicantSubmission ? !!application.dateSubmittedToAlc : true;
 
-        this.isAwaitingLfng =
+        this.isSubmittedLfng =
           this.isApplicantSubmission &&
           [
             APPLICATION_STATUS.SUBMITTED_TO_LG,

--- a/alcs-frontend/src/app/features/application/application.component.ts
+++ b/alcs-frontend/src/app/features/application/application.component.ts
@@ -174,8 +174,8 @@ export class ApplicationComponent implements OnInit, OnDestroy {
   submission?: ApplicationSubmissionDto;
 
   isApplicantSubmission = false;
-  isSubmittedAlc = false;
-  isSubmittedLfng = false;
+  isSubmittedToAlc = false;
+  wasSubmittedToLfng = false;
 
   constructor(
     private applicationDetailService: ApplicationDetailService,
@@ -203,9 +203,9 @@ export class ApplicationComponent implements OnInit, OnDestroy {
 
         this.submission = await this.applicationSubmissionService.fetchSubmission(application.fileNumber);
 
-        this.isSubmittedAlc = this.isApplicantSubmission ? !!application.dateSubmittedToAlc : true;
+        this.isSubmittedToAlc = this.isApplicantSubmission ? !!application.dateSubmittedToAlc : true;
 
-        this.isSubmittedLfng =
+        this.wasSubmittedToLfng =
           this.isApplicantSubmission &&
           [
             APPLICATION_STATUS.SUBMITTED_TO_LG,

--- a/alcs-frontend/src/app/features/application/application.component.ts
+++ b/alcs-frontend/src/app/features/application/application.component.ts
@@ -207,8 +207,12 @@ export class ApplicationComponent implements OnInit, OnDestroy {
 
         this.isAwaitingLfng =
           this.isApplicantSubmission &&
-          (this.submission?.status?.code === APPLICATION_STATUS.SUBMITTED_TO_LG ||
-            this.submission?.status?.code === APPLICATION_STATUS.IN_REVIEW);
+          [
+            APPLICATION_STATUS.SUBMITTED_TO_LG,
+            APPLICATION_STATUS.IN_REVIEW,
+            APPLICATION_STATUS.WRONG_GOV,
+            APPLICATION_STATUS.INCOMPLETE,
+          ].includes(this.submission?.status?.code);
       }
     });
 

--- a/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.html
+++ b/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.html
@@ -1,7 +1,15 @@
 <h3>L/FNG Info</h3>
 <section>
   <div *ngIf="!requiresReview" class="warning">
-    Application not subjected to Local/First Nation Government Review.
+    <mat-icon>info</mat-icon>Application not subjected to Local/First Nation Government Review.
+  </div>
+  <div *ngIf="!applicationReview && requiresReview && !showComment" class="warning">
+    <mat-icon>info</mat-icon>Pending Local/First Nation Government review.
+  </div>
+  <div *ngIf="showComment" class="comment-container">
+    <div><strong>Comment for Applicant</strong></div>
+    {{ submission?.returnedComment }}
+    <span class="no-comment" *ngIf="!submission?.returnedComment">No comment added</span>
   </div>
   <ng-container *ngIf="applicationReview">
     <h4>Government File & Contact</h4>

--- a/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.scss
+++ b/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.scss
@@ -10,7 +10,29 @@ h4 {
 
 .warning {
   background-color: colors.$secondary-color-light;
+  border-radius: 4px;
   padding: 16px;
+  display: flex;
+  align-items: center;
+
+  mat-icon {
+    margin-right: 12px;
+  }
+}
+
+.comment-container {
+  @extend .warning;
+  flex-direction: column;
+  align-items: flex-start;
+
+  div {
+    margin-bottom: 4px;
+  }
+}
+
+.no-comment {
+  color: colors.$grey-dark;
+  font-style: italic;
 }
 
 .review-table {

--- a/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.spec.ts
+++ b/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 import { ApplicationDetailService } from '../../../services/application/application-detail.service';
 import { ApplicationDocumentService } from '../../../services/application/application-document/application-document.service';
 import { ApplicationReviewService } from '../../../services/application/application-review/application-review.service';
+import { ApplicationSubmissionService } from '../../../services/application/application-submission/application-submission.service';
 import { ApplicationDto } from '../../../services/application/application.dto';
 
 import { LfngInfoComponent } from './lfng-info.component';
@@ -14,11 +15,13 @@ describe('LfngInfoComponent', () => {
   let mockApplicationDetailService: DeepMocked<ApplicationDetailService>;
   let mockAppDocumentService: DeepMocked<ApplicationDocumentService>;
   let mockApplicationReviewService: DeepMocked<ApplicationReviewService>;
+  let mockAppSubmissionService: DeepMocked<ApplicationSubmissionService>;
 
   beforeEach(async () => {
     mockApplicationDetailService = createMock();
     mockAppDocumentService = createMock();
     mockApplicationReviewService = createMock();
+    mockAppSubmissionService = createMock();
     mockApplicationDetailService.$application = new BehaviorSubject<ApplicationDto | undefined>(undefined);
 
     await TestBed.configureTestingModule({
@@ -31,6 +34,10 @@ describe('LfngInfoComponent', () => {
         {
           provide: ApplicationDocumentService,
           useValue: mockAppDocumentService,
+        },
+        {
+          provide: ApplicationSubmissionService,
+          useValue: mockAppSubmissionService,
         },
         {
           provide: ApplicationReviewService,

--- a/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.ts
+++ b/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.ts
@@ -6,7 +6,12 @@ import {
   DOCUMENT_TYPE,
 } from '../../../services/application/application-document/application-document.service';
 import { ApplicationReviewService } from '../../../services/application/application-review/application-review.service';
-import { ApplicationReviewDto } from '../../../services/application/application.dto';
+import {
+  APPLICATION_STATUS,
+  ApplicationReviewDto,
+  ApplicationSubmissionDto,
+} from '../../../services/application/application.dto';
+import { ApplicationSubmissionService } from '../../../services/application/application-submission/application-submission.service';
 
 @Component({
   selector: 'app-lfng-info',
@@ -18,10 +23,13 @@ export class LfngInfoComponent implements OnInit {
   resolutionDocument: ApplicationDocumentDto | undefined;
   staffReport: ApplicationDocumentDto | undefined;
   otherAttachments: ApplicationDocumentDto[] = [];
+  submission?: ApplicationSubmissionDto;
   requiresReview = true;
+  showComment = false;
 
   constructor(
     private applicationDetailService: ApplicationDetailService,
+    private applicationSubmissionService: ApplicationSubmissionService,
     private applicationDocumentService: ApplicationDocumentService,
     private applicationReviewService: ApplicationReviewService
   ) {}
@@ -31,6 +39,10 @@ export class LfngInfoComponent implements OnInit {
       if (application) {
         this.requiresReview = application.type.code !== 'TURP';
         this.applicationReview = await this.applicationReviewService.fetchReview(application.fileNumber);
+        this.submission = await this.applicationSubmissionService.fetchSubmission(application.fileNumber);
+        this.showComment = [APPLICATION_STATUS.WRONG_GOV, APPLICATION_STATUS.INCOMPLETE].includes(
+          this.submission?.status?.code
+        );
         this.loadDocuments(application.fileNumber);
       }
     });

--- a/alcs-frontend/src/app/services/application/application-submission/application-submission.service.spec.ts
+++ b/alcs-frontend/src/app/services/application/application-submission/application-submission.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { of } from 'rxjs';
 import { ToastService } from '../../toast/toast.service';
-import { ApplicationSubmissionDto, SubmittedApplicationOwnerDto } from '../application.dto';
+import { ApplicationStatus, ApplicationSubmissionDto, SubmittedApplicationOwnerDto } from '../application.dto';
 
 import { ApplicationSubmissionService } from './application-submission.service';
 
@@ -30,6 +30,7 @@ describe('ApplicationSubmissionService', () => {
     soilToPlaceVolume: null,
     soilToRemoveAverageDepth: null,
     soilToRemoveMaximumDepth: null,
+    status: {} as ApplicationStatus,
     type: '',
     updatedAt: '',
     uuid: '',

--- a/alcs-frontend/src/app/services/application/application.dto.ts
+++ b/alcs-frontend/src/app/services/application/application.dto.ts
@@ -14,11 +14,28 @@ export enum PARCEL_OWNERSHIP_TYPE {
   CROWN = 'CRWN',
 }
 
+export enum APPLICATION_STATUS {
+  IN_PROGRESS = 'PROG',
+  SUBMITTED_TO_ALC = 'SUBM',
+  SUBMITTED_TO_LG = 'SUBG',
+  IN_REVIEW = 'REVW',
+  REFUSED_TO_FORWARD = 'REFU',
+  INCOMPLETE = 'INCM',
+  WRONG_GOV = 'WRNG',
+  CANCELLED = 'CANC',
+  ALC_DECISION = 'ALCD',
+  CEO_DECISION = 'CEOD',
+}
+
 export interface StatusHistory {
   type: 'status_change';
   label: string;
   description: string;
   time: number;
+}
+
+export interface ApplicationStatus extends BaseCodeDto {
+  code: APPLICATION_STATUS;
 }
 
 export interface CreateApplicationDto {
@@ -95,7 +112,7 @@ export interface ApplicationSubmissionDto {
   lastStatusUpdate: number;
   applicant: string;
   type: string;
-
+  status: ApplicationStatus;
   typeCode: string;
   localGovernmentUuid: string;
   canEdit: boolean;


### PR DESCRIPTION
- Retrieve app status using `ApplicationSubmissionService`
- Display L/FNG banner based on status
- Add app status enum to ALCS (same enum exist in `portal-frontend` and `services` directories)