### PR TITLE
Open portal non-decision documents in new browser tab iframe

### DIFF
--- a/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
@@ -7,13 +7,13 @@ import {
   ApplicationOwnerDetailedDto,
   ApplicationOwnerDto,
 } from '../../../services/application-owner/application-owner.dto';
-import { PARCEL_OWNERSHIP_TYPE } from '../../../services/application-parcel/application-parcel.dto';
 import { ApplicationParcelService } from '../../../services/application-parcel/application-parcel.service';
 import { ApplicationSubmissionDetailedDto } from '../../../services/application-submission/application-submission.dto';
 import { LocalGovernmentDto } from '../../../services/code/code.dto';
 import { CodeService } from '../../../services/code/code.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-application-details',
@@ -85,7 +85,9 @@ export class ApplicationDetailsComponent implements OnInit, OnDestroy {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 
   async onNavigateToStep(step: number) {

--- a/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
@@ -6,6 +6,7 @@ import { ApplicationSubmissionDetailedDto } from '../../../../services/applicati
 import { CovenantTransfereeDto } from '../../../../services/covenant-transferee/covenant-transferee.dto';
 import { CovenantTransfereeService } from '../../../../services/covenant-transferee/covenant-transferee.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-cove-details',
@@ -53,7 +54,9 @@ export class CoveDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 
   private async loadTransferees(uuid: string) {

--- a/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentService } from '../../../../services/application-doc
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-excl-details',
@@ -53,6 +54,8 @@ export class ExclDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
@@ -6,6 +6,7 @@ import { ApplicationSubmissionDetailedDto } from '../../../../services/applicati
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { AuthenticationService } from '../../../../services/authentication/authentication.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-incl-details',
@@ -73,7 +74,9 @@ export class InclDetailsComponent implements OnInit, OnDestroy {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 
   ngOnDestroy(): void {

--- a/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-naru-details[applicationSubmission]',
@@ -43,6 +44,8 @@ export class NaruDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-nfu-details[applicationSubmission]',
@@ -35,6 +36,8 @@ export class NfuDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
@@ -4,7 +4,6 @@ import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationOwnerDto } from '../../../../services/application-owner/application-owner.dto';
-import { ApplicationOwnerService } from '../../../../services/application-owner/application-owner.service';
 import {
   ApplicationParcelDto,
   ApplicationParcelUpdateDto,
@@ -14,6 +13,7 @@ import { ApplicationParcelService } from '../../../../services/application-parce
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { BaseCodeDto } from '../../../../shared/dto/base.dto';
 import { formatBooleanToYesNoString } from '../../../../shared/utils/boolean-helper';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 export class ApplicationParcelBasicValidation {
   // indicates general validity check state, including owner related information
@@ -101,7 +101,7 @@ export class ParcelComponent {
   async onOpenFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[applicationSubmission]',
@@ -49,6 +50,8 @@ export class PfrsDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[applicationSubmission]',
@@ -47,6 +48,8 @@ export class PofoDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[applicationSubmission]',
@@ -47,6 +48,8 @@ export class RosoDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
@@ -5,6 +5,7 @@ import { ApplicationDocumentService } from '../../../../services/application-doc
 import { ApplicationParcelService } from '../../../../services/application-parcel/application-parcel.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-subd-details[applicationSubmission]',
@@ -57,7 +58,9 @@ export class SubdDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 
   private async loadParcels(fileNumber: string) {

--- a/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
@@ -4,6 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-tur-details[applicationSubmission]',
@@ -44,6 +45,8 @@ export class TurDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
@@ -9,6 +9,7 @@ import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { RemoveFileConfirmationDialogComponent } from '../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { StepComponent } from './step.partial';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -85,7 +86,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
@@ -21,6 +21,7 @@ import { OwnerDialogComponent } from '../../../../../shared/owner-dialogs/owner-
 import { formatBooleanToString } from '../../../../../shared/utils/boolean-helper';
 import { RemoveFileConfirmationDialogComponent } from '../../../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
+import { openFileIframe } from '../../../../../shared/utils/file';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -345,7 +346,7 @@ export class ParcelEntryComponent implements OnInit {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
@@ -1,5 +1,4 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { Router } from '@angular/router';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
@@ -8,6 +7,7 @@ import { ToastService } from '../../../../services/toast/toast.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
 import { FileHandle } from '../../../../shared/file-drag-drop/drag-drop.directive';
 import { ReviewApplicationFngSteps, ReviewApplicationSteps } from '../review-submission.component';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-attachments',
@@ -128,7 +128,7 @@ export class ReviewAttachmentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
@@ -16,6 +16,7 @@ import { MOBILE_BREAKPOINT } from '../../../../shared/utils/breakpoints';
 import { ReviewApplicationFngSteps } from '../review-submission.component';
 import { ToastService } from '../../../../services/toast/toast.service';
 import { SubmitConfirmationDialogComponent } from '../submit-confirmation-dialog/submit-confirmation-dialog.component';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-submit-fng[stepper]',
@@ -123,7 +124,7 @@ export class ReviewSubmitFngComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
@@ -15,6 +15,7 @@ import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.
 import { MOBILE_BREAKPOINT } from '../../../../shared/utils/breakpoints';
 import { ReviewApplicationSteps } from '../review-submission.component';
 import { SubmitConfirmationDialogComponent } from '../submit-confirmation-dialog/submit-confirmation-dialog.component';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-submit[stepper]',
@@ -131,7 +132,7 @@ export class ReviewSubmitComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,6 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 import { ApplicationDocumentService } from '../../../../../services/application-document/application-document.service';
+import { openFileIframe } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -32,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../../services/application-submission/application-submission.dto';
 import { PdfGenerationService } from '../../../../services/pdf-generation/pdf-generation.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-lfng-review',
@@ -40,7 +41,7 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
     private applicationReviewService: ApplicationSubmissionReviewService,
     private pdfGenerationService: PdfGenerationService,
     private applicationDocumentService: ApplicationDocumentService,
-    private router: Router,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -69,7 +70,7 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
     this.$application.pipe(takeUntil(this.$destroy)).subscribe((application) => {
       this.application = application;
       this.submittedToAlcStatus = !!this.application?.submissionStatuses.find(
-        (s) => s.statusTypeCode === SUBMISSION_STATUS.SUBMITTED_TO_ALC && !!s.effectiveDate,
+        (s) => s.statusTypeCode === SUBMISSION_STATUS.SUBMITTED_TO_ALC && !!s.effectiveDate
       );
       this.isTurOrCov = this.application?.typeCode === 'COVE' || this.application?.typeCode === 'TURP';
       this.loadReview();
@@ -78,10 +79,10 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
     this.$applicationDocuments.subscribe((documents) => {
       this.staffReport = documents.filter((document) => document.type?.code === DOCUMENT_TYPE.STAFF_REPORT);
       this.resolutionDocument = documents.filter(
-        (document) => document.type?.code === DOCUMENT_TYPE.RESOLUTION_DOCUMENT,
+        (document) => document.type?.code === DOCUMENT_TYPE.RESOLUTION_DOCUMENT
       );
       this.governmentOtherAttachments = documents.filter(
-        (document) => document.type?.code === DOCUMENT_TYPE.OTHER && document.source === DOCUMENT_SOURCE.LFNG,
+        (document) => document.type?.code === DOCUMENT_TYPE.OTHER && document.source === DOCUMENT_SOURCE.LFNG
       );
     });
   }
@@ -109,7 +110,7 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
@@ -12,6 +12,7 @@ import {
 import { ApplicationSubmissionService } from '../../../services/application-submission/application-submission.service';
 import { PdfGenerationService } from '../../../services/pdf-generation/pdf-generation.service';
 import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/confirmation-dialog.service';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-view-application-submission',
@@ -96,7 +97,7 @@ export class ViewApplicationSubmissionComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
@@ -9,6 +9,7 @@ import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { RemoveFileConfirmationDialogComponent } from '../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { StepComponent } from './step.partial';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -85,7 +86,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
@@ -20,6 +20,7 @@ import { formatBooleanToString } from '../../../../../shared/utils/boolean-helpe
 import { RemoveFileConfirmationDialogComponent } from '../../../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
 import { scrollToElement } from '../../../../../shared/utils/scroll-helper';
+import { openFileIframe } from '../../../../../shared/utils/file';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -343,7 +344,7 @@ export class ParcelEntryComponent implements OnInit {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
@@ -8,6 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../edit-submission/additional-information/additional-information.component';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -101,6 +102,8 @@ export class AdditionalInformationComponent {
 
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
@@ -10,6 +10,7 @@ import { NoticeOfIntentParcelService } from '../../../services/notice-of-intent-
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-noi-details',
@@ -83,7 +84,9 @@ export class NoticeOfIntentDetailsComponent implements OnInit, OnDestroy {
 
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 
   async onNavigateToStep(step: number) {

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
@@ -14,6 +14,7 @@ import { NoticeOfIntentParcelService } from '../../../../services/notice-of-inte
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { BaseCodeDto } from '../../../../shared/dto/base.dto';
 import { formatBooleanToYesNoString } from '../../../../shared/utils/boolean-helper';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 export class NoticeOfIntentParcelBasicValidation {
   // indicates general validity check state, including owner related information
@@ -99,7 +100,7 @@ export class ParcelComponent {
   async onOpenFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
@@ -4,6 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[noiSubmission]',
@@ -49,6 +50,8 @@ export class PfrsDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
@@ -4,6 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[noiSubmission]',
@@ -49,6 +50,8 @@ export class PofoDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
@@ -4,6 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[noiSubmission]',
@@ -49,6 +50,8 @@ export class RosoDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,6 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { NoticeOfIntentDocumentDto } from '../../../../../services/notice-of-intent-document/notice-of-intent-document.dto';
 import { NoticeOfIntentDocumentService } from '../../../../../services/notice-of-intent-document/notice-of-intent-document.service';
+import { openFileIframe } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -32,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
@@ -9,6 +9,7 @@ import { ToastService } from '../../../services/toast/toast.service';
 import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { StepComponent } from './step.partial';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -71,7 +72,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
@@ -8,6 +8,7 @@ import { NotificationDocumentService } from '../../../services/notification-docu
 import { NotificationSubmissionDetailedDto } from '../../../services/notification-submission/notification-submission.dto';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
+import { openFileIframe } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-notification-details',
@@ -65,7 +66,9 @@ export class NotificationDetailsComponent implements OnInit, OnDestroy {
 
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 
   async onNavigateToStep(step: number) {

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
@@ -4,6 +4,7 @@ import { NotificationDocumentDto } from '../../../../services/notification-docum
 import { NotificationDocumentService } from '../../../../services/notification-document/notification-document.service';
 import { NotificationSubmissionDetailedDto } from '../../../../services/notification-submission/notification-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileIframe } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-proposal-details[notificationSubmission]',
@@ -38,6 +39,8 @@ export class ProposalDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileIframe(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,6 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { NotificationDocumentDto } from '../../../../../services/notification-document/notification-document.dto';
 import { NotificationDocumentService } from '../../../../../services/notification-document/notification-document.service';
+import { openFileIframe } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -32,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileIframe(res);
     }
   }
 

--- a/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
 

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
@@ -1,6 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
-import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
+import { Component, Input } from '@angular/core';
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
 

--- a/portal-frontend/src/app/services/application-document/application-document.service.ts
+++ b/portal-frontend/src/app/services/application-document/application-document.service.ts
@@ -52,8 +52,7 @@ export class ApplicationDocumentService {
   async openFile(fileUuid: string) {
     try {
       return await firstValueFrom(
-        // TODO: Make fileName mandatory when ready to update all other usage
-        this.httpClient.get<{ url: string; fileName?: string }>(`${this.serviceUrl}/${fileUuid}/open`)
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${fileUuid}/open`)
       );
     } catch (e) {
       console.error(e);

--- a/portal-frontend/src/app/services/application-document/application-document.service.ts
+++ b/portal-frontend/src/app/services/application-document/application-document.service.ts
@@ -51,7 +51,10 @@ export class ApplicationDocumentService {
 
   async openFile(fileUuid: string) {
     try {
-      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${fileUuid}/open`));
+      return await firstValueFrom(
+        // TODO: Make fileName mandatory when ready to update all other usage
+        this.httpClient.get<{ url: string; fileName?: string }>(`${this.serviceUrl}/${fileUuid}/open`)
+      );
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
@@ -52,8 +52,7 @@ export class NoticeOfIntentDocumentService {
   async openFile(fileUuid: string) {
     try {
       return await firstValueFrom(
-        // TODO: Make fileName mandatory when ready to update all other usage
-        this.httpClient.get<{ url: string; fileName?: string }>(`${this.serviceUrl}/${fileUuid}/open`)
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${fileUuid}/open`)
       );
     } catch (e) {
       console.error(e);

--- a/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
@@ -51,7 +51,10 @@ export class NoticeOfIntentDocumentService {
 
   async openFile(fileUuid: string) {
     try {
-      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${fileUuid}/open`));
+      return await firstValueFrom(
+        // TODO: Make fileName mandatory when ready to update all other usage
+        this.httpClient.get<{ url: string; fileName?: string }>(`${this.serviceUrl}/${fileUuid}/open`)
+      );
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/notification-document/notification-document.service.ts
+++ b/portal-frontend/src/app/services/notification-document/notification-document.service.ts
@@ -51,7 +51,9 @@ export class NotificationDocumentService {
 
   async openFile(fileUuid: string) {
     try {
-      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${fileUuid}/open`));
+      return await firstValueFrom(
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${fileUuid}/open`)
+      );
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
@@ -108,8 +108,7 @@ export class ParcelOwnersComponent {
   async onOpenFile(uuid: string) {
     const res = await this.documentService.openFile(uuid);
     if (res) {
-      const { fileName, url } = res;
-      openFileIframe(fileName || 'browser title', url);
+      openFileIframe(res);
     }
   }
 }

--- a/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
@@ -11,6 +11,7 @@ import { NoticeOfIntentOwnerService } from '../../../services/notice-of-intent-o
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { CrownOwnerDialogComponent } from '../crown-owner-dialog/crown-owner-dialog.component';
 import { OwnerDialogComponent } from '../owner-dialog/owner-dialog.component';
+import { openFileIframe } from '../../utils/file';
 
 @Component({
   selector: 'app-parcel-owners[owners][fileId][submissionUuid][ownerService]',
@@ -107,7 +108,8 @@ export class ParcelOwnersComponent {
   async onOpenFile(uuid: string) {
     const res = await this.documentService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      const { fileName, url } = res;
+      openFileIframe(fileName || 'browser title', url);
     }
   }
 }

--- a/portal-frontend/src/app/shared/utils/file.ts
+++ b/portal-frontend/src/app/shared/utils/file.ts
@@ -12,13 +12,13 @@ export const openPdfFile = (fileName: string, data: any) => {
   downloadLink.click();
 };
 
-export const openFileIframe = (fileName: string, url: string) => {
+export const openFileIframe = (data: { url: string; fileName: string }) => {
   const newWindow = window.open('', '_blank');
   if (newWindow) {
-    newWindow.document.title = fileName;
+    newWindow.document.title = data.fileName;
 
     const iframe = newWindow.document.createElement('iframe');
-    iframe.src = url;
+    iframe.src = data.url;
     iframe.style.borderWidth = '0';
     iframe.style.width = '100%';
     iframe.style.height = '100%';

--- a/portal-frontend/src/app/shared/utils/file.ts
+++ b/portal-frontend/src/app/shared/utils/file.ts
@@ -11,3 +11,23 @@ export const openPdfFile = (fileName: string, data: any) => {
   }
   downloadLink.click();
 };
+
+export const openFileIframe = (fileName: string, url: string) => {
+  const newWindow = window.open('', '_blank');
+  if (newWindow) {
+    newWindow.document.title = fileName;
+
+    const iframe = newWindow.document.createElement('iframe');
+    iframe.src = url;
+    iframe.style.borderWidth = '0';
+    iframe.style.width = '100%';
+    iframe.style.height = '100%';
+
+    newWindow.document.body.appendChild(iframe);
+    newWindow.document.body.style.backgroundColor = 'rgb(82, 86, 89)';
+    newWindow.document.body.style.height = '100%';
+    newWindow.document.body.style.width = '100%';
+    newWindow.document.body.style.margin = '0';
+    newWindow.document.body.style.overflow = 'hidden';
+  }
+};

--- a/services/apps/alcs/src/portal/application-document/application-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/application-document/application-document.controller.spec.ts
@@ -136,7 +136,9 @@ describe('ApplicationDocumentController', () => {
       },
     });
 
+    expect(appDocumentService.getInlineUrl).toHaveBeenCalledTimes(1);
     expect(res.url).toEqual(fakeUrl);
+    expect(res.fileName).toEqual(mockDocument.document.fileName);
   });
 
   it('should call through for download', async () => {

--- a/services/apps/alcs/src/portal/application-document/application-document.controller.ts
+++ b/services/apps/alcs/src/portal/application-document/application-document.controller.ts
@@ -75,7 +75,6 @@ export class ApplicationDocumentController {
 
     if (canAccessDocument) {
       const url = await this.applicationDocumentService.getInlineUrl(document);
-      // TODO: Same thing for other document controllers
       const { fileName } = document.document;
       return { url, fileName };
     }

--- a/services/apps/alcs/src/portal/application-document/application-document.controller.ts
+++ b/services/apps/alcs/src/portal/application-document/application-document.controller.ts
@@ -75,7 +75,9 @@ export class ApplicationDocumentController {
 
     if (canAccessDocument) {
       const url = await this.applicationDocumentService.getInlineUrl(document);
-      return { url };
+      // TODO: Same thing for other document controllers
+      const { fileName } = document.document;
+      return { url, fileName };
     }
 
     throw new NotFoundException('Failed to find document');

--- a/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.spec.ts
@@ -120,8 +120,9 @@ describe('NoticeOfIntentDocumentController', () => {
 
     const res = await controller.open('fake-uuid', mockRequest);
 
-    expect(res.url).toEqual(fakeUrl);
     expect(noiDocumentService.getInlineUrl).toHaveBeenCalledTimes(1);
+    expect(res.url).toEqual(fakeUrl);
+    expect(res.fileName).toEqual(mockDocument.document.fileName);
   });
 
   it('should call through for download', async () => {

--- a/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.ts
+++ b/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.ts
@@ -80,7 +80,8 @@ export class NoticeOfIntentDocumentController {
     if (canAccessDocument) {
       const url =
         await this.noticeOfIntentDocumentService.getInlineUrl(document);
-      return { url };
+      const { fileName } = document.document;
+      return { url, fileName };
     }
 
     throw new NotFoundException('Failed to find document');

--- a/services/apps/alcs/src/portal/notification-document/notification-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/notification-document/notification-document.controller.spec.ts
@@ -5,7 +5,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ClsService } from 'nestjs-cls';
 import { mockKeyCloakProviders } from '../../../test/mocks/mockTypes';
 import { VISIBILITY_FLAG } from '../../alcs/application/application-document/application-document.entity';
-import { NoticeOfIntentDocument } from '../../alcs/notice-of-intent/notice-of-intent-document/notice-of-intent-document.entity';
 import { NotificationDocument } from '../../alcs/notification/notification-document/notification-document.entity';
 import { NotificationDocumentService } from '../../alcs/notification/notification-document/notification-document.service';
 import { NotificationService } from '../../alcs/notification/notification.service';
@@ -137,7 +136,11 @@ describe('NotificationDocumentController', () => {
       },
     });
 
+    expect(mockNotificationDocumentService.getInlineUrl).toHaveBeenCalledTimes(
+      1,
+    );
     expect(res.url).toEqual(fakeUrl);
+    expect(res.fileName).toEqual(mockDocument.document.fileName);
   });
 
   it('should call through for download', async () => {

--- a/services/apps/alcs/src/portal/notification-document/notification-document.controller.ts
+++ b/services/apps/alcs/src/portal/notification-document/notification-document.controller.ts
@@ -78,7 +78,8 @@ export class NotificationDocumentController {
 
     if (canAccessDocument) {
       const url = await this.notificationDocumentService.getInlineUrl(document);
-      return { url };
+      const { fileName } = document.document;
+      return { url, fileName };
     }
 
     throw new NotFoundException('Failed to find document');


### PR DESCRIPTION
- Add new `utils` method to open file in iframe with `fileName` as browser tab title
- Apply method to all non-decision documents in frontend
- Update backend controller and test files