### PR TITLE
Disable organization name obfuscation

### DIFF
--- a/bin/migrate-oats-data/prod_db_obfuscation/alcs/application/application.py
+++ b/bin/migrate-oats-data/prod_db_obfuscation/alcs/application/application.py
@@ -107,7 +107,6 @@ def _update_application_owner(conn=None):
                             SET 
                             {get_update_column_query("first_name")},
                             {get_update_column_query("last_name")},
-                            {get_update_column_query("organization_name")},
                             {get_update_column_query("phone_number")},
                             {get_update_column_query("email")}
                             WHERE uuid = %s;
@@ -117,7 +116,6 @@ def _update_application_owner(conn=None):
                     (
                         fake.first_name(),
                         fake.last_name(),
-                        fake.company(),
                         fake.phone_number(),
                         "11@11",
                         r_id[0],

--- a/bin/migrate-oats-data/prod_db_obfuscation/alcs/covenant/covenant.py
+++ b/bin/migrate-oats-data/prod_db_obfuscation/alcs/covenant/covenant.py
@@ -27,7 +27,6 @@ def _update_covenant_transferee(conn=None):
                             SET 
                                 {get_update_column_query("first_name")},
                                 {get_update_column_query("last_name")},
-                                {get_update_column_query("organization_name")},
                                 {get_update_column_query("phone_number")},
                                 {get_update_column_query("email")}
                             WHERE uuid = %s;
@@ -37,7 +36,6 @@ def _update_covenant_transferee(conn=None):
                     (
                         fake.first_name(),
                         fake.last_name(),
-                        fake.company(),
                         fake.phone_number(),
                         "11@11",
                         r_id[0],

--- a/bin/migrate-oats-data/prod_db_obfuscation/alcs/notice_of_intent/notice_of_intent.py
+++ b/bin/migrate-oats-data/prod_db_obfuscation/alcs/notice_of_intent/notice_of_intent.py
@@ -141,7 +141,6 @@ def _update_notice_of_intent_owner(conn=None):
                             SET 
                             {get_update_column_query("first_name")},
                             {get_update_column_query("last_name")},
-                            {get_update_column_query("organization_name")},
                             {get_update_column_query("phone_number")},
                             {get_update_column_query("email")}
                             WHERE uuid = %s;
@@ -151,7 +150,6 @@ def _update_notice_of_intent_owner(conn=None):
                     (
                         fake.first_name(),
                         fake.last_name(),
-                        fake.company(),
                         fake.phone_number(),
                         "11@11",
                         r_id[0],

--- a/bin/migrate-oats-data/prod_db_obfuscation/alcs/notification/notification.py
+++ b/bin/migrate-oats-data/prod_db_obfuscation/alcs/notification/notification.py
@@ -140,7 +140,6 @@ def _update_notification_transferee(conn=None):
                             SET 
                             {get_update_column_query("first_name")},
                             {get_update_column_query("last_name")},
-                            {get_update_column_query("organization_name")},
                             {get_update_column_query("phone_number")},
                             {get_update_column_query("email")}
                             WHERE uuid = %s;
@@ -150,7 +149,6 @@ def _update_notification_transferee(conn=None):
                     (
                         fake.first_name(),
                         fake.last_name(),
-                        fake.company(),
                         fake.phone_number(),
                         "11@11",
                         r_id[0],


### PR DESCRIPTION
disable organization name obfuscation since it is not 'personally identifiable information' and as result not protected under Personal Information Protection Act