### PR TITLE
Include submissions associated with soft deleted types in ALCS frontend (ALCS-1459)

### DIFF
--- a/services/apps/alcs/src/alcs/search/application/application-advanced-search.service.spec.ts
+++ b/services/apps/alcs/src/alcs/search/application/application-advanced-search.service.spec.ts
@@ -53,6 +53,7 @@ describe('ApplicationAdvancedSearchService', () => {
       andWhere: jest.fn().mockReturnThis(),
       setParameters: jest.fn().mockReturnThis(),
       leftJoin: jest.fn().mockReturnThis(),
+      withDeleted: jest.fn().mockReturnThis(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/services/apps/alcs/src/alcs/search/application/application-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/application/application-advanced-search.service.ts
@@ -80,6 +80,10 @@ export class ApplicationAdvancedSearchService {
 
   private compileApplicationGroupBySearchQuery(query) {
     query = query
+      // FIXME: This is a quick fix for the search performance issues. It temporarily allows
+      //        submissions with deleted submission types to be shown. For now, there are no
+      //        deleted submission types, so this should be fine, but should be fixed soon.
+      .withDeleted()
       .innerJoinAndMapOne(
         'appSearch.applicationType',
         'appSearch.applicationType',

--- a/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.spec.ts
+++ b/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.spec.ts
@@ -52,6 +52,7 @@ describe('NoticeOfIntentService', () => {
       andWhere: jest.fn().mockReturnThis(),
       setParameters: jest.fn().mockReturnThis(),
       leftJoin: jest.fn().mockReturnThis(),
+      withDeleted: jest.fn().mockReturnThis(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
@@ -75,6 +75,10 @@ export class NoticeOfIntentAdvancedSearchService {
     query: SelectQueryBuilder<NoticeOfIntentSubmissionSearchView>,
   ) {
     query = query
+      // FIXME: This is a quick fix for the search performance issues. It temporarily allows
+      //        submissions with deleted submission types to be shown. For now, there are no
+      //        deleted submission types, so this should be fine, but should be fixed soon.
+      .withDeleted()
       .innerJoinAndMapOne(
         'noiSearch.noticeOfIntentType',
         'noiSearch.noticeOfIntentType',

--- a/services/apps/alcs/src/alcs/search/notification/notification-advanced-search.service.spec.ts
+++ b/services/apps/alcs/src/alcs/search/notification/notification-advanced-search.service.spec.ts
@@ -52,6 +52,7 @@ describe('NotificationAdvancedSearchService', () => {
       andWhere: jest.fn().mockReturnThis(),
       setParameters: jest.fn().mockReturnThis(),
       leftJoin: jest.fn().mockReturnThis(),
+      withDeleted: jest.fn().mockReturnThis(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/services/apps/alcs/src/alcs/search/notification/notification-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/notification/notification-advanced-search.service.ts
@@ -74,6 +74,10 @@ export class NotificationAdvancedSearchService {
     query: SelectQueryBuilder<NotificationSubmissionSearchView>,
   ) {
     query = query
+      // FIXME: This is a quick fix for the search performance issues. It temporarily allows
+      //        submissions with deleted submission types to be shown. For now, there are no
+      //        deleted submission types, so this should be fine, but should be fixed soon.
+      .withDeleted()
       .innerJoinAndMapOne(
         'notificationSearch.notificationType',
         'notificationSearch.notificationType',


### PR DESCRIPTION
- Include submissions associated with soft-deleted app/NOI/notification types to be included in ALCS frontend search results
- Update query mocks to include `withDeleted` method