### PR TITLE
Hardcode tab order for easier referencing

### DIFF
--- a/portal-frontend/src/app/features/home/home.module.ts
+++ b/portal-frontend/src/app/features/home/home.module.ts
@@ -1,15 +1,12 @@
 import { NgModule } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
 import { MatOptionModule } from '@angular/material/core';
 import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatSelectModule } from '@angular/material/select';
-import { MatSortModule } from '@angular/material/sort';
 import { RouterModule, Routes } from '@angular/router';
 import { SharedModule } from '../../shared/shared.module';
 import { CreateSubmissionDialogComponent } from '../create-submission-dialog/create-submission-dialog.component';
-import { InboxTableComponent } from './inbox/inbox-table/inbox-table.component';
 import { HomeComponent } from './home.component';
 import { InboxListComponent } from './inbox/inbox-list/inbox-list.component';
+import { InboxTableComponent } from './inbox/inbox-table/inbox-table.component';
 import { InboxComponent } from './inbox/inbox.component';
 
 const routes: Routes = [

--- a/portal-frontend/src/app/features/home/inbox/inbox.component.html
+++ b/portal-frontend/src/app/features/home/inbox/inbox.component.html
@@ -123,7 +123,7 @@
         ></app-inbox-table>
       </mat-tab>
 
-      <mat-tab label="nois">
+      <mat-tab label="notices-of-intent">
         <ng-template mat-tab-label> Notice of Intent: {{ noticeOfIntentTotal }} </ng-template>
         <app-inbox-list
           *ngIf="isMobile"

--- a/portal-frontend/src/app/features/home/inbox/inbox.component.spec.ts
+++ b/portal-frontend/src/app/features/home/inbox/inbox.component.spec.ts
@@ -1,8 +1,9 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { ActivatedRoute, ParamMap } from '@angular/router';
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { UserDto } from '../../../services/authentication/authentication.dto';
 import { AuthenticationService } from '../../../services/authentication/authentication.service';
 import { CodeService } from '../../../services/code/code.service';
@@ -19,12 +20,16 @@ describe('InboxComponent', () => {
   let mockAuthService: DeepMocked<AuthenticationService>;
   let mockCodeService: DeepMocked<CodeService>;
 
+  let activatedRoute: DeepMocked<ActivatedRoute>;
+
   beforeEach(async () => {
     mockInboxService = createMock();
     mockAuthService = createMock();
     mockCodeService = createMock();
+    activatedRoute = createMock();
 
     mockAuthService.$currentProfile = new BehaviorSubject<UserDto | undefined>(undefined);
+    Object.assign(activatedRoute, { paramMap: new Observable<ParamMap>() });
 
     await TestBed.configureTestingModule({
       imports: [MatAutocompleteModule],
@@ -37,6 +42,10 @@ describe('InboxComponent', () => {
         {
           provide: CodeService,
           useValue: mockCodeService,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRoute,
         },
         {
           provide: StatusService,

--- a/portal-frontend/src/app/features/home/inbox/inbox.component.ts
+++ b/portal-frontend/src/app/features/home/inbox/inbox.component.ts
@@ -17,7 +17,7 @@ import { ToastService } from '../../../services/toast/toast.service';
 import { MOBILE_BREAKPOINT } from '../../../shared/utils/breakpoints';
 import { FileTypeFilterDropDownComponent } from '../../public/search/file-type-filter-drop-down/file-type-filter-drop-down.component';
 import { TableChange } from '../../public/search/search.interface';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 export interface InboxResultDto extends BaseInboxResultDto {
   statusType: ApplicationStatusDto;
@@ -28,6 +28,12 @@ const CLASS_TO_URL_MAP: Record<string, string> = {
   APP: 'application',
   NOI: 'notice-of-intent',
   NOTI: 'notification',
+};
+
+const TAB_ORDER: Record<string, number> = {
+  applications: 0,
+  'notices-of-intent': 1,
+  notifications: 2,
 };
 
 @Component({
@@ -112,7 +118,7 @@ export class InboxComponent implements OnInit, OnDestroy {
         this.pageIndex = 0;
       }
       this.populateTable();
-      this.tabIndex = this.tabIndexFromName(this.currentTabName);
+      this.tabIndex = TAB_ORDER[this.currentTabName];
     }
 
     this.isMobile = isMobile;
@@ -123,7 +129,8 @@ export class InboxComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private titleService: Title,
     private authenticationService: AuthenticationService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {
     this.titleService.setTitle('ALC Portal | Inbox');
   }
@@ -133,6 +140,14 @@ export class InboxComponent implements OnInit, OnDestroy {
     if (this.isMobile) {
       this.itemsPerPage = 5;
     }
+
+    this.route.paramMap.pipe(takeUntil(this.$destroy)).subscribe((paramMap) => {
+      const selectedTab = paramMap.get('submissionType');
+      if (selectedTab) {
+        this.currentTabName = selectedTab;
+        this.tabIndex = TAB_ORDER[this.currentTabName];
+      }
+    });
 
     this.setup();
 
@@ -150,34 +165,9 @@ export class InboxComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['currentTabName']) {
-      this.currentTabName = changes['currentTabName'].currentValue;
-      this.tabIndex = this.tabIndexFromName(this.currentTabName);
-    }
-  }
-
-  tabIndexFromName(tabName: string) {
-    // Default to 'application' tab
-    if (!this.tabGroup) {
-      return 0;
-    }
-
-    return this.tabGroup._tabs
-      .map((a) => a.textLabel)
-      .reduce((iPrev, b, i) => {
-        if (b == tabName) {
-          return i;
-        }
-        return iPrev;
-      }, 0);
-  }
-
   private async setup() {
     await this.loadStatuses();
     await this.populateTable();
-
-    this.tabIndex = this.tabIndexFromName(this.currentTabName);
   }
 
   ngOnDestroy(): void {
@@ -216,7 +206,7 @@ export class InboxComponent implements OnInit, OnDestroy {
   async onClear() {
     this.searchForm.reset();
     await this.populateTable();
-    this.tabIndex = this.tabIndexFromName(this.currentTabName);
+    this.tabIndex = TAB_ORDER[this.currentTabName];
     if (this.fileTypeFilterDropDownComponent) {
       this.fileTypeFilterDropDownComponent.reset();
     }


### PR DESCRIPTION
* Requiring the tabs to be rendered to get their order forces the page to default to application since they are not rendered on initial load, meaning it was always going to applications