### PR TITLE
Update Selected Own Governmment on Blur

### DIFF
--- a/portal-frontend/src/app/features/applications/edit-submission/select-government/select-government.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/select-government/select-government.component.ts
@@ -89,7 +89,9 @@ export class SelectGovernmentComponent extends StepComponent implements OnInit, 
       const localGovernmentName = this.localGovernment.getRawValue();
       if (localGovernmentName) {
         const localGovernment = this.localGovernments.find((lg) => lg.name == localGovernmentName);
-        if (!localGovernment) {
+        if (localGovernment) {
+          this.selectedOwnGovernment = localGovernment.matchesUserGuid;
+        } else {
           this.localGovernment.setValue(null);
           console.log('Clearing Local Government field');
         }


### PR DESCRIPTION
* If you type the full government name but do not select it, the warning banner was not showing
* By updating the value on Blur, this is fixed