### PR TITLE
Manually decode token on Code Controller

### DIFF
--- a/services/apps/alcs/src/common/authorization/authorization.module.ts
+++ b/services/apps/alcs/src/common/authorization/authorization.module.ts
@@ -17,6 +17,6 @@ import { AuthorizationService } from './authorization.service';
   ],
   providers: [AuthorizationService],
   controllers: [AuthorizationController],
-  exports: [KeycloakConnectModule, UserModule],
+  exports: [KeycloakConnectModule, UserModule, AuthorizationService],
 })
 export class AuthorizationModule {}

--- a/services/apps/alcs/src/common/authorization/roles-guard.service.spec.ts
+++ b/services/apps/alcs/src/common/authorization/roles-guard.service.spec.ts
@@ -16,7 +16,7 @@ import { mockAppLoggerService } from '../../../test/mocks/mockLogger';
 import { RolesGuard } from './roles-guard.service';
 import { AUTH_ROLE } from './roles';
 
-describe('RoleGuard', () => {
+describe('RolesGuard', () => {
   let guard: RolesGuard;
   let reflector: DeepMocked<Reflector>;
   let mockContext;

--- a/services/apps/alcs/src/portal/code/code.controller.spec.ts
+++ b/services/apps/alcs/src/portal/code/code.controller.spec.ts
@@ -1,18 +1,18 @@
 import { classes } from '@automapper/classes';
 import { AutomapperModule } from '@automapper/nestjs';
-import { DeepMocked, createMock } from '@golevelup/nestjs-testing';
+import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ClsService } from 'nestjs-cls';
 import { mockKeyCloakProviders } from '../../../test/mocks/mockTypes';
-import { CodeService } from '../../alcs/code/code.service';
-import { LocalGovernment } from '../../alcs/local-government/local-government.entity';
-import { LocalGovernmentService } from '../../alcs/local-government/local-government.service';
 import { ApplicationDocumentService } from '../../alcs/application/application-document/application-document.service';
 import { ApplicationService } from '../../alcs/application/application.service';
 import { CardType } from '../../alcs/card/card-type/card-type.entity';
 import { CardService } from '../../alcs/card/card.service';
+import { CodeService } from '../../alcs/code/code.service';
+import { LocalGovernment } from '../../alcs/local-government/local-government.entity';
+import { LocalGovernmentService } from '../../alcs/local-government/local-government.service';
 import { NoticeOfIntentService } from '../../alcs/notice-of-intent/notice-of-intent.service';
-import { User } from '../../user/user.entity';
+import { AuthorizationService } from '../../common/authorization/authorization.service';
 import { ApplicationSubmissionService } from '../application-submission/application-submission.service';
 import { CodeController } from './code.controller';
 
@@ -25,6 +25,7 @@ describe('CodeController', () => {
   let mockAppSubmissionService: DeepMocked<ApplicationSubmissionService>;
   let mockNoiService: DeepMocked<NoticeOfIntentService>;
   let mockCodeService: DeepMocked<CodeService>;
+  let mockAuthorizationService: DeepMocked<AuthorizationService>;
 
   beforeEach(async () => {
     mockLgService = createMock();
@@ -34,6 +35,7 @@ describe('CodeController', () => {
     mockAppSubmissionService = createMock();
     mockNoiService = createMock();
     mockCodeService = createMock();
+    mockAuthorizationService = createMock();
 
     const app: TestingModule = await Test.createTestingModule({
       imports: [
@@ -73,6 +75,10 @@ describe('CodeController', () => {
           useValue: mockCodeService,
         },
         {
+          provide: AuthorizationService,
+          useValue: mockAuthorizationService,
+        },
+        {
           provide: ClsService,
           useValue: {},
         },
@@ -99,6 +105,8 @@ describe('CodeController', () => {
       }),
     ]);
 
+    mockAuthorizationService.decodeHeaderToken.mockResolvedValue({} as any);
+
     mockAppDocService.fetchTypes.mockResolvedValue([]);
     mockAppSubmissionService.listNaruSubtypes.mockResolvedValue([]);
     mockNoiService.listTypes.mockResolvedValue([]);
@@ -115,9 +123,7 @@ describe('CodeController', () => {
 
   it('should call out to local government service for fetching codes', async () => {
     const codes = await portalController.loadCodes({
-      user: {
-        entity: new User(),
-      },
+      headers: {},
     });
     expect(codes.localGovernments).toBeDefined();
     expect(codes.localGovernments.length).toBe(1);
@@ -128,6 +134,9 @@ describe('CodeController', () => {
 
   it('should set the matches flag correctly when users guid matches government', async () => {
     const matchingGuid = 'guid';
+    mockAuthorizationService.decodeHeaderToken.mockResolvedValue({
+      bceid_business_guid: matchingGuid,
+    } as any);
     mockLgService.listActive.mockResolvedValue([
       new LocalGovernment({
         uuid: 'fake-uuid',
@@ -138,13 +147,10 @@ describe('CodeController', () => {
     ]);
 
     const codes = await portalController.loadCodes({
-      user: {
-        entity: new User({
-          bceidBusinessGuid: matchingGuid,
-        }),
-      },
+      headers: {},
     });
 
+    expect(mockAuthorizationService.decodeHeaderToken).toHaveBeenCalledTimes(1);
     expect(codes.localGovernments).toBeDefined();
     expect(codes.localGovernments.length).toBe(1);
     expect(codes.localGovernments[0].name).toEqual('fake-name');
@@ -154,9 +160,7 @@ describe('CodeController', () => {
 
   it('should call out to local submission service for fetching codes', async () => {
     const codes = await portalController.loadCodes({
-      user: {
-        entity: new User(),
-      },
+      headers: {},
     });
     expect(codes.submissionTypes).toBeDefined();
     expect(codes.submissionTypes.length).toBe(1);

--- a/services/apps/alcs/src/portal/code/code.controller.ts
+++ b/services/apps/alcs/src/portal/code/code.controller.ts
@@ -1,22 +1,21 @@
 import { Mapper } from '@automapper/core';
 import { InjectMapper } from '@automapper/nestjs';
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Req } from '@nestjs/common';
 import { Public } from 'nest-keycloak-connect';
 import { ApplicationDecisionMakerCode } from '../../alcs/application-decision/application-decision-maker/application-decision-maker.entity';
 import { ApplicationDecisionMakerCodeDto } from '../../alcs/application-decision/application-decision-maker/decision-maker.dto';
-import { ApplicationSubmissionStatusService } from '../../alcs/application/application-submission-status/application-submission-status.service';
+import { ApplicationDocumentService } from '../../alcs/application/application-document/application-document.service';
+import { ApplicationService } from '../../alcs/application/application.service';
+import { CardService } from '../../alcs/card/card.service';
 import { ApplicationRegionDto } from '../../alcs/code/application-code/application-region/application-region.dto';
 import { ApplicationRegion } from '../../alcs/code/application-code/application-region/application-region.entity';
 import { CodeService } from '../../alcs/code/code.service';
 import { LocalGovernment } from '../../alcs/local-government/local-government.entity';
 import { LocalGovernmentService } from '../../alcs/local-government/local-government.service';
 import { NoticeOfIntentService } from '../../alcs/notice-of-intent/notice-of-intent.service';
+import { AuthorizationService } from '../../common/authorization/authorization.service';
 import { DocumentCode } from '../../document/document-code.entity';
-import { ApplicationDocumentService } from '../../alcs/application/application-document/application-document.service';
-import { ApplicationService } from '../../alcs/application/application.service';
-import { CardService } from '../../alcs/card/card.service';
 import { DocumentTypeDto } from '../../document/document.dto';
-import { User } from '../../user/user.entity';
 import { ApplicationSubmissionService } from '../application-submission/application-submission.service';
 
 export interface LocalGovernmentDto {
@@ -38,6 +37,7 @@ export class CodeController {
     private applicationSubmissionService: ApplicationSubmissionService,
     private noticeOfIntentService: NoticeOfIntentService,
     private codeService: CodeService,
+    private authorizationService: AuthorizationService,
   ) {}
 
   @Get()
@@ -72,10 +72,7 @@ export class CodeController {
     );
 
     return {
-      localGovernments: this.mapLocalGovernments(
-        localGovernments,
-        req.user?.entity,
-      ),
+      localGovernments: await this.mapLocalGovernments(localGovernments, req),
       applicationTypes,
       noticeOfIntentTypes,
       submissionTypes,
@@ -86,18 +83,27 @@ export class CodeController {
     };
   }
 
-  private mapLocalGovernments(
+  private async mapLocalGovernments(
     governments: LocalGovernment[],
-    user?: User,
-  ): LocalGovernmentDto[] {
+    req: any,
+  ): Promise<LocalGovernmentDto[]> {
+    //No auth guard, so we can't use req.user.entity
+    const tokenHeader = req.headers['authorization'];
+    const token = await this.authorizationService.decodeHeaderToken(
+      tokenHeader,
+    );
+    const bceidGuid: string | boolean = token
+      ? token['bceid_business_guid']
+      : false;
+
     return governments.map((government) => ({
       name: government.name,
       uuid: government.uuid,
       hasGuid: government.bceidBusinessGuid !== null,
       matchesUserGuid:
-        user &&
+        !!bceidGuid &&
         !!government.bceidBusinessGuid &&
-        government.bceidBusinessGuid === user.bceidBusinessGuid,
+        government.bceidBusinessGuid === bceidGuid,
     }));
   }
 }


### PR DESCRIPTION
* Controller is now public, so without the RolesGuard there is no req.user.entity
* Grab token from headers and decode it.