### PR TITLE
update obfuscation, update batch insert, update readme

### DIFF
--- a/bin/migrate-oats-data/applications/sql/insert-batch-application.sql
+++ b/bin/migrate-oats-data/applications/sql/insert-batch-application.sql
@@ -163,7 +163,7 @@ FROM
     LEFT JOIN application_type_lookup AS atl ON oa.alr_application_id = atl.application_id
 	LEFT JOIN alcs.application_region ar ON panel_lookup.panel_region = ar."label"
     LEFT JOIN alcs_gov ON oa.alr_application_id = alcs_gov.application_id
-WHERE atl.code <> 'SRW' -- filter out SRW type as it is a "notification" type
+WHERE atl.code <> 'SRW' AND oa.application_class_code IN ('LOA', 'BLK', 'SCH', 'NAN') -- filter out SRW type as it is a "notification" type
  
 
 

--- a/bin/migrate-oats-data/noi/sql/insert_noi.sql
+++ b/bin/migrate-oats-data/noi/sql/insert_noi.sql
@@ -117,7 +117,14 @@ application_type_lookup AS (
         LEFT JOIN oats.alcs_etl_application_exclude aee ON oaac.alr_appl_component_id = aee.component_id
     WHERE aee.component_id IS NULL
 )
-SELECT ng.noi_application_id::text AS file_number,
+SELECT 
+    ng.noi_application_id::text AS file_number,
+    CASE
+        WHEN atl.code = 'SCH' THEN 'PFRS'
+        WHEN atl.code = 'EXT' THEN 'ROSO'
+        WHEN atl.code = 'FILL' THEN 'POFO'
+        ELSE 'POFO' -- POFO if value is null
+    END AS type_code,
     CASE
         WHEN noi_lookup.orgs IS NOT NULL THEN noi_lookup.orgs
         WHEN noi_lookup.persons IS NOT NULL THEN noi_lookup.persons
@@ -128,13 +135,7 @@ SELECT ng.noi_application_id::text AS file_number,
         WHEN alcs_gov.gov_uuid IS NOT NULL THEN alcs_gov.gov_uuid
         ELSE '001cfdad-bc6e-4d25-9294-1550603da980' --Peace River if unable to find uuid
     END AS local_government_uuid,
-    'oats_etl' AS audit_created_by,
-    CASE
-        WHEN atl.code = 'SCH' THEN 'PFRS'
-        WHEN atl.code = 'EXT' THEN 'ROSO'
-        WHEN atl.code = 'FILL' THEN 'POFO'
-        ELSE 'POFO' -- POFO if value is null
-    END AS type_code
+    'oats_etl' AS audit_created_by
 FROM noi_grouped AS ng
     LEFT JOIN noi_lookup ON ng.noi_application_id = noi_lookup.application_id
     LEFT JOIN panel_lookup ON ng.noi_application_id = panel_lookup.application_id

--- a/bin/migrate-oats-data/prod_db_obfuscation/oats/obfuscate.py
+++ b/bin/migrate-oats-data/prod_db_obfuscation/oats/obfuscate.py
@@ -21,7 +21,8 @@ def process_oats_data():
     _update_term_columns()
     _update_with_random_oats_issues()
     _update_with_random_oats_documents()
-    _update_with_random_oats_organization()
+    # organization name is not 'personally identifiable information' so its not protected under Personal Information Protection Act
+    # _update_with_random_oats_organization()
     _update_with_random_oats_planning_review()
     _update_comment_columns()
     _update_with_random_oats_alr_application()


### PR DESCRIPTION
- do not obfuscate the organization name in OATS
- update readme file with backup and restore instructions for Postgres DB
- update batch insert script to correctly handle duplications of applications and NOIs if they are caused by local government duplications
- add filter to application batch insert