### PR TITLE
Fixes for Portal Maintenance Mode

### DIFF
--- a/portal-frontend/src/app/features/applications/alcs-edit-submission/alcs-edit-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/alcs-edit-submission/alcs-edit-submission.component.ts
@@ -50,6 +50,7 @@ export class AlcsEditSubmissionComponent implements OnInit, OnDestroy, AfterView
   expandedParcelUuid?: string;
 
   showValidationErrors = false;
+  isDeactivating = false;
 
   @ViewChild('cdkStepper') public customStepper!: CustomStepperComponent;
 
@@ -89,6 +90,8 @@ export class AlcsEditSubmissionComponent implements OnInit, OnDestroy, AfterView
     combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.paramMap])
       .pipe(takeUntil(this.$destroy))
       .subscribe(([queryParamMap, paramMap]) => {
+        this.isDeactivating = false;
+
         const fileId = paramMap.get('fileId');
         if (fileId) {
           this.loadDraftSubmission(fileId).then(() => {
@@ -143,7 +146,16 @@ export class AlcsEditSubmissionComponent implements OnInit, OnDestroy, AfterView
 
   // this gets fired whenever applicant navigates away from edit page
   async canDeactivate(): Promise<Observable<boolean>> {
-    await this.saveApplication(this.customStepper.selectedIndex);
+    if (!this.isDeactivating) {
+      this.isDeactivating = true;
+
+      try {
+        await this.saveApplication(this.customStepper.selectedIndex);
+      } catch (e) {
+        console.error('Failed to save application');
+      }
+    }
+
     return of(true);
   }
 

--- a/portal-frontend/src/app/features/applications/edit-submission/edit-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/edit-submission.component.ts
@@ -1,4 +1,3 @@
-import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -65,6 +64,7 @@ export class EditSubmissionComponent implements OnInit, OnDestroy, AfterViewInit
   expandedParcelUuid?: string;
 
   showValidationErrors = false;
+  isDeactivating = false;
 
   @ViewChild('cdkStepper') public customStepper!: CustomStepperComponent;
 
@@ -119,6 +119,8 @@ export class EditSubmissionComponent implements OnInit, OnDestroy, AfterViewInit
     combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.paramMap])
       .pipe(takeUntil(this.$destroy))
       .subscribe(([queryParamMap, paramMap]) => {
+        this.isDeactivating = false;
+
         const fileId = paramMap.get('fileId');
         if (fileId) {
           this.loadApplication(fileId).then(() => {
@@ -190,7 +192,15 @@ export class EditSubmissionComponent implements OnInit, OnDestroy, AfterViewInit
 
   // this gets fired whenever applicant navigates away from edit page
   async canDeactivate(): Promise<Observable<boolean>> {
-    await this.saveApplication(this.customStepper.selectedIndex);
+    if (!this.isDeactivating) {
+      this.isDeactivating = true;
+
+      try {
+        await this.saveApplication(this.customStepper.selectedIndex);
+      } catch (e) {
+        console.error('Failed to save application');
+      }
+    }
 
     return of(true);
   }

--- a/portal-frontend/src/app/features/applications/review-submission/review-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submission.component.ts
@@ -51,6 +51,7 @@ export class ReviewSubmissionComponent implements OnInit, OnDestroy {
   doNotSaveAppReview = false;
   showValidationErrors = false;
   isOnLastStep = false;
+  isDeactivating = false;
 
   @ViewChild('cdkStepper') public customStepper!: CustomStepperComponent;
 
@@ -74,6 +75,8 @@ export class ReviewSubmissionComponent implements OnInit, OnDestroy {
     combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.paramMap])
       .pipe(takeUntil(this.$destroy))
       .subscribe(([queryParamMap, paramMap]) => {
+        this.isDeactivating = false;
+
         const fileId = paramMap.get('fileId');
         if (fileId) {
           if (this.fileId !== fileId) {
@@ -185,11 +188,16 @@ export class ReviewSubmissionComponent implements OnInit, OnDestroy {
 
   // this gets fired whenever applicant navigates away from edit page
   async canDeactivate(): Promise<Observable<boolean>> {
-    if (this.doNotSaveAppReview) {
+    if (this.doNotSaveAppReview || this.isDeactivating) {
       return of(true);
     }
+    this.isDeactivating = true;
 
-    await this.saveApplicationReview(this.customStepper.selectedIndex);
+    try {
+      await this.saveApplicationReview(this.customStepper.selectedIndex);
+    } catch (e) {
+      console.error('Failed to save application');
+    }
 
     return of(true);
   }

--- a/portal-frontend/src/app/features/notice-of-intents/alcs-edit-submission/alcs-edit-submission.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/alcs-edit-submission/alcs-edit-submission.component.ts
@@ -43,6 +43,7 @@ export class AlcsEditSubmissionComponent implements OnInit, OnDestroy, AfterView
   expandedParcelUuid?: string;
 
   showValidationErrors = false;
+  isDeactivating = false;
 
   @ViewChild('cdkStepper') public customStepper!: CustomStepperComponent;
 
@@ -81,6 +82,8 @@ export class AlcsEditSubmissionComponent implements OnInit, OnDestroy, AfterView
     combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.paramMap])
       .pipe(takeUntil(this.$destroy))
       .subscribe(([queryParamMap, paramMap]) => {
+        this.isDeactivating = false;
+
         const fileId = paramMap.get('fileId');
         if (fileId) {
           this.loadDraftSubmission(fileId).then(() => {
@@ -127,7 +130,16 @@ export class AlcsEditSubmissionComponent implements OnInit, OnDestroy, AfterView
 
   // this gets fired whenever applicant navigates away from edit page
   async canDeactivate(): Promise<Observable<boolean>> {
-    await this.saveSubmission(this.customStepper.selectedIndex);
+    if (!this.isDeactivating) {
+      this.isDeactivating = true;
+
+      try {
+        await this.saveSubmission(this.customStepper.selectedIndex);
+      } catch (e) {
+        console.error('Failed to save application');
+      }
+    }
+
     return of(true);
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/edit-submission.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/edit-submission.component.ts
@@ -52,6 +52,7 @@ export class EditSubmissionComponent implements OnDestroy, AfterViewInit {
   steps = EditNoiSteps;
   expandedParcelUuid?: string;
   showValidationErrors = false;
+  isDeactivating = false;
 
   @ViewChild('cdkStepper') public customStepper!: CustomStepperComponent;
 
@@ -85,6 +86,8 @@ export class EditSubmissionComponent implements OnDestroy, AfterViewInit {
     combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.paramMap])
       .pipe(takeUntil(this.$destroy))
       .subscribe(([queryParamMap, paramMap]) => {
+        this.isDeactivating = false;
+
         const fileId = paramMap.get('fileId');
         if (fileId) {
           this.loadSubmission(fileId).then(() => {
@@ -121,7 +124,15 @@ export class EditSubmissionComponent implements OnDestroy, AfterViewInit {
 
   // this gets fired whenever applicant navigates away from edit page
   async canDeactivate(): Promise<Observable<boolean>> {
-    await this.saveSubmission(this.customStepper.selectedIndex);
+    if (!this.isDeactivating) {
+      this.isDeactivating = true;
+
+      try {
+        await this.saveSubmission(this.customStepper.selectedIndex);
+      } catch (e) {
+        console.error('Failed to save application');
+      }
+    }
 
     return of(true);
   }

--- a/portal-frontend/src/app/features/notifications/edit-submission/edit-submission.component.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/edit-submission.component.ts
@@ -47,6 +47,7 @@ export class EditSubmissionComponent implements OnDestroy, AfterViewInit {
   steps = EditNotificationSteps;
   expandedParcelUuid?: string;
   showValidationErrors = false;
+  isDeactivating = false;
 
   @ViewChild('cdkStepper') public customStepper!: CustomStepperComponent;
   @ViewChild(ParcelDetailsComponent) parcelDetailsComponent!: ParcelDetailsComponent;
@@ -75,6 +76,8 @@ export class EditSubmissionComponent implements OnDestroy, AfterViewInit {
     combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.paramMap])
       .pipe(takeUntil(this.$destroy))
       .subscribe(([queryParamMap, paramMap]) => {
+        this.isDeactivating = false;
+
         const fileId = paramMap.get('fileId');
         if (fileId) {
           this.loadSubmission(fileId).then(() => {
@@ -111,7 +114,15 @@ export class EditSubmissionComponent implements OnDestroy, AfterViewInit {
 
   // this gets fired whenever applicant navigates away from edit page
   async canDeactivate(): Promise<Observable<boolean>> {
-    await this.saveSubmission(this.customStepper.selectedIndex);
+    if (!this.isDeactivating) {
+      this.isDeactivating = true;
+
+      try {
+        await this.saveSubmission(this.customStepper.selectedIndex);
+      } catch (e) {
+        console.error('Failed to save application');
+      }
+    }
 
     return of(true);
   }

--- a/portal-frontend/src/app/services/authentication/alcs-auth.guard.ts
+++ b/portal-frontend/src/app/services/authentication/alcs-auth.guard.ts
@@ -8,14 +8,14 @@ import { AuthenticationService } from './authentication.service';
 export class AlcsAuthGuard implements CanActivate {
   constructor(private authenticationService: AuthenticationService, private router: Router) {}
 
-  async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
+  async canActivate(): Promise<boolean> {
     const hasToken = await this.authenticationService.getToken(false);
     if (hasToken) {
       return true;
     }
 
     const res = await this.authenticationService.getLoginUrl();
-    if (res) {
+    if (res && res.loginUrl) {
       //Set desired return URL to current page
       const targetUrl = window.location.href;
       localStorage.setItem('targetUrl', targetUrl);

--- a/portal-frontend/src/app/services/authentication/auth.guard.spec.ts
+++ b/portal-frontend/src/app/services/authentication/auth.guard.spec.ts
@@ -41,13 +41,13 @@ describe('AuthGuard', () => {
   });
 
   it('should allow activation when a token is present', async () => {
-    const canActivate = await guard.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot);
+    const canActivate = await guard.canActivate();
     expect(canActivate).toBeTruthy();
   });
 
   it('should redirect to login when there is no token', async () => {
     mockAuthService.getToken.mockResolvedValue(undefined);
-    const canActivate = await guard.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot);
+    const canActivate = await guard.canActivate();
     expect(canActivate).toBeFalsy();
     expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/login');
   });

--- a/portal-frontend/src/app/services/authentication/auth.guard.ts
+++ b/portal-frontend/src/app/services/authentication/auth.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { CanActivate, Router } from '@angular/router';
 import { AuthenticationService } from './authentication.service';
 
 @Injectable({
@@ -8,7 +8,7 @@ import { AuthenticationService } from './authentication.service';
 export class AuthGuard implements CanActivate {
   constructor(private authenticationService: AuthenticationService, private router: Router) {}
 
-  async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
+  async canActivate(): Promise<boolean> {
     const hasToken = await this.authenticationService.getToken();
     if (hasToken) {
       return true;

--- a/portal-frontend/src/app/services/authentication/authentication.service.ts
+++ b/portal-frontend/src/app/services/authentication/authentication.service.ts
@@ -60,7 +60,7 @@ export class AuthenticationService {
   }
 
   async getLoginUrl() {
-    return firstValueFrom(this.http.get<{ loginUrl: string }>(`${environment.authUrl}/authorize/login`));
+    return firstValueFrom(this.http.get<{ loginUrl: string }>(`${environment.apiUrl}/authorize/login`));
   }
 
   async getToken(redirect = true) {
@@ -116,7 +116,7 @@ export class AuthenticationService {
   private async isTokenValid(token: string) {
     try {
       await firstValueFrom(
-        this.http.get(`${environment.authUrl}/portal/token`, {
+        this.http.get(`${environment.apiUrl}/token`, {
           responseType: 'text',
           headers: {
             Authorization: `Bearer ${token}`,
@@ -137,7 +137,7 @@ export class AuthenticationService {
       this.http.get<{
         refresh_token: string;
         token: string;
-      }>(`${environment.authUrl}/authorize/refresh?r=${refreshToken}`)
+      }>(`${environment.apiUrl}/authorize/refresh?r=${refreshToken}`)
     );
   }
 

--- a/portal-frontend/src/app/shared/guard/can-deactivate.guard.ts
+++ b/portal-frontend/src/app/shared/guard/can-deactivate.guard.ts
@@ -12,11 +12,7 @@ export interface CanComponentDeactivate {
   providedIn: 'root',
 })
 export class CanDeactivateGuard implements CanDeactivate<CanComponentDeactivate> {
-  canDeactivate(
-    component: CanComponentDeactivate,
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ): CanDeactivateType {
+  canDeactivate(component: CanComponentDeactivate): CanDeactivateType {
     return component.canDeactivate();
   }
 }

--- a/services/apps/alcs/src/common/authorization/authorization.controller.ts
+++ b/services/apps/alcs/src/common/authorization/authorization.controller.ts
@@ -15,7 +15,8 @@ import { KEYCLOAK_INSTANCE, Public } from 'nest-keycloak-connect';
 import { v4 } from 'uuid';
 import { AuthorizationService } from './authorization.service';
 
-@Controller('/authorize')
+//One for ALCS, One for Portal that triggers maintenance guard
+@Controller(['/authorize', '/portal/authorize'])
 export class AuthorizationController {
   private logger = new Logger(AuthorizationController.name);
 


### PR DESCRIPTION
* Add new route for auth controller so that it triggers maintenance guard for portal
* Add logic to prevent deactivate from infinite looping when navigating to the maintenance page. Save fails triggering a redirect which triggers canDeactivate which calls save again.