### PR TITLE
Bug Fixes Pt3

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/conditions/condition/condition.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/conditions/condition/condition.component.ts
@@ -134,8 +134,8 @@ export class ConditionComponent implements OnInit, AfterViewInit {
         [field]: value,
       });
 
-      const labels = this.condition.componentLabels;
-      this.condition = { ...update, componentLabels: labels } as Condition;
+      const labels = this.condition.componentLabelsStr;
+      this.condition = { ...update, componentLabelsStr: labels } as Condition;
 
       this.updateStatus();
     }

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -8,7 +8,10 @@ import { combineLatestWith, Subject, takeUntil } from 'rxjs';
 import { ApplicationDetailService } from '../../../../../services/application/application-detail.service';
 import { ApplicationModificationDto } from '../../../../../services/application/application-modification/application-modification.dto';
 import { ApplicationModificationService } from '../../../../../services/application/application-modification/application-modification.service';
-import { ApplicationReconsiderationDto } from '../../../../../services/application/application-reconsideration/application-reconsideration.dto';
+import {
+  ApplicationReconsiderationDto,
+  RECONSIDERATION_TYPE,
+} from '../../../../../services/application/application-reconsideration/application-reconsideration.dto';
 import { ApplicationReconsiderationService } from '../../../../../services/application/application-reconsideration/application-reconsideration.service';
 import {
   ApplicationDecisionConditionDto,
@@ -260,7 +263,8 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
       .filter(
         (reconsideration) =>
           (existingDecision && existingDecision.reconsiders?.uuid === reconsideration.uuid) ||
-          (reconsideration.reviewOutcome?.code === 'PRC' && !reconsideration.resultingDecision)
+          (reconsideration.reviewOutcome?.code === 'PRC' && !reconsideration.resultingDecision) ||
+          (reconsideration.type.code === RECONSIDERATION_TYPE.T_33_1 && !reconsideration.resultingDecision)
       )
       .map((reconsideration, index) => ({
         label: `Reconsideration Request #${reconsiderations.length - index} - ${reconsideration.reconsideredDecisions

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/condition/condition.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/condition/condition.component.ts
@@ -61,8 +61,8 @@ export class ConditionComponent implements OnInit, AfterViewInit {
         [field]: value,
       });
 
-      const labels = this.condition.componentLabels;
-      this.condition = { ...update, componentLabels: labels } as Condition;
+      const labels = this.condition.componentLabelsStr;
+      this.condition = { ...update, componentLabelsStr: labels } as Condition;
 
       this.updateStatus();
     }
@@ -92,9 +92,5 @@ export class ConditionComponent implements OnInit, AfterViewInit {
     } else {
       this.conditionStatus = CONDITION_STATUS.INCOMPLETE;
     }
-  }
-
-  getComponentLabel(componentUuid: string) {
-    return this.condition.conditionComponentsLabels?.find((e) => e.componentUuid === componentUuid)?.label;
   }
 }

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.ts
@@ -13,7 +13,6 @@ import { NoticeOfIntentDto } from '../../../../services/notice-of-intent/notice-
 import {
   DRAFT_DECISION_TYPE_LABEL,
   MODIFICATION_TYPE_LABEL,
-  RECON_TYPE_LABEL,
   RELEASED_DECISION_TYPE_LABEL,
 } from '../../../../shared/application-type-pill/application-type-pill.constants';
 
@@ -56,7 +55,6 @@ export class ConditionsComponent implements OnInit {
 
   dratDecisionLabel = DRAFT_DECISION_TYPE_LABEL;
   releasedDecisionLabel = RELEASED_DECISION_TYPE_LABEL;
-  reconLabel = RECON_TYPE_LABEL;
   modificationLabel = MODIFICATION_TYPE_LABEL;
 
   constructor(

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-components/decision-components.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-components/decision-components.component.ts
@@ -212,4 +212,8 @@ export class DecisionComponentsComponent implements OnInit, OnDestroy, AfterView
       isDisabled: this.components.some((c) => c.noticeOfIntentDecisionComponentTypeCode === e.code),
     }));
   }
+
+  onValidate() {
+    this.childComponents.forEach((component) => component.form.markAllAsTouched());
+  }
 }

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -380,6 +380,9 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
     if (this.decisionConditionsComponent) {
       this.decisionConditionsComponent.onValidate();
     }
+    if (this.decisionComponentsComponent) {
+      this.decisionComponentsComponent.onValidate();
+    }
 
     if (
       !this.form.valid ||

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.controller.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.controller.ts
@@ -37,7 +37,6 @@ import { generateALCDNoticeOfIntentHtml } from '../../../../../../templates/emai
 import { NOI_SUBMISSION_STATUS } from '../../notice-of-intent/notice-of-intent-submission-status/notice-of-intent-status.dto';
 import { PARENT_TYPE } from '../../card/card-subtask/card-subtask.dto';
 import { NoticeOfIntentSubmissionService } from '../../../portal/notice-of-intent-submission/notice-of-intent-submission.service';
-import { NoticeOfIntentSubmission } from '../../../portal/notice-of-intent-submission/notice-of-intent-submission.entity';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
 @Controller('notice-of-intent-decision/v2')

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
@@ -98,6 +98,7 @@ export class NoticeOfIntentDecisionV2Service {
         },
         conditions: {
           type: true,
+          components: true,
         },
       },
     });


### PR DESCRIPTION
* Change componentLabels -> componentLabelsStr to prevent the labels from disappearing on both NOI and Application Conditions pages when updating
* Add an extra check to allow 33.1 recons to not require approval to be used as links
* Mark the decision components as touched when validating so they show red error borders
* Load components attached to conditions so they show on the NOI conditions page