### PR TITLE
convert cron expression to utc to properly map to PST or PDT

### DIFF
--- a/services/apps/alcs/src/queues/scheduler/scheduler.service.spec.ts
+++ b/services/apps/alcs/src/queues/scheduler/scheduler.service.spec.ts
@@ -1,10 +1,13 @@
 import { ConfigModule } from '@app/common/config/config.module';
 import { BullModule, getQueueToken } from '@nestjs/bullmq';
 import { Test, TestingModule } from '@nestjs/testing';
+import { isDST } from '../../utils/pacific-date-time-helper';
 import { BullConfigService } from '../bullConfig.service';
 import {
-  EVERYDAY_MIDNIGHT,
-  EVERY_15_MINUTES_STARTING_FROM_8AM,
+  EVERYDAY_MIDNIGHT_PDT_IN_UTC,
+  EVERYDAY_MIDNIGHT_PST_IN_UTC,
+  EVERY_15_MINUTES_STARTING_FROM_8AM_PDT_IN_UTC,
+  EVERY_15_MINUTES_STARTING_FROM_8AM_PST_IN_UTC,
   QUEUES,
   SchedulerService,
 } from './scheduler.service';
@@ -84,9 +87,15 @@ describe('SchedulerService', () => {
   //   expect(mockAppExpiryQueue.getRepeatableJobs).toBeCalledTimes(1);
   //   expect(mockAppExpiryQueue.add).toBeCalledTimes(1);
   //   expect(mockAppExpiryQueue.add).toBeCalledWith(
-  //     'applicationExpiry'
+  //     'applicationExpiry',
   //     {},
-  //     { repeat: { pattern: MONDAY_TO_FRIDAY_AT_2AM } },
+  //     {
+  //       repeat: {
+  //         pattern: isDST()
+  //           ? MONDAY_TO_FRIDAY_AT_2AM_PST_IN_UTC
+  //           : MONDAY_TO_FRIDAY_AT_2AM_PDT_IN_UTC,
+  //       },
+  //     },
   //   );
   // });
 
@@ -97,7 +106,13 @@ describe('SchedulerService', () => {
     expect(mockNotificationCleanUpQueue.add).toBeCalledWith(
       'cleanupNotifications',
       {},
-      { repeat: { pattern: EVERYDAY_MIDNIGHT } },
+      {
+        repeat: {
+          pattern: isDST()
+            ? EVERYDAY_MIDNIGHT_PST_IN_UTC
+            : EVERYDAY_MIDNIGHT_PDT_IN_UTC,
+        },
+      },
     );
   });
 
@@ -110,7 +125,13 @@ describe('SchedulerService', () => {
     expect(mockApplicationStatusEmailsQueue.add).toBeCalledWith(
       'applicationSubmissionStatusEmails',
       {},
-      { repeat: { pattern: EVERY_15_MINUTES_STARTING_FROM_8AM } },
+      {
+        repeat: {
+          pattern: isDST()
+            ? EVERY_15_MINUTES_STARTING_FROM_8AM_PST_IN_UTC
+            : EVERY_15_MINUTES_STARTING_FROM_8AM_PDT_IN_UTC,
+        },
+      },
     );
   });
 
@@ -123,7 +144,13 @@ describe('SchedulerService', () => {
     expect(mockNoticeOfIntentStatusEmailsQueue.add).toBeCalledWith(
       'noticeOfIntentSubmissionStatusEmails',
       {},
-      { repeat: { pattern: EVERY_15_MINUTES_STARTING_FROM_8AM } },
+      {
+        repeat: {
+          pattern: isDST()
+            ? EVERY_15_MINUTES_STARTING_FROM_8AM_PST_IN_UTC
+            : EVERY_15_MINUTES_STARTING_FROM_8AM_PDT_IN_UTC,
+        },
+      },
     );
   });
 });

--- a/services/apps/alcs/src/utils/pacific-date-time-helper.spec.ts
+++ b/services/apps/alcs/src/utils/pacific-date-time-helper.spec.ts
@@ -2,6 +2,7 @@
 import {
   getNextDayToPacific,
   getStartOfDayToPacific,
+  isDST,
 } from './pacific-date-time-helper';
 
 describe('Pacific date helpers', () => {
@@ -19,5 +20,23 @@ describe('Pacific date helpers', () => {
 
     const result = getStartOfDayToPacific(mockTimestamp);
     expect(result).toEqual(expectedDate);
+  });
+});
+
+describe('isDST function', () => {
+  // Test when it's daylight saving time
+  it("should return true when it's daylight saving time", () => {
+    jest.useFakeTimers().setSystemTime(new Date('2021-07-01'));
+
+    expect(isDST()).toBe(true);
+    jest.useRealTimers();
+  });
+
+  // Test when it's not daylight saving time
+  it("should return false when it's not daylight saving time", () => {
+    jest.useFakeTimers().setSystemTime(new Date('2021-01-01'));
+
+    expect(isDST()).toBe(false);
+    jest.useRealTimers();
   });
 });

--- a/services/apps/alcs/src/utils/pacific-date-time-helper.ts
+++ b/services/apps/alcs/src/utils/pacific-date-time-helper.ts
@@ -15,3 +15,10 @@ export const getStartOfDayToPacific = (timestamp: number) => {
   const date = formatIncomingDate(timestamp);
   return dayjs(date).tz('Canada/Pacific').startOf('day').toDate();
 };
+
+export const isDST = () => {
+  const timezone = 'America/Vancouver';
+  const jan = dayjs('2021-01-01').tz(timezone).utcOffset();
+  const jul = dayjs('2021-07-01').tz(timezone).utcOffset();
+  return Math.max(jan, jul) === dayjs().tz(timezone).utcOffset();
+};

--- a/services/apps/alcs/src/utils/pacific-date-time-helper.ts
+++ b/services/apps/alcs/src/utils/pacific-date-time-helper.ts
@@ -18,7 +18,6 @@ export const getStartOfDayToPacific = (timestamp: number) => {
 
 export const isDST = () => {
   const timezone = 'America/Vancouver';
-  const jan = dayjs('2021-01-01').tz(timezone).utcOffset();
   const jul = dayjs('2021-07-01').tz(timezone).utcOffset();
-  return Math.max(jan, jul) === dayjs().tz(timezone).utcOffset();
+  return jul === dayjs().tz(timezone).utcOffset();
 };


### PR DESCRIPTION
- introduce isDST function
- use utc corn expression to match desired PST or PDT time