### PR TITLE
Copy over TempID when re-mapping and simplify filter logic

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-condition/decision-condition.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-condition/decision-condition.component.ts
@@ -67,6 +67,7 @@ export class DecisionConditionComponent implements OnInit, OnChanges {
         .map((e) => ({
           componentDecisionUuid: e.decisionUuid,
           componentToConditionType: e.code,
+          tempId: e.tempId,
         }));
 
       this.dataChange.emit({

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-conditions.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-conditions.component.ts
@@ -117,24 +117,15 @@ export class DecisionConditionsComponent implements OnInit, OnChanges, OnDestroy
         this.decision.resolutionYear
       );
       this.selectableComponents = [...this.allComponents, ...updatedComponents];
+      const validComponentIds = this.selectableComponents.map((component) => component.tempId);
 
       this.mappedConditions = this.mappedConditions.map((condition) => {
-        const selectedComponents = this.selectableComponents
-          .filter((component) =>
-            condition.componentsToCondition
-              ?.map((conditionComponent) => conditionComponent.tempId)
-              .includes(component.tempId)
-          )
-          .map((e) => ({
-            componentDecisionUuid: e.decisionUuid,
-            componentToConditionType: e.code,
-            tempId: e.tempId,
-          }));
-
-        return {
-          ...condition,
-          componentsToCondition: selectedComponents,
-        };
+        if (condition.componentsToCondition) {
+          condition.componentsToCondition = condition.componentsToCondition.filter((component) =>
+            validComponentIds.includes(component.tempId)
+          );
+        }
+        return condition;
       });
       this.onChanges();
     }
@@ -155,6 +146,7 @@ export class DecisionConditionsComponent implements OnInit, OnChanges, OnDestroy
           componentDecisionUuid: e.decisionUuid,
           componentToConditionType: e.code,
           tempId: e.tempId,
+          uuid: e.uuid,
         }));
 
       return {

--- a/alcs-frontend/src/app/services/application/decision/application-decision-v2/application-decision-v2.dto.ts
+++ b/alcs-frontend/src/app/services/application/decision/application-decision-v2/application-decision-v2.dto.ts
@@ -203,7 +203,7 @@ export interface ApplicationDecisionConditionDto {
 export interface ComponentToCondition {
   componentDecisionUuid?: string;
   componentToConditionType?: string;
-  tempId?: string;
+  tempId: string;
 }
 export interface UpdateApplicationDecisionConditionDto {
   uuid?: string;


### PR DESCRIPTION
* Copy over temp ID when we re-map components so that we can easily filter using TempID whenever their inputs change.