### PR TITLE
execute oats related migrations conditionally

### DIFF
--- a/services/apps/alcs/src/providers/typeorm/migrations/1707852182314-set_purpose_on_app_from_oats.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1707852182314-set_purpose_on_app_from_oats.ts
@@ -5,40 +5,45 @@ export class SetPurposeOnAppFromOats1707852182314
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-        WITH alcs_app_sub_to_update AS (
-        SELECT
-            as2.file_number
-        FROM
-            alcs.application_submission as2
-        WHERE
-            audit_created_by = 'oats_etl'
-            AND purpose IS NULL
-            AND type_code IN ('POFO', 'ROSO', 'PFRS', 'INC')
-        ),
-        purpose_with_background AS (
-        SELECT
-            alr_application_id, 
-            oaa.proposal_summary_desc,
-            oaa.proposal_background_desc
-        FROM
-            oats.oats_alr_applications oaa
-        JOIN alcs_app_sub_to_update AS alcs_sub ON
-            alcs_sub.file_number::bigint = oaa.alr_application_id
-        ),
-        mapped_backgrounds AS (
-        SELECT
-            pb.alr_application_id::TEXT,
-            CASE 
-                WHEN length(proposal_background_desc) > 10 THEN pb.proposal_summary_desc || '. Background: ' || pb.proposal_background_desc
-                ELSE pb.proposal_summary_desc
-            END AS oats_purpose
-        FROM
-            purpose_with_background AS pb
-            )
-        UPDATE alcs.application_submission 
-        SET purpose = COALESCE(mapped_backgrounds.oats_purpose, alcs.application_submission.purpose)
-        FROM mapped_backgrounds
-        WHERE alcs.application_submission.file_number = mapped_backgrounds.alr_application_id;
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'oats') THEN
+                WITH alcs_app_sub_to_update AS (
+                SELECT
+                    as2.file_number
+                FROM
+                    alcs.application_submission as2
+                WHERE
+                    audit_created_by = 'oats_etl'
+                    AND purpose IS NULL
+                    AND type_code IN ('POFO', 'ROSO', 'PFRS', 'INC')
+                ),
+                purpose_with_background AS (
+                SELECT
+                    alr_application_id, 
+                    oaa.proposal_summary_desc,
+                    oaa.proposal_background_desc
+                FROM
+                    oats.oats_alr_applications oaa
+                JOIN alcs_app_sub_to_update AS alcs_sub ON
+                    alcs_sub.file_number::bigint = oaa.alr_application_id
+                ),
+                mapped_backgrounds AS (
+                SELECT
+                    pb.alr_application_id::TEXT,
+                    CASE 
+                        WHEN length(proposal_background_desc) > 10 THEN pb.proposal_summary_desc || '. Background: ' || pb.proposal_background_desc
+                        ELSE pb.proposal_summary_desc
+                    END AS oats_purpose
+                FROM
+                    purpose_with_background AS pb
+                    )
+                UPDATE alcs.application_submission 
+                SET purpose = COALESCE(mapped_backgrounds.oats_purpose, alcs.application_submission.purpose)
+                FROM mapped_backgrounds
+                WHERE alcs.application_submission.file_number = mapped_backgrounds.alr_application_id;
+            END IF;
+        END $$;
     `);
   }
 

--- a/services/apps/alcs/src/providers/typeorm/migrations/1707940567877-add_advanced_parcel_mapping_true.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1707940567877-add_advanced_parcel_mapping_true.ts
@@ -5,30 +5,34 @@ export class AddAdvancedParcelMappingTrue1707940567877
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-        WITH parcels_to_insert AS (
-            SELECT apps."uuid" as submission_uuid
-            FROM alcs.application_submission apps
-                JOIN oats.oats_subject_properties osp ON osp.alr_application_id = apps.file_number::bigint
-            WHERE osp.alr_application_land_ind <> 'Y' -- ensure that only other parcels are selected
-            ),
-            grouped_parcels AS (
-            SELECT *
-            FROM parcels_to_insert pti
-            Group BY pti.submission_uuid)
-        UPDATE 
-            alcs.application_submission
-        SET
-            has_other_parcels_in_community = 'True',
-            other_parcels_description = 'Not migrated from OATS'
-        FROM 
-            grouped_parcels
-        WHERE
-            "uuid" = grouped_parcels.submission_uuid 
-
-        `);
+      DO $$
+          BEGIN
+              IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'oats') THEN
+              WITH parcels_to_insert AS (
+                  SELECT apps."uuid" as submission_uuid
+                  FROM alcs.application_submission apps
+                      JOIN oats.oats_subject_properties osp ON osp.alr_application_id = apps.file_number::bigint
+                  WHERE osp.alr_application_land_ind <> 'Y' -- ensure that only other parcels are selected
+                  ),
+                  grouped_parcels AS (
+                  SELECT *
+                  FROM parcels_to_insert pti
+                  Group BY pti.submission_uuid)
+              UPDATE 
+                  alcs.application_submission
+              SET
+                  has_other_parcels_in_community = 'True',
+                  other_parcels_description = 'Not migrated from OATS'
+              FROM 
+                  grouped_parcels
+              WHERE
+                  "uuid" = grouped_parcels.submission_uuid 
+            END IF;
+      END $$;
+    `);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down(): Promise<void> {
     // Do Nothing
   }
 }

--- a/services/apps/alcs/src/providers/typeorm/migrations/1707948028191-reset_REVG_status_if_no_review.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1707948028191-reset_REVG_status_if_no_review.ts
@@ -5,34 +5,39 @@ export class ResetREVGStatusIfNoReview1707948028191
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-        WITH under_review_submissions AS (
-        SELECT
-            as2.file_number,
-            astss.submission_uuid ,
-            astss.status_type_code,
-            astss.effective_date,
-            asr.uuid
-        FROM
-            alcs.application_submission_to_submission_status astss
-        JOIN alcs.application_submission as2 ON
-            astss.submission_uuid = as2."uuid"
-        LEFT JOIN alcs.application_submission_review asr ON
-            asr.application_file_number = as2.file_number
-        WHERE
-            asr."uuid" IS NULL
-            AND astss.status_type_code = 'REVG'
-            AND astss.effective_date IS NOT NULL)
-        UPDATE
-            alcs.application_submission_to_submission_status
-        SET
-            effective_date = NULL,
-            email_sent_date = NULL
-        FROM
-            under_review_submissions
-        WHERE
-            alcs.application_submission_to_submission_status.submission_uuid = under_review_submissions.submission_uuid
-            AND
-        alcs.application_submission_to_submission_status.status_type_code = under_review_submissions.status_type_code;
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'oats') THEN
+                WITH under_review_submissions AS (
+                SELECT
+                    as2.file_number,
+                    astss.submission_uuid ,
+                    astss.status_type_code,
+                    astss.effective_date,
+                    asr.uuid
+                FROM
+                    alcs.application_submission_to_submission_status astss
+                JOIN alcs.application_submission as2 ON
+                    astss.submission_uuid = as2."uuid"
+                LEFT JOIN alcs.application_submission_review asr ON
+                    asr.application_file_number = as2.file_number
+                WHERE
+                    asr."uuid" IS NULL
+                    AND astss.status_type_code = 'REVG'
+                    AND astss.effective_date IS NOT NULL)
+                UPDATE
+                    alcs.application_submission_to_submission_status
+                SET
+                    effective_date = NULL,
+                    email_sent_date = NULL
+                FROM
+                    under_review_submissions
+                WHERE
+                    alcs.application_submission_to_submission_status.submission_uuid = under_review_submissions.submission_uuid
+                    AND
+                alcs.application_submission_to_submission_status.status_type_code = under_review_submissions.status_type_code;
+            END IF;
+        END $$;
     `);
   }
 


### PR DESCRIPTION
Run oats migrations conditionally. This will ensure that developers who work on local env do not need to introduce oats schema and related infrastructure. All hosted envs have "oats" as part of DB