### PR TITLE
Add Permissions Checks to Document Portal Endpoints

### DIFF
--- a/portal-frontend/src/app/services/notification-document/notification-document.service.spec.ts
+++ b/portal-frontend/src/app/services/notification-document/notification-document.service.spec.ts
@@ -88,22 +88,4 @@ describe('NotificationDocumentService', () => {
     expect(mockHttpClient.patch).toHaveBeenCalledTimes(1);
     expect(mockToastService.showErrorToast).toHaveBeenCalledTimes(1);
   });
-
-  it('should make a post request for deleting multiple files', async () => {
-    mockHttpClient.post.mockReturnValue(of({}));
-
-    await service.deleteExternalFiles(['fileId']);
-
-    expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
-    expect(mockHttpClient.post.mock.calls[0][0]).toContain('notification-document');
-  });
-
-  it('should show an error toast if deleting a file fails', async () => {
-    mockHttpClient.post.mockReturnValue(throwError(() => ({})));
-
-    await service.deleteExternalFiles(['fileId']);
-
-    expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
-    expect(mockToastService.showErrorToast).toHaveBeenCalledTimes(1);
-  });
 });

--- a/portal-frontend/src/app/services/notification-document/notification-document.service.ts
+++ b/portal-frontend/src/app/services/notification-document/notification-document.service.ts
@@ -80,18 +80,6 @@ export class NotificationDocumentService {
     }
   }
 
-  async deleteExternalFiles(fileUuids: string[]) {
-    try {
-      this.overlayService.showSpinner();
-      await firstValueFrom(this.httpClient.post(`${this.serviceUrl}/delete-files`, fileUuids));
-    } catch (e) {
-      console.error(e);
-      this.toastService.showErrorToast('Failed to delete documents');
-    } finally {
-      this.overlayService.hideSpinner();
-    }
-  }
-
   async update(fileNumber: string | undefined, updateDtos: NotificationDocumentUpdateDto[]) {
     try {
       await firstValueFrom(this.httpClient.patch<void>(`${this.serviceUrl}/notification/${fileNumber}`, updateDtos));

--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.spec.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.spec.ts
@@ -600,6 +600,17 @@ describe('ApplicationDecisionV2Service', () => {
       );
     });
 
+    it('should call the repository to check if portal user can download document', async () => {
+      mockDecisionDocumentRepository.findOne.mockResolvedValue(
+        new ApplicationDecisionDocument(),
+      );
+      mockDocumentService.getDownloadUrl.mockResolvedValue('');
+
+      await service.getDownloadForPortal('fake-uuid');
+      expect(mockDecisionDocumentRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(mockDocumentService.getDownloadUrl).toHaveBeenCalledTimes(1);
+    });
+
     it('should throw an exception when document not found for deletion', async () => {
       mockDecisionDocumentRepository.findOne.mockResolvedValue(null);
       await expect(service.deleteDocument('fake-uuid')).rejects.toMatchObject(

--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
@@ -490,6 +490,28 @@ export class ApplicationDecisionV2Service {
     );
   }
 
+  async getDownloadForPortal(decisionDocumentUuid: string) {
+    const decisionDocument = await this.decisionDocumentRepository.findOne({
+      where: {
+        decision: {
+          isDraft: false,
+        },
+        uuid: decisionDocumentUuid,
+      },
+      relations: {
+        document: true,
+      },
+    });
+
+    if (decisionDocument) {
+      return this.documentService.getDownloadUrl(
+        decisionDocument.document,
+        false,
+      );
+    }
+    throw new ServiceNotFoundException('Failed to find document');
+  }
+
   getOutcomeByCode(code: string) {
     return this.decisionOutcomeRepository.findOneOrFail({
       where: {

--- a/services/apps/alcs/src/alcs/application/application-submission/application-submission.service.ts
+++ b/services/apps/alcs/src/alcs/application/application-submission/application-submission.service.ts
@@ -3,14 +3,13 @@ import { InjectMapper } from '@automapper/nestjs';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { ApplicationOwnerDto } from '../../../portal/application-submission/application-owner/application-owner.dto';
+import { ApplicationOwner } from '../../../portal/application-submission/application-owner/application-owner.entity';
+import { ApplicationSubmission } from '../../../portal/application-submission/application-submission.entity';
+import { filterUndefined } from '../../../utils/undefined';
 import { ApplicationSubmissionStatusService } from '../application-submission-status/application-submission-status.service';
 import { ApplicationSubmissionStatusType } from '../application-submission-status/submission-status-type.entity';
 import { SUBMISSION_STATUS } from '../application-submission-status/submission-status.dto';
-import { ApplicationOwnerDto } from '../../../portal/application-submission/application-owner/application-owner.dto';
-import { ApplicationOwner } from '../../../portal/application-submission/application-owner/application-owner.entity';
-import { ApplicationSubmissionUpdateDto } from '../../../portal/application-submission/application-submission.dto';
-import { ApplicationSubmission } from '../../../portal/application-submission/application-submission.entity';
-import { filterUndefined } from '../../../utils/undefined';
 import { AlcsApplicationSubmissionDto } from '../application.dto';
 import { AlcsApplicationSubmissionUpdateDto } from './application-submission.dto';
 

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.spec.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.spec.ts
@@ -9,6 +9,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DocumentService } from '../../../document/document.service';
+import { ApplicationDecisionDocument } from '../../application-decision/application-decision-document/application-decision-document.entity';
 import { NOI_SUBMISSION_STATUS } from '../../notice-of-intent/notice-of-intent-submission-status/notice-of-intent-status.dto';
 import { NoticeOfIntentSubmissionStatusService } from '../../notice-of-intent/notice-of-intent-submission-status/notice-of-intent-submission-status.service';
 import { NoticeOfIntent } from '../../notice-of-intent/notice-of-intent.entity';
@@ -459,6 +460,17 @@ describe('NoticeOfIntentDecisionV2Service', () => {
       await service.attachDocument('uuid', {} as any, {} as any);
       expect(mockDecisionDocumentRepository.save).toHaveBeenCalledTimes(1);
       expect(mockDocumentService.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call the repository to check if portal user can download document', async () => {
+      mockDecisionDocumentRepository.findOne.mockResolvedValue(
+        new NoticeOfIntentDecisionDocument(),
+      );
+      mockDocumentService.getDownloadUrl.mockResolvedValue('');
+
+      await service.getDownloadForPortal('fake-uuid');
+      expect(mockDecisionDocumentRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(mockDocumentService.getDownloadUrl).toHaveBeenCalledTimes(1);
     });
 
     it('should throw an exception when attaching a document to a non-existent decision', async () => {

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
@@ -410,6 +410,29 @@ export class NoticeOfIntentDecisionV2Service {
     );
   }
 
+  async getDownloadForPortal(decisionDocumentUuid: string) {
+    const decisionDocument = await this.decisionDocumentRepository.findOne({
+      where: {
+        decision: {
+          isDraft: false,
+        },
+        uuid: decisionDocumentUuid,
+      },
+      relations: {
+        document: true,
+      },
+    });
+
+    if (decisionDocument) {
+      return this.documentService.getDownloadUrl(
+        decisionDocument.document,
+        true,
+      );
+    }
+
+    throw new ServiceNotFoundException('Failed to find document');
+  }
+
   getOutcomeByCode(code: string) {
     return this.decisionOutcomeRepository.findOneOrFail({
       where: {

--- a/services/apps/alcs/src/portal/application-document/application-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/application-document/application-document.controller.spec.ts
@@ -94,6 +94,7 @@ describe('ApplicationDocumentController', () => {
   it('should call through to delete documents', async () => {
     appDocumentService.delete.mockResolvedValue(mockDocument);
     appDocumentService.get.mockResolvedValue(mockDocument);
+    mockApplicationSubmissionService.canDeleteDocument.mockResolvedValue(true);
 
     await controller.delete('fake-uuid', {
       user: {
@@ -127,6 +128,7 @@ describe('ApplicationDocumentController', () => {
     const fakeUrl = 'fake-url';
     appDocumentService.getInlineUrl.mockResolvedValue(fakeUrl);
     appDocumentService.get.mockResolvedValue(mockDocument);
+    mockApplicationSubmissionService.canAccessDocument.mockResolvedValue(true);
 
     const res = await controller.open('fake-uuid', {
       user: {
@@ -141,6 +143,7 @@ describe('ApplicationDocumentController', () => {
     const fakeUrl = 'fake-url';
     appDocumentService.getDownloadUrl.mockResolvedValue(fakeUrl);
     appDocumentService.get.mockResolvedValue(mockDocument);
+    mockApplicationSubmissionService.canAccessDocument.mockResolvedValue(true);
 
     const res = await controller.download('fake-uuid', {
       user: {

--- a/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.spec.ts
@@ -29,6 +29,8 @@ describe('NoticeOfIntentDocumentController', () => {
   let mockDocumentService: DeepMocked<DocumentService>;
   let mockNoticeOfIntentService: DeepMocked<NoticeOfIntentService>;
 
+  const mockRequest = { user: { entity: 'Bruce' } };
+
   const mockDocument = new NoticeOfIntentDocument({
     document: new Document({
       fileName: 'fileName',
@@ -92,12 +94,9 @@ describe('NoticeOfIntentDocumentController', () => {
   it('should call through to delete document', async () => {
     noiDocumentService.delete.mockResolvedValue(mockDocument);
     noiDocumentService.get.mockResolvedValue(mockDocument);
+    mockNoiSubmissionService.canDeleteDocument.mockResolvedValue(true);
 
-    await controller.delete('fake-uuid', {
-      user: {
-        entity: {},
-      },
-    });
+    await controller.delete('fake-uuid', mockRequest);
 
     expect(noiDocumentService.get).toHaveBeenCalledTimes(1);
     expect(noiDocumentService.delete).toHaveBeenCalledTimes(1);
@@ -106,31 +105,20 @@ describe('NoticeOfIntentDocumentController', () => {
   it('should call through to update documents', async () => {
     noiDocumentService.updateDescriptionAndType.mockResolvedValue([]);
 
-    await controller.update(
-      'file-number',
-      {
-        user: {
-          entity: {},
-        },
-      },
-      [],
-    );
+    await controller.update('file-number', mockRequest, []);
 
     expect(noiDocumentService.updateDescriptionAndType).toHaveBeenCalledTimes(
       1,
     );
   });
 
-  it('should call through for download', async () => {
+  it('should call through for open', async () => {
     const fakeUrl = 'fake-url';
     noiDocumentService.getInlineUrl.mockResolvedValue(fakeUrl);
     noiDocumentService.get.mockResolvedValue(mockDocument);
+    mockNoiSubmissionService.canAccessDocument.mockResolvedValue(true);
 
-    const res = await controller.open('fake-uuid', {
-      user: {
-        entity: {},
-      },
-    });
+    const res = await controller.open('fake-uuid', mockRequest);
 
     expect(res.url).toEqual(fakeUrl);
   });
@@ -243,8 +231,10 @@ describe('NoticeOfIntentDocumentController', () => {
 
   it('should call through to delete multiple documents', async () => {
     noiDocumentService.deleteMany.mockResolvedValue();
+    noiDocumentService.get.mockResolvedValue(new NoticeOfIntentDocument());
+    mockNoiSubmissionService.canDeleteDocument.mockResolvedValue(true);
 
-    await controller.deleteMany(['fake-uuid']);
+    await controller.deleteMany(['fake-uuid'], mockRequest);
 
     expect(noiDocumentService.deleteMany).toHaveBeenCalledTimes(1);
   });

--- a/services/apps/alcs/src/portal/notification-document/notification-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/notification-document/notification-document.controller.spec.ts
@@ -93,6 +93,7 @@ describe('NotificationDocumentController', () => {
   it('should call through to delete documents', async () => {
     mockNotificationDocumentService.delete.mockResolvedValue(mockDocument);
     mockNotificationDocumentService.get.mockResolvedValue(mockDocument);
+    mockNotificationSubmissionService.canDeleteDocument.mockResolvedValue(true);
 
     await controller.delete('fake-uuid', {
       user: {
@@ -128,6 +129,7 @@ describe('NotificationDocumentController', () => {
     const fakeUrl = 'fake-url';
     mockNotificationDocumentService.getInlineUrl.mockResolvedValue(fakeUrl);
     mockNotificationDocumentService.get.mockResolvedValue(mockDocument);
+    mockNotificationSubmissionService.canAccessDocument.mockResolvedValue(true);
 
     const res = await controller.open('fake-uuid', {
       user: {
@@ -142,6 +144,7 @@ describe('NotificationDocumentController', () => {
     const fakeUrl = 'fake-url';
     mockNotificationDocumentService.getDownloadUrl.mockResolvedValue(fakeUrl);
     mockNotificationDocumentService.get.mockResolvedValue(mockDocument);
+    mockNotificationSubmissionService.canAccessDocument.mockResolvedValue(true);
 
     const res = await controller.download('fake-uuid', {
       user: {

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.entity.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.entity.ts
@@ -8,14 +8,12 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { NoticeOfIntentSubmissionToSubmissionStatus } from '../../alcs/notice-of-intent/notice-of-intent-submission-status/notice-of-intent-status.entity';
 import { NotificationSubmissionToSubmissionStatus } from '../../alcs/notification/notification-submission-status/notification-status.entity';
 import { Notification } from '../../alcs/notification/notification.entity';
 import { Base } from '../../common/entities/base.entity';
 import { User } from '../../user/user.entity';
 import { ColumnNumericTransformer } from '../../utils/column-numeric-transform';
 import { NotificationParcel } from './notification-parcel/notification-parcel.entity';
-import { NotificationTransfereeDto } from './notification-transferee/notification-transferee.dto';
 import { NotificationTransferee } from './notification-transferee/notification-transferee.entity';
 
 @Entity()

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.service.spec.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.service.spec.ts
@@ -4,7 +4,8 @@ import { AutomapperModule } from '@automapper/nestjs';
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { VISIBILITY_FLAG } from '../../alcs/application/application-document/application-document.entity';
 import { LocalGovernment } from '../../alcs/local-government/local-government.entity';
 import { LocalGovernmentService } from '../../alcs/local-government/local-government.service';
 import { NoticeOfIntentType } from '../../alcs/notice-of-intent/notice-of-intent-type/notice-of-intent-type.entity';
@@ -16,13 +17,14 @@ import { NotificationSubmissionStatusService } from '../../alcs/notification/not
 import { Notification } from '../../alcs/notification/notification.entity';
 import { NotificationService } from '../../alcs/notification/notification.service';
 import { NotificationSubmissionProfile } from '../../common/automapper/notification-submission.automapper.profile';
+import { Document } from '../../document/document.entity';
 import { FileNumberService } from '../../file-number/file-number.service';
 import { EmailService } from '../../providers/email/email.service';
 import { User } from '../../user/user.entity';
+import { ApplicationSubmission } from '../application-submission/application-submission.entity';
 import { ValidatedNotificationSubmission } from './notification-submission-validator.service';
 import { NotificationSubmission } from './notification-submission.entity';
 import { NotificationSubmissionService } from './notification-submission.service';
-import { Document } from '../../document/document.entity';
 
 describe('NotificationSubmissionService', () => {
   let service: NotificationSubmissionService;
@@ -34,6 +36,7 @@ describe('NotificationSubmissionService', () => {
   let mockDocumentService: DeepMocked<NotificationDocumentService>;
   let mockEmailService: DeepMocked<EmailService>;
   let mockSubmission;
+  let mockQueryBuilder;
 
   beforeEach(async () => {
     mockRepository = createMock();
@@ -97,6 +100,19 @@ describe('NotificationSubmissionService', () => {
         clientRoles: [],
       }),
     });
+
+    mockQueryBuilder = createMock<SelectQueryBuilder<ApplicationSubmission>>();
+    mockQueryBuilder.leftJoin.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.select.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.execute.mockResolvedValue([
+      {
+        user_uuid: 'user_uuid',
+        bceid_business_guid: 'bceid_business_guid',
+        localGovernment_bceid_business_guid:
+          'localGovernment_bceid_business_guid',
+      },
+    ]);
   });
 
   it('should be defined', () => {
@@ -392,5 +408,151 @@ describe('NotificationSubmissionService', () => {
 
     expect(mockDocumentService.attachDocumentAsBuffer).toHaveBeenCalledTimes(0);
     expect(mockStatusService.setStatusDate).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return true for access document if its public', async () => {
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.PUBLIC],
+      }),
+      new User(),
+    );
+
+    expect(res).toBe(true);
+  });
+
+  it('should return true for access document if its applicant and requesting user owns it', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.APPLICANT],
+      }),
+      new User({
+        uuid: 'user_uuid',
+      }),
+    );
+
+    expect(res).toBe(true);
+  });
+
+  it('should return false for access document if its applicant and requesting user does not own it', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.APPLICANT],
+      }),
+      new User({
+        uuid: 'NOT_user_uuid',
+      }),
+    );
+
+    expect(res).toBe(false);
+  });
+
+  it('should return true for access document if its government and requesting user is in that government', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.GOVERNMENT],
+      }),
+      new User({
+        bceidBusinessGuid: 'localGovernment_bceid_business_guid',
+      }),
+    );
+
+    expect(res).toBe(true);
+  });
+
+  it('should return false for access document if its government and requesting user is NOT in that government', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.GOVERNMENT],
+      }),
+      new User({
+        bceidBusinessGuid: 'NOT_localGovernment_bceid_business_guid',
+      }),
+    );
+
+    expect(res).toBe(false);
+  });
+
+  it('should return true for access document if its applicant and requesting user is in same business', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.APPLICANT],
+      }),
+      new User({
+        bceidBusinessGuid: 'bceid_business_guid',
+      }),
+    );
+
+    expect(res).toBe(true);
+  });
+
+  it('should return false for access document if its applicant and requesting user is NOT in same business account', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canAccessDocument(
+      new NotificationDocument({
+        visibilityFlags: [VISIBILITY_FLAG.APPLICANT],
+      }),
+      new User({
+        bceidBusinessGuid: 'NOT_bceid_business_guid',
+      }),
+    );
+
+    expect(res).toBe(false);
+  });
+
+  it('should return true for delete document if user is owner', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canDeleteDocument(
+      new NotificationDocument({}),
+      new User({
+        uuid: 'user_uuid',
+      }),
+    );
+
+    expect(res).toBe(true);
+  });
+
+  it('should return false for delete document if user is NOT owner', async () => {
+    mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    const noiSubmission = new NotificationSubmission();
+    mockRepository.findOneOrFail.mockResolvedValue(noiSubmission);
+
+    const res = await service.canDeleteDocument(
+      new NotificationDocument({}),
+      new User({
+        uuid: 'NOT_user_uuid',
+      }),
+    );
+
+    expect(res).toBe(false);
   });
 });

--- a/services/apps/alcs/src/portal/public/application/application-decision.controller.spec.ts
+++ b/services/apps/alcs/src/portal/public/application/application-decision.controller.spec.ts
@@ -64,11 +64,11 @@ describe('ApplicationDecisionController', () => {
   });
 
   it('should call through for loading files', async () => {
-    mockDecisionService.getDownloadUrl.mockResolvedValue('Mock Url');
+    mockDecisionService.getDownloadForPortal.mockResolvedValue('Mock Url');
 
     const res = await controller.openFile('');
 
     expect(res.url).toBeTruthy();
-    expect(mockDecisionService.getDownloadUrl).toHaveBeenCalledTimes(1);
+    expect(mockDecisionService.getDownloadForPortal).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/apps/alcs/src/portal/public/application/application-decision.controller.ts
+++ b/services/apps/alcs/src/portal/public/application/application-decision.controller.ts
@@ -1,6 +1,6 @@
 import { Mapper } from '@automapper/core';
 import { InjectMapper } from '@automapper/nestjs';
-import { Controller, Get, Param, Req } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { Public } from 'nest-keycloak-connect';
 import { ApplicationDecisionV2Service } from '../../../alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service';
 import { ApplicationDecision } from '../../../alcs/application-decision/application-decision.entity';
@@ -31,7 +31,7 @@ export class ApplicationDecisionController {
 
   @Get('/:uuid/open')
   async openFile(@Param('uuid') fileUuid: string) {
-    const url = await this.decisionService.getDownloadUrl(fileUuid);
+    const url = await this.decisionService.getDownloadForPortal(fileUuid);
 
     return { url };
   }

--- a/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.spec.ts
+++ b/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.spec.ts
@@ -69,11 +69,11 @@ describe('NoticeOfIntentDecisionController', () => {
   });
 
   it('should call through for loading files', async () => {
-    mockDecisionService.getDownloadUrl.mockResolvedValue('Mock Url');
+    mockDecisionService.getDownloadForPortal.mockResolvedValue('Mock Url');
 
     const res = await controller.openFile('');
 
     expect(res.url).toBeTruthy();
-    expect(mockDecisionService.getDownloadUrl).toHaveBeenCalledTimes(1);
+    expect(mockDecisionService.getDownloadForPortal).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.ts
+++ b/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.ts
@@ -31,7 +31,7 @@ export class NoticeOfIntentDecisionController {
 
   @Get('/:uuid/open')
   async openFile(@Param('uuid') fileUuid: string) {
-    const url = await this.decisionService.getDownloadUrl(fileUuid);
+    const url = await this.decisionService.getDownloadForPortal(fileUuid);
 
     return { url };
   }


### PR DESCRIPTION
* Add logic to check that the current user has correct permissions in accordance with the documents visibility flags to access the documents
* Add logic so only people who have edit rights on a submission can delete its documents