### PR TITLE
Improvements for notifications buttons, uploader, review, and submit confirmation

### DIFF
--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.html
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.html
@@ -306,8 +306,9 @@
       <div>
         <mat-radio-group
           color="primary"
-          [value]="selectedOwner?.uuid" required
-          [ngClass]="{ 'error': ownerInput.errors && ownerInput.errors['required'] }"
+          [value]="selectedOwner?.uuid"
+          required
+          [ngClass]="{ error: ownerInput.errors && ownerInput.errors['required'] }"
           formControlName="selectedOwnerVal"
         >
           <mat-radio-button
@@ -321,7 +322,7 @@
           </mat-radio-button>
         </mat-radio-group>
 
-        <div class="warning-banner" *ngIf="selectedOwner">
+        <div id="owner-info" class="warning-banner" *ngIf="selectedOwner">
           <div class="owner-details">
             <div class="row">
               <div class="key"><strong>First Name:</strong></div>
@@ -331,8 +332,8 @@
               <div class="key"><strong>Last Name:</strong></div>
               <div class="value">{{ selectedOwner.lastName }}</div>
             </div>
-            <div class="row"> 
-              <div class="key"><strong>Ministry or Department:</strong> </div>
+            <div class="row">
+              <div class="key"><strong>Ministry or Department:</strong></div>
               <div class="value">{{ selectedOwner.organizationName }}</div>
             </div>
             <div class="row">

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.html
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.html
@@ -315,14 +315,14 @@
             *ngFor="let owner of filteredOwners"
             [value]="owner.uuid"
             class="radio-option"
-            (click)="onCrownOwnerSelected($event, owner, owner.isSelected)"
+            (click)="onCrownOwnerSelected(owner, owner.isSelected)"
             required
           >
             {{ owner.firstName + ' ' + owner.lastName }}
           </mat-radio-button>
         </mat-radio-group>
 
-        <div id="owner-info" class="warning-banner" *ngIf="selectedOwner">
+        <div #ownerInfo class="warning-banner" *ngIf="selectedOwner">
           <div class="owner-details">
             <div class="row">
               <div class="key"><strong>First Name:</strong></div>

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
@@ -21,6 +21,7 @@ import { OwnerDialogComponent } from '../../../../../shared/owner-dialogs/owner-
 import { formatBooleanToString } from '../../../../../shared/utils/boolean-helper';
 import { RemoveFileConfirmationDialogComponent } from '../../../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
+import { scrollToElement } from '../../../../../shared/utils/scroll-helper';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -99,7 +100,7 @@ export class ParcelEntryComponent implements OnInit {
     purchaseDate: this.purchaseDate,
     crownLandOwnerType: this.crownLandOwnerType,
     isConfirmedByApplicant: this.isConfirmedByApplicant,
-    searchBy: this.searchBy
+    searchBy: this.searchBy,
   });
   pidPinPlaceholder = '';
   selectedOwner?: ApplicationOwnerDto = undefined;
@@ -354,6 +355,10 @@ export class ParcelEntryComponent implements OnInit {
     this.selectedOwner = owner;
     const selectedOwners = [owner];
     this.updateParcelOwners(selectedOwners);
+
+    setTimeout(() => {
+      scrollToElement({ id: 'owner-info', center: false });
+    });
   }
 
   onEditCrownOwner(owner: ApplicationOwnerDto) {

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
 import { MatDialog } from '@angular/material/dialog';
@@ -21,7 +21,6 @@ import { OwnerDialogComponent } from '../../../../../shared/owner-dialogs/owner-
 import { formatBooleanToString } from '../../../../../shared/utils/boolean-helper';
 import { RemoveFileConfirmationDialogComponent } from '../../../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
-import { scrollToElement } from '../../../../../shared/utils/scroll-helper';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -69,6 +68,8 @@ export class ParcelEntryComponent implements OnInit {
   @Output() private onSaveProgress = new EventEmitter<void>();
   @Output() onOwnersUpdated = new EventEmitter<void>();
   @Output() onOwnersDeleted = new EventEmitter<void>();
+
+  @ViewChild('ownerInfo') ownerInfo!: ElementRef<HTMLElement>;
 
   owners: ApplicationOwnerDto[] = [];
   filteredOwners: (ApplicationOwnerDto & { isSelected: boolean })[] = [];
@@ -351,13 +352,13 @@ export class ParcelEntryComponent implements OnInit {
     }
   }
 
-  async onCrownOwnerSelected(event: Event, owner: ApplicationOwnerDto, isSelected: boolean) {
+  async onCrownOwnerSelected(owner: ApplicationOwnerDto, isSelected: boolean) {
     this.selectedOwner = owner;
     const selectedOwners = [owner];
     this.updateParcelOwners(selectedOwners);
 
     setTimeout(() => {
-      scrollToElement({ id: 'owner-info', center: false });
+      this.ownerInfo.nativeElement.scrollIntoView({ behavior: 'smooth' });
     });
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.html
@@ -2,7 +2,8 @@
   <div class="type">
     <mat-label for="parcelType">Select parcel type:</mat-label>
     <div class="warning">
-      Fee simple includes privately-owned parcels and parcels within First Nation treaty lands.  Crown land includes crown leases.
+      Fee simple includes privately-owned parcels and parcels within First Nation treaty lands. Crown land includes
+      crown leases.
     </div>
     <mat-button-toggle-group
       class="input"
@@ -152,7 +153,13 @@
       <mat-label for="isFarm">Farm Classification</mat-label>
       <div class="subtext">
         As determined by
-        <a class="subtext" href="https://info.bcassessment.ca/Services-products/property-classes-and-exemptions/farm-land-assessment/about-farm-land-assessment" target="_blank" rel="noreferrer">BC Assessment</a>
+        <a
+          class="subtext"
+          href="https://info.bcassessment.ca/Services-products/property-classes-and-exemptions/farm-land-assessment/about-farm-land-assessment"
+          target="_blank"
+          rel="noreferrer"
+          >BC Assessment</a
+        >
       </div>
       <mat-button-toggle-group class="input" id="isFarm" formControlName="isFarm">
         <mat-button-toggle
@@ -258,14 +265,8 @@
           [formControl]="ownerInput"
         />
         <mat-autocomplete #auto="matAutocomplete">
-          <mat-option
-            (click)="onSelectOwner($event, option, option.isSelected)"
-            *ngFor="let option of filteredOwners"
-          >
-            <mat-checkbox
-              [checked]="option.isSelected"
-              color="primary"
-            >
+          <mat-option (click)="onSelectOwner($event, option, option.isSelected)" *ngFor="let option of filteredOwners">
+            <mat-checkbox [checked]="option.isSelected" color="primary">
               <div class="owner-option">
                 <div>{{ option.displayName }}</div>
               </div>
@@ -302,8 +303,9 @@
       <div>
         <mat-radio-group
           color="primary"
-          [value]="selectedOwner?.uuid" required
-          [ngClass]="{ 'error': ownerInput.errors && ownerInput.errors['required'] }"
+          [value]="selectedOwner?.uuid"
+          required
+          [ngClass]="{ error: ownerInput.errors && ownerInput.errors['required'] }"
           formControlName="selectedOwnerVal"
         >
           <mat-radio-button
@@ -313,38 +315,40 @@
             (click)="onCrownOwnerSelected($event, owner, owner.isSelected)"
             required
           >
-          {{ owner.firstName + ' ' + owner.lastName }}
+            {{ owner.firstName + ' ' + owner.lastName }}
           </mat-radio-button>
         </mat-radio-group>
 
-        <div class="warning-banner" *ngIf="selectedOwner">
+        <div id="owner-info" class="warning-banner" *ngIf="selectedOwner">
           <div class="owner-details">
             <div class="row">
-              <div class="key"><strong>First Name:</strong> </div>
+              <div class="key"><strong>First Name:</strong></div>
               <div class="value">{{ selectedOwner.firstName }}</div>
             </div>
             <div class="row">
-              <div class="key"><strong>Last Name:</strong> </div>
+              <div class="key"><strong>Last Name:</strong></div>
               <div class="value">{{ selectedOwner.lastName }}</div>
             </div>
-            <div class="row"> 
-              <div class="key"><strong>Ministry or Department:</strong> </div>
+            <div class="row">
+              <div class="key"><strong>Ministry or Department:</strong></div>
               <div class="value">{{ selectedOwner.organizationName }}</div>
             </div>
             <div class="row">
-              <div class="key"><strong>Phone Number:</strong> </div>
+              <div class="key"><strong>Phone Number:</strong></div>
               <div class="value">{{ selectedOwner.phoneNumber }}</div>
             </div>
             <div class="row">
-              <div class="key"><strong>Email:</strong> </div>
+              <div class="key"><strong>Email:</strong></div>
               <div class="value">{{ selectedOwner.email }}</div>
             </div>
             <div class="row">
-              <div class="key"><strong>Crown Type:</strong> </div>
+              <div class="key"><strong>Crown Type:</strong></div>
               <div class="value">{{ selectedOwner.crownLandOwnerType }}</div>
             </div>
             <div class="row">
-              <button [disabled]="_disabled" (click)="onEditCrownOwner(selectedOwner)" mat-flat-button>Edit information</button>
+              <button [disabled]="_disabled" (click)="onEditCrownOwner(selectedOwner)" mat-flat-button>
+                Edit information
+              </button>
             </div>
           </div>
         </div>

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
@@ -19,6 +19,7 @@ import { OwnerDialogComponent } from '../../../../../shared/owner-dialogs/owner-
 import { formatBooleanToString } from '../../../../../shared/utils/boolean-helper';
 import { RemoveFileConfirmationDialogComponent } from '../../../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
+import { scrollToElement } from '../../../../../shared/utils/scroll-helper';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -339,6 +340,10 @@ export class ParcelEntryComponent implements OnInit {
     this.selectedOwner = owner;
     const selectedOwners = [owner];
     this.updateParcelOwners(selectedOwners);
+
+    setTimeout(() => {
+      scrollToElement({ id: 'owner-info', center: false });
+    });
   }
 
   onEditCrownOwner(owner: NoticeOfIntentOwnerDto) {

--- a/portal-frontend/src/app/features/notifications/edit-submission/edit-submission.component.scss
+++ b/portal-frontend/src/app/features/notifications/edit-submission/edit-submission.component.scss
@@ -78,7 +78,7 @@
     display: grid;
     grid-template-columns: 1fr;
     grid-row-gap: rem(24);
-    margin-bottom: rem(32);
+    margin-bottom: rem(16);
   }
 
   .step-documents {
@@ -208,11 +208,16 @@
     }
 
     .button-container {
+      position: sticky;
+      bottom: 0;
       margin-top: rem(40);
-      margin-bottom: rem(24);
+      background-color: colors.$white;
       display: flex;
+      padding: rem(16) 0;
       flex-direction: column-reverse;
       justify-content: space-between;
+      z-index: 2;
+      box-shadow: -3px 0 colors.$white, 3px 0 colors.$white;
 
       @media screen and (min-width: $tabletBreakpoint) {
         flex-direction: row;

--- a/portal-frontend/src/app/features/notifications/edit-submission/other-attachments/other-attachments.component.html
+++ b/portal-frontend/src/app/features/notifications/edit-submission/other-attachments/other-attachments.component.html
@@ -6,7 +6,7 @@
   </p>
 </div>
 <section>
-  <span class="subheading2">Upload Optional Attachments (Max. 100 MB per attachment)</span>
+  <span class="subheading2">Upload Optional Attachments</span>
   <div class="uploader">
     <app-file-drag-drop (uploadFiles)="attachDocument($event)" [showVirusError]="showVirusError"></app-file-drag-drop>
   </div>

--- a/portal-frontend/src/app/features/notifications/edit-submission/proposal/proposal.component.html
+++ b/portal-frontend/src/app/features/notifications/edit-submission/proposal/proposal.component.html
@@ -1,6 +1,6 @@
 <div class="step-description">
   <h2>Purpose of SRW</h2>
-  <p>* All fields are required unless stated optional or disabled.</p>
+  <p>*All fields are required unless stated optional or disabled.</p>
 </div>
 <app-warning-banner>
   The information entered below will be reflected in the automatically generated notification response and must match

--- a/portal-frontend/src/app/features/notifications/edit-submission/review-and-submit/submit-confirmation-dialog/submit-confirmation-dialog.component.html
+++ b/portal-frontend/src/app/features/notifications/edit-submission/review-and-submit/submit-confirmation-dialog/submit-confirmation-dialog.component.html
@@ -26,8 +26,8 @@
     </mat-checkbox>
   </div>
   <p>
-    If you have any questions about the collection or use of this information, please contact the Agricultural Land
-    Commission.
+    If you have any questions about the collection or use of this information, please
+    <a target="_blank" href="https://www.alc.gov.bc.ca/contact/">contact the Agricultural Land Commission.</a>
   </p>
   <div>
     <div class="step-controls">

--- a/portal-frontend/src/app/features/notifications/edit-submission/review-and-submit/submit-confirmation-dialog/submit-confirmation-dialog.component.html
+++ b/portal-frontend/src/app/features/notifications/edit-submission/review-and-submit/submit-confirmation-dialog/submit-confirmation-dialog.component.html
@@ -20,9 +20,9 @@
       best of my/our knowledge, true and correct.
     </mat-checkbox>
     <mat-checkbox #checkbox4 color="primary" class="checkbox">
-      I/we understand that the Agricultural Land Commission will take the steps necessary to confirm the
-      accuracy of the information and documents provided. This information will be available for review by any member of
-      the public.
+      I/we understand that the Agricultural Land Commission will take the steps necessary to confirm the accuracy of the
+      information and documents provided. This information, excluding phone numbers and emails, will be available for
+      review by any member of the public once received by the ALC.
     </mat-checkbox>
   </div>
   <p>

--- a/portal-frontend/src/app/features/notifications/edit-submission/review-and-submit/submit-confirmation-dialog/submit-confirmation-dialog.component.scss
+++ b/portal-frontend/src/app/features/notifications/edit-submission/review-and-submit/submit-confirmation-dialog/submit-confirmation-dialog.component.scss
@@ -11,9 +11,19 @@ p {
 
 .step-controls {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column-reverse;
 
-  button:not(:last-child) {
-    margin-right: rem(16) !important;
+  button {
+    width: 100%;
+    margin-top: rem(12) !important;
+  }
+
+  @media screen and (min-width: $tabletBreakpoint) {
+    flex-direction: row;
+    justify-content: space-between;
+
+    button {
+      width: unset;
+    }
   }
 }

--- a/portal-frontend/src/app/features/notifications/notification-details/parcel/parcel.component.html
+++ b/portal-frontend/src/app/features/notifications/notification-details/parcel/parcel.component.html
@@ -5,7 +5,7 @@
       <h4>Parcel {{ parcelInd + 1 }}</h4>
       <div>
         <button
-          *ngIf="showEdit"
+          *ngIf="showEdit && parcels.length > 1"
           class="mobile-hidden"
           mat-flat-button
           color="accent"
@@ -14,7 +14,7 @@
           Edit Parcel {{ parcelInd + 1 }}
         </button>
         <button
-          *ngIf="showEdit"
+          *ngIf="showEdit && parcels.length > 1"
           class="tablet-hidden"
           mat-icon-button
           color="accent"

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.html
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.html
@@ -13,7 +13,7 @@
 
   <div class="subheading2 grid-1">Total area of the SRW</div>
   <div class="grid-double">
-    {{ _notificationSubmission.totalArea }}
+    {{ _notificationSubmission.totalArea }} <ng-container *ngIf="_notificationSubmission.totalArea">ha</ng-container>
     <app-no-data [showRequired]="showErrors" *ngIf="!_notificationSubmission.totalArea"></app-no-data>
   </div>
 

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.html
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.html
@@ -13,7 +13,7 @@
 
   <div class="subheading2 grid-1">Total area of the SRW</div>
   <div class="grid-double">
-    {{ _notificationSubmission.totalArea }} <ng-container *ngIf="_notificationSubmission.totalArea">ha</ng-container>
+    {{ _notificationSubmission.totalArea }} <span *ngIf="_notificationSubmission.totalArea">ha</span>
     <app-no-data [showRequired]="showErrors" *ngIf="!_notificationSubmission.totalArea"></app-no-data>
   </div>
 


### PR DESCRIPTION
- Scroll to owner info on owner select (parcel step)
  - Missed from ALCS-1270
- Make save and step buttons sticky
- Remove redundant max file size notices
- Remove space to align with others
- Only show edit button when parcels > 1
- Show units for total area of SR
- Expand submit confirmation text
- Add contact link to submit confirmation
- Fix submit confirmation mobile button layout
