### PR TITLE
Fix report path

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,5 +39,5 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: e2e/playwright-report/
           retention-days: 30


### PR DESCRIPTION
- Upload artifact does not support `working-directory`, so path needs to be relative to repo root