### PR TITLE
Open card after creating

### DIFF
--- a/alcs-frontend/src/app/features/board/board.component.html
+++ b/alcs-frontend/src/app/features/board/board.component.html
@@ -29,7 +29,7 @@
             Planning Review
           </button>
           <button *ngIf="boardHasCreateAppModification" mat-menu-item (click)="onCreateAppModification()">
-            Modification
+            Application Modification
           </button>
           <button *ngIf="boardHasCreateNOIModification" mat-menu-item (click)="onCreateNoiModifications()">
             Modification

--- a/alcs-frontend/src/app/features/board/dialogs/app-modification/create/create-app-modification-dialog.component.spec.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/app-modification/create/create-app-modification-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 import { CreateAppModificationDialogComponent } from './create-app-modification-dialog.component';
 
 describe('CreateReconsiderationDialogComponent', () => {
@@ -32,6 +33,7 @@ describe('CreateReconsiderationDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/alcs-frontend/src/app/features/board/dialogs/app-modification/create/create-app-modification-dialog.component.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/app-modification/create/create-app-modification-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatOptionSelectionChange } from '@angular/material/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 import { debounceTime, distinctUntilChanged, Observable, startWith, Subject, switchMap, takeUntil } from 'rxjs';
 import { ApplicationRegionDto, ApplicationTypeDto } from '../../../../../services/application/application-code.dto';
 import { ApplicationLocalGovernmentDto } from '../../../../../services/application/application-local-government/application-local-government.dto';
@@ -59,7 +60,9 @@ export class CreateAppModificationDialogComponent implements OnInit, OnDestroy {
     private modificationService: ApplicationModificationService,
     private localGovernmentService: ApplicationLocalGovernmentService,
     private decisionService: ApplicationDecisionService,
-    private toastService: ToastService
+    private toastService: ToastService,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
@@ -89,7 +92,7 @@ export class CreateAppModificationDialogComponent implements OnInit, OnDestroy {
           return this.applicationService.searchApplicationsByNumber(val);
         }
         return [];
-      })
+      }),
     );
   }
 
@@ -148,8 +151,14 @@ export class CreateAppModificationDialogComponent implements OnInit, OnDestroy {
         return;
       }
 
-      await this.modificationService.create(modificationCreateDto);
+      const res = await this.modificationService.create(modificationCreateDto);
       this.dialogRef.close(true);
+      if (res) {
+        await this.router.navigate(this.activatedRoute.snapshot.url, {
+          queryParams: res.card.uuid && res.card.type ? { card: res.card.uuid, type: res.card.type } : {},
+          relativeTo: this.activatedRoute,
+        });
+      }
       this.toastService.showSuccessToast('Modification card created');
     } finally {
       this.isLoading = false;

--- a/alcs-frontend/src/app/features/board/dialogs/noi-modification/create/create-noi-modification-dialog.component.spec.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/noi-modification/create/create-noi-modification-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 import { CreateNoiModificationDialogComponent } from './create-noi-modification-dialog.component';
 
 describe('CreateNoiModificationDialogComponent', () => {
@@ -32,6 +33,7 @@ describe('CreateNoiModificationDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/alcs-frontend/src/app/features/board/dialogs/noi-modification/create/create-noi-modification-dialog.component.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/noi-modification/create/create-noi-modification-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatOptionSelectionChange } from '@angular/material/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 import { debounceTime, distinctUntilChanged, Observable, startWith, Subject, switchMap, takeUntil } from 'rxjs';
 import { ApplicationRegionDto, ApplicationTypeDto } from '../../../../../services/application/application-code.dto';
 import { ApplicationLocalGovernmentDto } from '../../../../../services/application/application-local-government/application-local-government.dto';
@@ -57,7 +58,9 @@ export class CreateNoiModificationDialogComponent implements OnInit, OnDestroy {
     private modificationService: NoticeOfIntentModificationService,
     private localGovernmentService: ApplicationLocalGovernmentService,
     private decisionService: NoticeOfIntentDecisionService,
-    private toastService: ToastService
+    private toastService: ToastService,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
@@ -84,7 +87,7 @@ export class CreateNoiModificationDialogComponent implements OnInit, OnDestroy {
           return this.noticeOfIntentService.searchByFileNumber(val);
         }
         return [];
-      })
+      }),
     );
   }
 
@@ -136,8 +139,15 @@ export class CreateNoiModificationDialogComponent implements OnInit, OnDestroy {
         return;
       }
 
-      await this.modificationService.create(modificationCreateDto);
+      const res = await this.modificationService.create(modificationCreateDto);
       this.dialogRef.close(true);
+      if (res) {
+        await this.router.navigate(this.activatedRoute.snapshot.url, {
+          queryParams: res.card.uuid && res.card.type ? { card: res.card.uuid, type: res.card.type } : {},
+          relativeTo: this.activatedRoute,
+        });
+      }
+
       this.toastService.showSuccessToast('Modification card created');
     } finally {
       this.isLoading = false;

--- a/alcs-frontend/src/app/features/board/dialogs/planning-review/create/create-planning-review-dialog.component.spec.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/planning-review/create/create-planning-review-dialog.component.spec.ts
@@ -9,6 +9,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { createMock } from '@golevelup/ts-jest';
 import { CreatePlanningReviewDialogComponent } from './create-planning-review-dialog.component';
 
 describe('CreatePlanningReviewDialogComponent', () => {
@@ -32,6 +34,7 @@ describe('CreatePlanningReviewDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/alcs-frontend/src/app/features/board/dialogs/planning-review/create/create-planning-review-dialog.component.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/planning-review/create/create-planning-review-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { ApplicationRegionDto } from '../../../../../services/application/application-code.dto';
 import { ApplicationLocalGovernmentDto } from '../../../../../services/application/application-local-government/application-local-government.dto';
@@ -42,7 +43,9 @@ export class CreatePlanningReviewDialogComponent implements OnInit, OnDestroy {
     private planningReviewService: PlanningReviewService,
     private cardService: CardService,
     private applicationService: ApplicationService,
-    private localGovernmentService: ApplicationLocalGovernmentService
+    private localGovernmentService: ApplicationLocalGovernmentService,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
@@ -71,6 +74,12 @@ export class CreatePlanningReviewDialogComponent implements OnInit, OnDestroy {
 
       const res = await this.planningReviewService.create(planningReview);
       this.dialogRef.close(true);
+      if (res) {
+        await this.router.navigate(this.activatedRoute.snapshot.url, {
+          queryParams: res.card.uuid && res.card.type ? { card: res.card.uuid, type: res.card.type } : {},
+          relativeTo: this.activatedRoute,
+        });
+      }
     } finally {
       this.isLoading = false;
     }

--- a/alcs-frontend/src/app/features/board/dialogs/reconsiderations/create/create-reconsideration-dialog.component.spec.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/reconsiderations/create/create-reconsideration-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 import { CreateReconsiderationDialogComponent } from './create-reconsideration-dialog.component';
 
 describe('CreateReconsiderationDialogComponent', () => {
@@ -32,6 +33,7 @@ describe('CreateReconsiderationDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: ActivatedRoute, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/alcs-frontend/src/app/features/board/dialogs/reconsiderations/create/create-reconsideration-dialog.component.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/reconsiderations/create/create-reconsideration-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatOptionSelectionChange } from '@angular/material/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
 import { debounceTime, distinctUntilChanged, Observable, startWith, Subject, switchMap, takeUntil } from 'rxjs';
 import { ApplicationRegionDto, ApplicationTypeDto } from '../../../../../services/application/application-code.dto';
 import { ApplicationLocalGovernmentDto } from '../../../../../services/application/application-local-government/application-local-government.dto';
@@ -72,7 +73,9 @@ export class CreateReconsiderationDialogComponent implements OnInit, OnDestroy {
     private reconsiderationService: ApplicationReconsiderationService,
     private localGovernmentService: ApplicationLocalGovernmentService,
     private toastService: ToastService,
-    private decisionService: ApplicationDecisionService
+    private decisionService: ApplicationDecisionService,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
   ) {}
 
   ngOnInit(): void {
@@ -107,7 +110,7 @@ export class CreateReconsiderationDialogComponent implements OnInit, OnDestroy {
           return this.applicationService.searchApplicationsByNumber(val);
         }
         return [];
-      })
+      }),
     );
   }
 
@@ -170,7 +173,13 @@ export class CreateReconsiderationDialogComponent implements OnInit, OnDestroy {
         return;
       }
 
-      await this.reconsiderationService.create(recon);
+      const res = await this.reconsiderationService.create(recon);
+      if (res) {
+        await this.router.navigate(this.activatedRoute.snapshot.url, {
+          queryParams: res.card.uuid && res.card.type ? { card: res.card.uuid, type: res.card.type } : {},
+          relativeTo: this.activatedRoute,
+        });
+      }
       this.dialogRef.close(true);
       this.toastService.showSuccessToast('Reconsideration card created');
     } finally {

--- a/alcs-frontend/src/app/services/planning-review/planning-review.service.ts
+++ b/alcs-frontend/src/app/services/planning-review/planning-review.service.ts
@@ -11,12 +11,16 @@ import { CreatePlanningReviewDto, PlanningReviewDto } from './planning-review.dt
 export class PlanningReviewService {
   private url = `${environment.apiUrl}/planning-review`;
 
-  constructor(private http: HttpClient, private toastService: ToastService) {}
+  constructor(
+    private http: HttpClient,
+    private toastService: ToastService,
+  ) {}
 
   async create(meeting: CreatePlanningReviewDto) {
     try {
-      await firstValueFrom(this.http.post<PlanningReviewDto>(`${this.url}`, meeting));
+      const res = await firstValueFrom(this.http.post<PlanningReviewDto>(`${this.url}`, meeting));
       this.toastService.showSuccessToast('Planning meeting card created');
+      return res;
     } catch (err) {
       console.error(err);
       this.toastService.showErrorToast('Failed to create planning review');

--- a/services/apps/alcs/src/alcs/application-decision/application-modification/application-modification.controller.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-modification/application-modification.controller.ts
@@ -39,7 +39,10 @@ export class ApplicationModificationController {
       uuid,
       updateDto,
     );
-    return this.modificationService.mapToDtos([updatedModification]);
+    const mapped = await this.modificationService.mapToDtos([
+      updatedModification,
+    ]);
+    return mapped[0];
   }
 
   @Post()
@@ -52,7 +55,8 @@ export class ApplicationModificationController {
       createDto,
       board,
     );
-    return this.modificationService.mapToDtos([modification]);
+    const mapped = await this.modificationService.mapToDtos([modification]);
+    return mapped[0];
   }
 
   @Delete('/:uuid')

--- a/services/apps/alcs/src/alcs/application-decision/application-reconsideration/application-reconsideration.controller.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-reconsideration/application-reconsideration.controller.ts
@@ -41,7 +41,8 @@ export class ApplicationReconsiderationController {
       board,
     );
 
-    return this.reconsiderationService.mapToDtos([createdRecon]);
+    const mapped = await this.reconsiderationService.mapToDtos([createdRecon]);
+    return mapped[0];
   }
 
   @Patch('/:uuid')
@@ -55,7 +56,8 @@ export class ApplicationReconsiderationController {
       reconsideration,
     );
 
-    return this.reconsiderationService.mapToDtos([updatedRecon]);
+    const mapped = await this.reconsiderationService.mapToDtos([updatedRecon]);
+    return mapped[0];
   }
 
   @Delete('/:uuid')

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-modification/notice-of-intent-modification.controller.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-modification/notice-of-intent-modification.controller.ts
@@ -39,7 +39,10 @@ export class NoticeOfIntentModificationController {
       uuid,
       updateDto,
     );
-    return this.modificationService.mapToDtos([updatedModification]);
+    const mapped = await this.modificationService.mapToDtos([
+      updatedModification,
+    ]);
+    return mapped[0];
   }
 
   @Post()
@@ -52,7 +55,8 @@ export class NoticeOfIntentModificationController {
       createDto,
       board,
     );
-    return this.modificationService.mapToDtos([modification]);
+    const mapped = await this.modificationService.mapToDtos([modification]);
+    return mapped[0];
   }
 
   @Delete('/:uuid')
@@ -73,9 +77,8 @@ export class NoticeOfIntentModificationController {
   @Get('/notice-of-intent/:fileNumber')
   @UserRoles(...ROLES_ALLOWED_APPLICATIONS)
   async getByFileNumber(@Param('fileNumber') fileNumber: string) {
-    const modification = await this.modificationService.getByFileNumber(
-      fileNumber,
-    );
+    const modification =
+      await this.modificationService.getByFileNumber(fileNumber);
     return this.modificationService.mapToDtos(modification);
   }
 }

--- a/services/apps/alcs/src/alcs/planning-review/planning-review.controller.ts
+++ b/services/apps/alcs/src/alcs/planning-review/planning-review.controller.ts
@@ -33,16 +33,15 @@ export class PlanningReviewController {
       board,
     );
 
-    const mapped = this.planningReviewService.mapToDtos([createdReview]);
+    const mapped = await this.planningReviewService.mapToDtos([createdReview]);
     return mapped[0];
   }
 
   @Get('/card/:uuid')
   @UserRoles(...ROLES_ALLOWED_BOARDS)
   async getByCard(@Param('uuid') cardUuid: string) {
-    const planningReview = await this.planningReviewService.getByCardUuid(
-      cardUuid,
-    );
+    const planningReview =
+      await this.planningReviewService.getByCardUuid(cardUuid);
     const mapped = await this.planningReviewService.mapToDtos([planningReview]);
     return mapped[0];
   }

--- a/services/apps/alcs/src/alcs/planning-review/planning-review.service.ts
+++ b/services/apps/alcs/src/alcs/planning-review/planning-review.service.ts
@@ -45,32 +45,31 @@ export class PlanningReviewService {
   };
 
   async create(data: CreatePlanningReviewDto, board: Board) {
-    const existingMeeting = await this.repository.findOne({
+    const existingReview = await this.repository.findOne({
       where: {
         fileNumber: data.fileNumber,
       },
     });
-    if (existingMeeting) {
+    if (existingReview) {
       throw new ServiceValidationException(
         `Planning meeting already exists with File ID ${data.fileNumber}`,
       );
     }
 
-    const planingMeeting = new PlanningReview({
+    const planningReview = new PlanningReview({
       type: data.type,
       localGovernmentUuid: data.localGovernmentUuid,
       fileNumber: data.fileNumber,
       regionCode: data.regionCode,
     });
 
-    planingMeeting.card = await this.cardService.create(
+    planningReview.card = await this.cardService.create(
       CARD_TYPE.PLAN,
       board,
       false,
     );
-    const savedMeeting = await this.repository.save(planingMeeting);
-
-    return this.getOrFail(savedMeeting.uuid);
+    const savedReview = await this.repository.save(planningReview);
+    return this.getOrFail(savedReview.uuid);
   }
 
   async getOrFail(uuid: string) {


### PR DESCRIPTION
* Applies to Planning Reviews, Reconds, and App/NOI Modifications
* Update backend controllers to correctly return created objects
* Update dialogs to load card into URL triggering its opening