### PR TITLE
Remove missed edit/cancel buttons, correct NOI cancel confirm text

### DIFF
--- a/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.html
+++ b/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.html
@@ -106,16 +106,6 @@
               Cancel Application
             </button>
           </div>
-          <div>
-            <button
-              [routerLink]="'/application/' + application.fileNumber + '/edit'"
-              *ngIf="application.canEdit"
-              mat-flat-button
-              color="primary"
-            >
-              Edit Application
-            </button>
-          </div>
         </div>
       </mat-tab>
       <mat-tab label="Local/First Nation Gov Review">

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/view-notice-of-intent-submission.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/view-notice-of-intent-submission.component.html
@@ -46,9 +46,6 @@
             <div class="header">
               <h2>Applicant Submission</h2>
               <div class="btns-wrapper">
-                <button *ngIf="submission.canEdit" mat-stroked-button color="warn" (click)="onCancel(submission.uuid)">
-                  Cancel NOI
-                </button>
                 <button mat-flat-button color="accent" (click)="onDownloadSubmissionPdf(submission.fileNumber)">
                   Download PDF
                 </button>
@@ -64,23 +61,6 @@
               ></app-noi-details>
             </div>
           </section>
-        </div>
-        <div class="buttons" *ngIf="submission">
-          <div>
-            <button *ngIf="submission.canEdit" mat-stroked-button color="warn" (click)="onCancel(submission.uuid)">
-              Cancel NOI
-            </button>
-          </div>
-          <div>
-            <button
-              [routerLink]="'/notice-of-intent/' + submission.fileNumber + '/edit'"
-              *ngIf="submission.canEdit"
-              mat-flat-button
-              color="primary"
-            >
-              Edit NOI
-            </button>
-          </div>
         </div>
       </mat-tab>
       <mat-tab label="ALC Review and Decision">

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/view-notice-of-intent-submission.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/view-notice-of-intent-submission.component.ts
@@ -67,7 +67,7 @@ export class ViewNoticeOfIntentSubmissionComponent implements OnInit, OnDestroy 
 
   async onCancel(uuid: string) {
     const dialog = this.confirmationDialogService.openDialog({
-      body: 'Are you sure you want to cancel the application? A cancelled application cannot be edited or submitted to the ALC. This cannot be undone.',
+      body: 'Are you sure you want to cancel the notice of intent? A cancelled application cannot be edited or submitted to the ALC. This cannot be undone.',
       confirmAction: 'Confirm',
       cancelAction: 'Return',
     });


### PR DESCRIPTION
This is MR is fixing missed reqs caught by QA:
- Removed missed edit/cancel buttons that were missed
- Correct NOI cancel confirmation from 'application' to 'notice of intent' 