### PR TITLE
Prevent green success toast from firing when file is too large

### DIFF
--- a/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
@@ -37,8 +37,9 @@ export abstract class FilesStepComponent extends StepComponent {
       await this.save();
       const mappedFiles = file.file;
 
+      let res;
       try {
-        await this.applicationDocumentService.attachExternalFile(this.fileId, mappedFiles, documentType);
+        res = await this.applicationDocumentService.attachExternalFile(this.fileId, mappedFiles, documentType);
       } catch (err) {
         this.toastService.showErrorToast('Document upload failed');
         if (err instanceof HttpErrorResponse && err.status === 403) {
@@ -46,9 +47,11 @@ export abstract class FilesStepComponent extends StepComponent {
         }
       }
 
-      const documents = await this.applicationDocumentService.getByFileId(this.fileId);
-      if (documents) {
-        this.$applicationDocuments.next(documents);
+      if (res) {
+        const documents = await this.applicationDocumentService.getByFileId(this.fileId);
+        if (documents) {
+          this.$applicationDocuments.next(documents);
+        }
       }
     }
     return true;

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
@@ -37,8 +37,9 @@ export abstract class FilesStepComponent extends StepComponent {
       await this.save();
       const mappedFiles = file.file;
 
+      let res;
       try {
-        await this.noticeOfIntentDocumentService.attachExternalFile(this.fileId, mappedFiles, documentType);
+        res = await this.noticeOfIntentDocumentService.attachExternalFile(this.fileId, mappedFiles, documentType);
       } catch (err) {
         this.toastService.showErrorToast('Document upload failed');
         if (err instanceof HttpErrorResponse && err.status === 403) {
@@ -46,9 +47,11 @@ export abstract class FilesStepComponent extends StepComponent {
         }
       }
 
-      const documents = await this.noticeOfIntentDocumentService.getByFileId(this.fileId);
-      if (documents) {
-        this.$noiDocuments.next(documents);
+      if (res) {
+        const documents = await this.noticeOfIntentDocumentService.getByFileId(this.fileId);
+        if (documents) {
+          this.$noiDocuments.next(documents);
+        }
       }
     }
     return true;

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/view-notice-of-intent-submission.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/view-notice-of-intent-submission.component.html
@@ -45,10 +45,10 @@
           <section>
             <div class="header">
               <h2>Applicant Submission</h2>
-              <button *ngIf="submission.canEdit" mat-stroked-button color="warn" (click)="onCancel(submission.uuid)">
-                Cancel NOI
-              </button>
               <div class="btns-wrapper">
+                <button *ngIf="submission.canEdit" mat-stroked-button color="warn" (click)="onCancel(submission.uuid)">
+                  Cancel NOI
+                </button>
                 <button mat-flat-button color="accent" (click)="onDownloadSubmissionPdf(submission.fileNumber)">
                   Download PDF
                 </button>

--- a/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
@@ -36,17 +36,22 @@ export abstract class FilesStepComponent extends StepComponent {
     if (this.fileId) {
       await this.save();
       const mappedFiles = file.file;
+
+      let res;
       try {
-        await this.notificationDocumentService.attachExternalFile(this.fileId, mappedFiles, documentType);
+        res = await this.notificationDocumentService.attachExternalFile(this.fileId, mappedFiles, documentType);
       } catch (err) {
         this.toastService.showErrorToast('Document upload failed');
         if (err instanceof HttpErrorResponse && err.status === 403) {
           return false;
         }
       }
-      const documents = await this.notificationDocumentService.getByFileId(this.fileId);
-      if (documents) {
-        this.$notificationDocuments.next(documents);
+
+      if (res) {
+        const documents = await this.notificationDocumentService.getByFileId(this.fileId);
+        if (documents) {
+          this.$notificationDocuments.next(documents);
+        }
       }
     }
     return true;

--- a/portal-frontend/src/app/services/application-document/application-document.service.ts
+++ b/portal-frontend/src/app/services/application-document/application-document.service.ts
@@ -35,7 +35,9 @@ export class ApplicationDocumentService {
         source,
         `${this.serviceUrl}/application/${fileNumber}/attachExternal`
       );
-      this.toastService.showSuccessToast('Document uploaded');
+      if (res) {
+        this.toastService.showSuccessToast('Document uploaded');
+      }
       return res;
     } catch (e) {
       if (e instanceof HttpErrorResponse && e.status === 403) {

--- a/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
@@ -35,7 +35,9 @@ export class NoticeOfIntentDocumentService {
         source,
         `${this.serviceUrl}/notice-of-intent/${fileNumber}/attachExternal`
       );
-      this.toastService.showSuccessToast('Document uploaded');
+      if (res) {
+        this.toastService.showSuccessToast('Document uploaded');
+      }
       return res;
     } catch (e) {
       if (e instanceof HttpErrorResponse && e.status === 403) {

--- a/portal-frontend/src/app/services/notification-document/notification-document.service.ts
+++ b/portal-frontend/src/app/services/notification-document/notification-document.service.ts
@@ -35,7 +35,9 @@ export class NotificationDocumentService {
         source,
         `${this.serviceUrl}/notification/${fileNumber}/attachExternal`
       );
-      this.toastService.showSuccessToast('Document uploaded');
+      if (res) {
+        this.toastService.showSuccessToast('Document uploaded');
+      }
       return res;
     } catch (e) {
       if (e instanceof HttpErrorResponse && e.status === 403) {


### PR DESCRIPTION
* Green toast was replacing the yellow warning toast
* Move Cancel NOI into the button container so it looks correct