### PR TITLE
Constrain dialogs to stay inside the screen

### DIFF
--- a/alcs-frontend/src/app/features/admin/board-management/board-management-dialog/board-management-dialog.component.scss
+++ b/alcs-frontend/src/app/features/admin/board-management/board-management-dialog/board-management-dialog.component.scss
@@ -5,15 +5,12 @@
 
   form {
     max-width: 100%;
-    max-height: 75vh;
     display: grid;
     grid-template-columns: 48% 48%;
     row-gap: 24px;
     column-gap: 24px;
     margin-bottom: 12px;
     padding-top: 5px;
-
-    overflow-y: auto;
 
     .full-width {
       grid-column: 1/3;

--- a/alcs-frontend/src/styles.scss
+++ b/alcs-frontend/src/styles.scss
@@ -169,10 +169,11 @@ body {
       flex-direction: column;
       height: 100%;
     }
+
     mat-dialog-content,
     div[mat-dialog-content] {
       flex-grow: 1;
-      max-height: unset;
+      max-height: 80vh;
     }
   }
 }


### PR DESCRIPTION
* Remove manual scroll bac from board dialog
* Change max-height to 80vh so the dialog stays on the screen