### PR TITLE
Logging changes

### DIFF
--- a/services/apps/alcs/src/main.module.ts
+++ b/services/apps/alcs/src/main.module.ts
@@ -46,6 +46,9 @@ import { UserModule } from './user/user.module';
     RedisModule,
     LoggerModule.forRoot({
       pinoHttp: {
+        redact: {
+          paths: ['req.headers'],
+        },
         level: config.get('LOG_LEVEL'),
         autoLogging: false, //Disable auto-logging every request/response for now
         transport:

--- a/services/apps/alcs/src/main.ts
+++ b/services/apps/alcs/src/main.ts
@@ -12,7 +12,7 @@ import * as config from 'config';
 import { Logger } from 'nestjs-pino';
 import { install } from 'source-map-support';
 import { generateModuleGraph } from './commands/graph';
-import { importApplications, importNOIs } from './commands/import';
+import { importApplications } from './commands/import';
 import { MainModule } from './main.module';
 
 const registerSwagger = (app: NestFastifyApplication) => {

--- a/services/apps/alcs/src/providers/keycloak/keycloak-config.service.ts
+++ b/services/apps/alcs/src/providers/keycloak/keycloak-config.service.ts
@@ -20,6 +20,7 @@ export class KeycloakConfigService implements KeycloakConnectOptionsFactory {
       'confidential-port': 0,
       tokenValidation: TokenValidation.OFFLINE,
       verifyTokenAudience: true,
+      logLevels: [], //Disable Expired Token Messages
     };
   }
 }


### PR DESCRIPTION
* Don't log all headers, they have the auth key and don't really help anyway
* Prevent keycloak from logging every token expiry