### PR TITLE
Don't load draft decisions for Public APPs

### DIFF
--- a/services/apps/alcs/src/portal/public/application/public-application.service.spec.ts
+++ b/services/apps/alcs/src/portal/public/application/public-application.service.spec.ts
@@ -100,7 +100,7 @@ describe('PublicApplicationService', () => {
     mockAppReviewService.getForPublicReview.mockResolvedValue(
       new ApplicationSubmissionReview(),
     );
-    mockAppDecService.getByAppFileNumber.mockResolvedValue([]);
+    mockAppDecService.getForPortal.mockResolvedValue([]);
 
     const fileId = 'file-id';
     await service.getPublicData(fileId);
@@ -115,7 +115,7 @@ describe('PublicApplicationService', () => {
       VISIBILITY_FLAG.PUBLIC,
     ]);
     expect(mockAppReviewService.getForPublicReview).toHaveBeenCalledTimes(1);
-    expect(mockAppDecService.getByAppFileNumber).toHaveBeenCalledTimes(1);
+    expect(mockAppDecService.getForPortal).toHaveBeenCalledTimes(1);
   });
 
   it('should call through to document service for getting files', async () => {

--- a/services/apps/alcs/src/portal/public/application/public-application.service.ts
+++ b/services/apps/alcs/src/portal/public/application/public-application.service.ts
@@ -88,7 +88,7 @@ export class PublicApplicationService {
       );
     }
 
-    const decisions = await this.applicationDecisionService.getByAppFileNumber(
+    const decisions = await this.applicationDecisionService.getForPortal(
       fileNumber,
     );
     const mappedDecisions = this.mapper.mapArray(


### PR DESCRIPTION
* Use get for portal instead which does not load draft decisions