### PR TITLE
switch from covert_time to add_time_zone

### DIFF
--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_cancelled.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_cancelled.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -109,7 +114,7 @@ def _map_fields(data):
         status_effective_date = data["min_date"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_in_progress.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_in_progress.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -117,7 +122,7 @@ def _map_fields(data):
             status_effective_date = data["when_created"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_returned_incomplete_lfng.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_returned_incomplete_lfng.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -111,7 +116,7 @@ def _map_fields(data):
         status_effective_date = data["max_date"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_review_lfng.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_review_lfng.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -111,7 +116,7 @@ def _map_fields(data):
         status_effective_date = data["max_date"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_submitted_alc.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_submitted_alc.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -109,7 +114,7 @@ def _map_fields(data):
     if data and data["submitted_to_alc_date"]:
         status_effective_date = data["submitted_to_alc_date"]
         if status_effective_date:
-            date = convert_timezone(status_effective_date, "US/Pacific")
+            date = add_timezone_and_keep_date_part(status_effective_date)
             data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_submitted_incomplete_alc.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_submitted_incomplete_alc.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -110,7 +115,7 @@ def _map_fields(data):
     if data and data["completion_date"]:
         status_effective_date = data["completion_date"]
         if status_effective_date:
-            date = convert_timezone(status_effective_date, "US/Pacific")
+            date = add_timezone_and_keep_date_part(status_effective_date)
             data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_submitted_lfng.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_submitted_lfng.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -111,7 +116,7 @@ def _map_fields(data):
         status_effective_date = data["max_date"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/applications/submissions/statuses/application_status_wrong_lfng.py
+++ b/bin/migrate-oats-data/applications/submissions/statuses/application_status_wrong_lfng.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -109,7 +114,7 @@ def _map_fields(data):
         status_effective_date = data["max_date"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_cancelled.py
+++ b/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_cancelled.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -111,7 +116,7 @@ def _map_fields(data):
         status_effective_date = data["min_date"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_in_progress.py
+++ b/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_in_progress.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -117,7 +122,7 @@ def _map_fields(data):
             status_effective_date = data["when_created"]
 
     if status_effective_date:
-        date = convert_timezone(status_effective_date, "US/Pacific")
+        date = add_timezone_and_keep_date_part(status_effective_date)
         data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_submitted_to_alc.py
+++ b/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_submitted_to_alc.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -110,7 +115,7 @@ def _map_fields(data):
     if data and data["submitted_to_alc_date"]:
         status_effective_date = data["submitted_to_alc_date"]
         if status_effective_date:
-            date = convert_timezone(status_effective_date, "US/Pacific")
+            date = add_timezone_and_keep_date_part(status_effective_date)
             data["date"] = set_time(date)
 
     return data

--- a/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_submitted_to_alc_incomplete.py
+++ b/bin/migrate-oats-data/noi/notice_of_intent_submissions/statuses/notice_of_intent_status_submitted_to_alc_incomplete.py
@@ -1,4 +1,9 @@
-from common import BATCH_UPLOAD_SIZE, setup_and_get_logger, convert_timezone, set_time
+from common import (
+    BATCH_UPLOAD_SIZE,
+    setup_and_get_logger,
+    add_timezone_and_keep_date_part,
+    set_time,
+)
 from db import inject_conn_pool
 from psycopg2.extras import RealDictCursor, execute_batch
 
@@ -110,7 +115,7 @@ def _map_fields(data):
     if data and data["completion_date"]:
         status_effective_date = data["completion_date"]
         if status_effective_date:
-            date = convert_timezone(status_effective_date, "US/Pacific")
+            date = add_timezone_and_keep_date_part(status_effective_date)
             data["date"] = set_time(date)
 
     return data


### PR DESCRIPTION
Oats stores dates the way users selected them so it is safe to assume that the date is actually in PST and not in UTC