### PR TITLE
Open alcs and portal document inline with standardized method

### DIFF
--- a/alcs-frontend/nginx.conf
+++ b/alcs-frontend/nginx.conf
@@ -19,7 +19,7 @@ http {
         add_header 'X-XSS-Protection' '1; mode=block';
         add_header 'Strict-Transport-Security' 'max-age=31536000; includeSubDomains; preload';
         add_header 'Cache-control' 'no-cache';
-        add_header 'Content-Security-Policy' "default-src 'self';img-src 'self';style-src 'unsafe-inline' 'self';connect-src $ENABLED_CONNECT_SRC; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; base-uri 'self'; object-src 'none'; frame-src https://alcs-metabase-test.apps.silver.devops.gov.bc.ca https://alcs-metabase-prod.apps.silver.devops.gov.bc.ca;";
+        add_header 'Content-Security-Policy' "default-src 'self';img-src 'self';style-src 'unsafe-inline' 'self';connect-src $ENABLED_CONNECT_SRC; font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; base-uri 'self'; object-src https://nrs.objectstore.gov.bc.ca; frame-src https://alcs-metabase-test.apps.silver.devops.gov.bc.ca https://alcs-metabase-prod.apps.silver.devops.gov.bc.ca https://nrs.objectstore.gov.bc.ca;";
         add_header 'Permissions-Policy' 'camera=(), geolocation=(), microphone=()';
         add_header 'Referrer-Policy' 'same-origin';
 

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.html
@@ -81,7 +81,7 @@
       <div class="subheading2 grid-1">Authorization Letter(s)</div>
       <div class="grid-double">
         <div *ngFor="let file of authorizationLetters">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
       </div>
     </ng-container>
@@ -226,7 +226,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div class="grid-1">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <div class="grid-2">
           {{ file.type?.label }}

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.ts
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.ts
@@ -47,8 +47,8 @@ export class ApplicationDetailsComponent implements OnInit, OnChanges, OnDestroy
     window.location.href = `${environment.portalUrl}/alcs/application/${this.fileNumber}/edit/${step}`;
   }
 
-  async openFile(uuid: string) {
-    await this.applicationDocumentService.download(uuid, '');
+  async openFile(file: ApplicationDocumentDto) {
+    await this.applicationDocumentService.download(file.uuid, file.fileName);
   }
 
   private async loadDocuments() {
@@ -56,10 +56,10 @@ export class ApplicationDetailsComponent implements OnInit, OnChanges, OnDestroy
     this.otherFiles = documents.filter(
       (document) =>
         document.type &&
-        [DOCUMENT_TYPE.PHOTOGRAPH, DOCUMENT_TYPE.OTHER, DOCUMENT_TYPE.PROFESSIONAL_REPORT].includes(document.type.code)
+        [DOCUMENT_TYPE.PHOTOGRAPH, DOCUMENT_TYPE.OTHER, DOCUMENT_TYPE.PROFESSIONAL_REPORT].includes(document.type.code),
     );
     this.authorizationLetters = documents.filter(
-      (document) => document.type?.code === DOCUMENT_TYPE.AUTHORIZATION_LETTER
+      (document) => document.type?.code === DOCUMENT_TYPE.AUTHORIZATION_LETTER,
     );
     this.files = documents;
   }

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.html
@@ -51,7 +51,7 @@
       <div class="subheading2 grid-1">Authorization Letter(s)</div>
       <div class="grid-double">
         <div *ngFor="let file of authorizationLetters">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
       </div>
     </ng-container>
@@ -68,21 +68,15 @@
     <div class="full-width">
       <h4>Land Use of Parcel(s) under Notice of Intent</h4>
     </div>
-    <div class="subheading2 grid-1">
-      Describe all agriculture that currently takes place on the parcel(s).
-    </div>
+    <div class="subheading2 grid-1">Describe all agriculture that currently takes place on the parcel(s).</div>
     <div class="grid-double">
       {{ submission.parcelsAgricultureDescription }}
     </div>
-    <div class="subheading2 grid-1">
-      Describe all agricultural improvements made to the parcel(s).
-    </div>
+    <div class="subheading2 grid-1">Describe all agricultural improvements made to the parcel(s).</div>
     <div class="grid-double">
       {{ submission.parcelsAgricultureImprovementDescription }}
     </div>
-    <div class="subheading2 grid-1">
-      Describe all other uses that currently take place on the parcel(s).
-    </div>
+    <div class="subheading2 grid-1">Describe all other uses that currently take place on the parcel(s).</div>
     <div class="grid-double">
       {{ submission.parcelsNonAgricultureUseDescription }}
     </div>
@@ -184,7 +178,7 @@
           {{ file.description }}
         </div>
         <div class="grid-3">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
       </ng-container>
       <div *ngIf="otherFiles.length === 0" class="full-width">No optional attachments</div>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.ts
@@ -47,8 +47,8 @@ export class NoticeOfIntentDetailsComponent implements OnInit, OnChanges, OnDest
     window.location.href = `${environment.portalUrl}/alcs/notice-of-intent/${this.fileNumber}/edit/${step}`;
   }
 
-  async openFile(uuid: string) {
-    await this.noiDocumentService.download(uuid, '');
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    await this.noiDocumentService.download(file.uuid, file.fileName);
   }
 
   private async loadDocuments() {

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.html
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.html
@@ -18,7 +18,7 @@
           <app-no-data *ngIf="!transferee.organizationName"></app-no-data>
         </div>
         <div>
-          <span *ngIf="transferee.phoneNumber">{{ transferee.phoneNumber | mask : '(000) 000-0000' }}</span>
+          <span *ngIf="transferee.phoneNumber">{{ transferee.phoneNumber | mask: '(000) 000-0000' }}</span>
         </div>
         <div>{{ transferee.email }}</div>
       </ng-container>
@@ -76,7 +76,7 @@
     <div class="subheading2 grid-1">Upload Terms of the SRW</div>
     <div class="grid-double">
       <div *ngFor="let document of srwTerms">
-        <a (click)="openFile(document.uuid)">
+        <a (click)="openFile(document)">
           {{ document.fileName }}
         </a>
       </div>
@@ -91,7 +91,7 @@
       <div class="subheading2">Control Number</div>
       <ng-container *ngFor="let document of surveyPlans">
         <div>
-          <a (click)="openFile(document.uuid)">
+          <a (click)="openFile(document)">
             {{ document.fileName }}
           </a>
         </div>
@@ -115,7 +115,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div>
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <div>
           {{ file.type?.label }}

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.ts
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.ts
@@ -42,8 +42,8 @@ export class NotificationDetailsComponent implements OnInit, OnChanges, OnDestro
     this.$destroy.complete();
   }
 
-  async openFile(uuid: string) {
-    await this.notificationDocumentService.download(uuid, '');
+  async openFile(file: NotificationDocumentDto) {
+    await this.notificationDocumentService.download(file.uuid, file.fileName);
   }
 
   private async loadDocuments() {
@@ -53,7 +53,7 @@ export class NotificationDetailsComponent implements OnInit, OnChanges, OnDestro
     this.otherFiles = documents.filter(
       (document) =>
         document.type &&
-        [DOCUMENT_TYPE.PHOTOGRAPH, DOCUMENT_TYPE.OTHER, DOCUMENT_TYPE.PROFESSIONAL_REPORT].includes(document.type.code)
+        [DOCUMENT_TYPE.PHOTOGRAPH, DOCUMENT_TYPE.OTHER, DOCUMENT_TYPE.PROFESSIONAL_REPORT].includes(document.type.code),
     );
     this.files = documents;
   }

--- a/alcs-frontend/src/app/services/application/application-document/application-document.service.ts
+++ b/alcs-frontend/src/app/services/application/application-document/application-document.service.ts
@@ -14,7 +14,10 @@ import { ApplicationDocumentDto, CreateDocumentDto, UpdateDocumentDto } from './
 export class ApplicationDocumentService {
   private url = `${environment.apiUrl}/application-document`;
 
-  constructor(private http: HttpClient, private toastService: ToastService) {}
+  constructor(
+    private http: HttpClient,
+    private toastService: ToastService,
+  ) {}
 
   async listAll(fileNumber: string) {
     return firstValueFrom(this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}`));
@@ -22,7 +25,7 @@ export class ApplicationDocumentService {
 
   async listByVisibility(fileNumber: string, visibilityFlags: string[]) {
     return firstValueFrom(
-      this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}/${visibilityFlags.join()}`)
+      this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}/${visibilityFlags.join()}`),
     );
   }
 
@@ -55,13 +58,13 @@ export class ApplicationDocumentService {
 
   async getReviewDocuments(fileNumber: string) {
     return firstValueFrom(
-      this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}/reviewDocuments`)
+      this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}/reviewDocuments`),
     );
   }
 
   async getApplicantDocuments(fileNumber: string) {
     return firstValueFrom(
-      this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}/applicantDocuments`)
+      this.http.get<ApplicationDocumentDto[]>(`${this.url}/application/${fileNumber}/applicantDocuments`),
     );
   }
 

--- a/alcs-frontend/src/app/services/application/application-submission/application-submission.service.ts
+++ b/alcs-frontend/src/app/services/application/application-submission/application-submission.service.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { openFileInline } from '../../../shared/utils/file';
 import { ToastService } from '../../toast/toast.service';
 import { ApplicationSubmissionDto, CovenantTransfereeDto, UpdateApplicationSubmissionDto } from '../application.dto';
 

--- a/alcs-frontend/src/app/shared/utils/file.ts
+++ b/alcs-frontend/src/app/shared/utils/file.ts
@@ -11,14 +11,21 @@ export const downloadFileFromUrl = (url: string, fileName: string) => {
 };
 
 export const openFileInline = (url: string, fileName: string) => {
-  const downloadLink = document.createElement('a');
-  downloadLink.href = url;
-  downloadLink.download = fileName;
-  downloadLink.target = '_blank';
-  if (window.webkitURL == null) {
-    downloadLink.onclick = (event: MouseEvent) => document.body.removeChild(<Node>event.target);
-    downloadLink.style.display = 'none';
-    document.body.appendChild(downloadLink);
+  const newWindow = window.open('', '_blank');
+  if (newWindow) {
+    newWindow.document.title = fileName;
+
+    const object = newWindow.document.createElement('object');
+    object.data = url;
+    object.style.borderWidth = '0';
+    object.style.width = '100%';
+    object.style.height = '100%';
+
+    newWindow.document.body.appendChild(object);
+    newWindow.document.body.style.backgroundColor = 'rgb(14, 14, 14)';
+    newWindow.document.body.style.height = '100%';
+    newWindow.document.body.style.width = '100%';
+    newWindow.document.body.style.margin = '0';
+    newWindow.document.body.style.overflow = 'hidden';
   }
-  downloadLink.click();
 };

--- a/portal-frontend/src/app/features/applications/application-details/application-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/application-details.component.html
@@ -91,7 +91,7 @@
           *ngIf="authorizationLetters.length === 0"
         ></app-no-data>
         <div *ngFor="let file of authorizationLetters">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <app-validation-error *ngIf="!needsAuthorizationLetter && authorizationLetters.length > 0">
           Authorization letters are not required, please remove them
@@ -320,7 +320,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div class="grid-1">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <div class="grid-2">
           {{ file.type?.label }}

--- a/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
@@ -13,7 +13,7 @@ import { LocalGovernmentDto } from '../../../services/code/code.dto';
 import { CodeService } from '../../../services/code/code.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-application-details',
@@ -86,7 +86,7 @@ export class ApplicationDetailsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
@@ -13,7 +13,7 @@ import { LocalGovernmentDto } from '../../../services/code/code.dto';
 import { CodeService } from '../../../services/code/code.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-application-details',
@@ -86,7 +86,7 @@ export class ApplicationDetailsComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/application-details.component.ts
@@ -83,10 +83,10 @@ export class ApplicationDetailsComponent implements OnInit, OnDestroy {
     this.$destroy.complete();
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.html
@@ -43,7 +43,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -61,7 +61,7 @@
     <div class="subheading2 grid-1">Draft Covenant</div>
     <div class="grid-double">
       <div *ngFor="let file of srwTerms">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>

--- a/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
@@ -52,10 +52,10 @@ export class CoveDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
@@ -6,7 +6,7 @@ import { ApplicationSubmissionDetailedDto } from '../../../../services/applicati
 import { CovenantTransfereeDto } from '../../../../services/covenant-transferee/covenant-transferee.dto';
 import { CovenantTransfereeService } from '../../../../services/covenant-transferee/covenant-transferee.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-cove-details',
@@ -55,7 +55,7 @@ export class CoveDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/cove-details/cove-details.component.ts
@@ -6,7 +6,7 @@ import { ApplicationSubmissionDetailedDto } from '../../../../services/applicati
 import { CovenantTransfereeDto } from '../../../../services/covenant-transferee/covenant-transferee.dto';
 import { CovenantTransfereeService } from '../../../../services/covenant-transferee/covenant-transferee.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-cove-details',
@@ -55,7 +55,7 @@ export class CoveDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.html
@@ -37,7 +37,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -46,7 +46,7 @@
   <div class="subheading2 grid-1">Notice of Public Hearing (Advertisement)</div>
   <div class="grid-double">
     <div *ngFor="let file of noticeOfPublicHearing">
-      <a (click)="openFile(file.uuid)">
+      <a (click)="openFile(file)">
         {{ file.fileName }}
       </a>
     </div>
@@ -56,7 +56,7 @@
   <div class="subheading2 grid-1">Proof of Signage</div>
   <div class="grid-double">
     <div *ngFor="let file of proofOfSignage">
-      <a (click)="openFile(file.uuid)">
+      <a (click)="openFile(file)">
         {{ file.fileName }}
       </a>
     </div>
@@ -66,7 +66,7 @@
   <div class="subheading2 grid-1">Report of Public Hearing</div>
   <div class="grid-double">
     <div *ngFor="let file of reportOfPublicHearing">
-      <a (click)="openFile(file.uuid)">
+      <a (click)="openFile(file)">
         {{ file.fileName }}
       </a>
     </div>

--- a/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentService } from '../../../../services/application-doc
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-excl-details',
@@ -55,7 +55,7 @@ export class ExclDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
@@ -52,10 +52,10 @@ export class ExclDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/excl-details/excl-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentService } from '../../../../services/application-doc
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-excl-details',
@@ -55,7 +55,7 @@ export class ExclDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.html
@@ -27,7 +27,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -52,7 +52,7 @@
     <div class="subheading2 grid-1">Notice of Public Hearing (Advertisement)</div>
     <div class="grid-double">
       <div *ngFor="let file of noticeOfPublicHearing">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>
@@ -62,7 +62,7 @@
     <div class="subheading2 grid-1">Proof of Signage</div>
     <div class="grid-double">
       <div *ngFor="let file of proofOfSignage">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>
@@ -72,7 +72,7 @@
     <div class="subheading2 grid-1">Report of Public Hearing</div>
     <div class="grid-double">
       <div *ngFor="let file of reportOfPublicHearing">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>

--- a/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
@@ -6,7 +6,7 @@ import { ApplicationSubmissionDetailedDto } from '../../../../services/applicati
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { AuthenticationService } from '../../../../services/authentication/authentication.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-incl-details',
@@ -75,7 +75,7 @@ export class InclDetailsComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
@@ -6,7 +6,7 @@ import { ApplicationSubmissionDetailedDto } from '../../../../services/applicati
 import { ApplicationDocumentDto } from '../../../../services/application-document/application-document.dto';
 import { AuthenticationService } from '../../../../services/authentication/authentication.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-incl-details',
@@ -75,7 +75,7 @@ export class InclDetailsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/incl-details/incl-details.component.ts
@@ -72,10 +72,10 @@ export class InclDetailsComponent implements OnInit, OnDestroy {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.html
@@ -143,7 +143,7 @@
 
     <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
     <div class="grid-double">
-      <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+      <a *ngFor="let map of proposalMap" (click)="openFile(map)">
         {{ map.fileName }}
       </a>
       <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-naru-details[applicationSubmission]',
@@ -45,7 +45,7 @@ export class NaruDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-naru-details[applicationSubmission]',
@@ -45,7 +45,7 @@ export class NaruDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/naru-details/naru-details.component.ts
@@ -42,10 +42,10 @@ export class NaruDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.html
@@ -22,7 +22,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-nfu-details[applicationSubmission]',
@@ -37,7 +37,7 @@ export class NfuDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
@@ -34,10 +34,10 @@ export class NfuDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/nfu-details/nfu-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-nfu-details[applicationSubmission]',
@@ -37,7 +37,7 @@ export class NfuDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.html
@@ -94,7 +94,7 @@
       <div *ngIf="showCertificateOfTitle" class="subheading2 grid-1">Certificate Of Title</div>
       <div *ngIf="showCertificateOfTitle" class="grid-double">
         <div *ngIf="parcel.certificateOfTitle">
-          <a (click)="onOpenFile(parcel.certificateOfTitle.uuid)">{{ parcel.certificateOfTitle.fileName }}</a>
+          <a (click)="onOpenFile(parcel.certificateOfTitle)">{{ parcel.certificateOfTitle.fileName }}</a>
         </div>
         <app-no-data
           [showRequired]="showErrors && !!parcel.validation?.isCertificateRequired"
@@ -110,16 +110,12 @@
             {{ parcel.owners[0].firstName }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].firstName"></app-no-data>
           </div>
-          <div class="subheading2 grid-1">
-            Last Name
-          </div>
+          <div class="subheading2 grid-1">Last Name</div>
           <div class="grid-double">
             {{ parcel.owners[0].lastName }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].lastName"></app-no-data>
           </div>
-          <div class="subheading2 grid-1">
-            Ministry or Department
-          </div>
+          <div class="subheading2 grid-1">Ministry or Department</div>
           <div class="grid-double">
             {{ parcel.owners[0].organizationName }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].organizationName"></app-no-data>
@@ -134,9 +130,7 @@
             {{ parcel.owners[0].email }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].email"></app-no-data>
           </div>
-          <div class="subheading2 grid-1">
-            Crown Type
-          </div>
+          <div class="subheading2 grid-1">Crown Type</div>
           <div class="grid-double">
             {{ parcel.owners[0].crownLandOwnerType === 'provincial' ? 'Provincial Crown' : '' }}
             {{ parcel.owners[0].crownLandOwnerType === 'federal' ? 'Federal Crown' : '' }}
@@ -146,17 +140,12 @@
         <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0]"></app-no-data>
       </ng-container>
 
-      <div
-        class="full-width owner-information"
-        *ngIf="parcel.ownershipTypeCode !== PARCEL_OWNERSHIP_TYPES.CROWN"
-      >
+      <div class="full-width owner-information" *ngIf="parcel.ownershipTypeCode !== PARCEL_OWNERSHIP_TYPES.CROWN">
         <div class="subheading2">Land Owner(s)</div>
         <div class="subheading2">Organization</div>
         <div class="subheading2">Phone</div>
         <div class="subheading2">Email</div>
-        <div class="subheading2">
-          Corporate Summary
-        </div>
+        <div class="subheading2">Corporate Summary</div>
         <ng-container *ngFor="let owner of parcel.owners">
           <div>{{ owner.displayName }}</div>
           <div>
@@ -166,7 +155,7 @@
           <div>{{ owner.phoneNumber ?? '' | mask : '(000) 000-0000' }}</div>
           <div>{{ owner.email }}</div>
           <div>
-            <a *ngIf="owner.corporateSummary" (click)="onOpenFile(owner.corporateSummary.uuid)">{{
+            <a *ngIf="owner.corporateSummary" (click)="onOpenFile(owner.corporateSummary)">{{
               owner.corporateSummary.fileName
             }}</a>
             <div class="no-data" *ngIf="!owner.corporateSummary">

--- a/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
@@ -13,7 +13,7 @@ import { ApplicationParcelService } from '../../../../services/application-parce
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { BaseCodeDto } from '../../../../shared/dto/base.dto';
 import { formatBooleanToYesNoString } from '../../../../shared/utils/boolean-helper';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 export class ApplicationParcelBasicValidation {
   // indicates general validity check state, including owner related information
@@ -101,7 +101,7 @@ export class ParcelComponent {
   async onOpenFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
@@ -13,7 +13,7 @@ import { ApplicationParcelService } from '../../../../services/application-parce
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { BaseCodeDto } from '../../../../shared/dto/base.dto';
 import { formatBooleanToYesNoString } from '../../../../shared/utils/boolean-helper';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 export class ApplicationParcelBasicValidation {
   // indicates general validity check state, including owner related information
@@ -101,7 +101,7 @@ export class ParcelComponent {
   async onOpenFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/parcel/parcel.component.ts
@@ -98,10 +98,10 @@ export class ParcelComponent {
     }
   }
 
-  async onOpenFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async onOpenFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.html
@@ -209,7 +209,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -217,7 +217,7 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="crossSections.length === 0"></app-no-data>
@@ -225,7 +225,7 @@
 
   <div class="subheading2 grid-1">Reclamation Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of reclamationPlans" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="reclamationPlans.length === 0"></app-no-data>
@@ -257,7 +257,7 @@
 
   <div *ngIf="_applicationSubmission.soilHasSubmittedNotice" class="subheading2 grid-1">Notice of Work</div>
   <div *ngIf="_applicationSubmission.soilHasSubmittedNotice" class="grid-double multiple-documents">
-    <a *ngFor="let file of noticeOfWork" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of noticeOfWork" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="noticeOfWork.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[applicationSubmission]',
@@ -51,7 +51,7 @@ export class PfrsDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
@@ -48,10 +48,10 @@ export class PfrsDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pfrs-details/pfrs-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[applicationSubmission]',
@@ -51,7 +51,7 @@ export class PfrsDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.html
@@ -133,7 +133,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -141,7 +141,7 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="crossSections.length === 0"></app-no-data>
@@ -149,7 +149,7 @@
 
   <div class="subheading2 grid-1">Reclamation Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of reclamationPlans" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="reclamationPlans.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
@@ -46,10 +46,10 @@ export class PofoDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[applicationSubmission]',
@@ -49,7 +49,7 @@ export class PofoDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/pofo-details/pofo-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[applicationSubmission]',
@@ -49,7 +49,7 @@ export class PofoDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.html
@@ -125,7 +125,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -133,7 +133,7 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="crossSections.length === 0"></app-no-data>
@@ -141,7 +141,7 @@
 
   <div class="subheading2 grid-1">Reclamation Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of reclamationPlans" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="reclamationPlans.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[applicationSubmission]',
@@ -49,7 +49,7 @@ export class RosoDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[applicationSubmission]',
@@ -49,7 +49,7 @@ export class RosoDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/roso-details/roso-details.component.ts
@@ -46,10 +46,10 @@ export class RosoDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.html
@@ -42,7 +42,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -61,7 +61,7 @@
     <div class="subheading2 grid-1">Proof of Homesite Severance Qualification</div>
     <div class="grid-double">
       <div *ngFor="let file of homesiteDocuments">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>

--- a/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
@@ -5,7 +5,7 @@ import { ApplicationDocumentService } from '../../../../services/application-doc
 import { ApplicationParcelService } from '../../../../services/application-parcel/application-parcel.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-subd-details[applicationSubmission]',
@@ -59,7 +59,7 @@ export class SubdDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
@@ -5,7 +5,7 @@ import { ApplicationDocumentService } from '../../../../services/application-doc
 import { ApplicationParcelService } from '../../../../services/application-parcel/application-parcel.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-subd-details[applicationSubmission]',
@@ -59,7 +59,7 @@ export class SubdDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/subd-details/subd-details.component.ts
@@ -56,10 +56,10 @@ export class SubdDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.html
@@ -40,14 +40,14 @@
   </div>
   <div class="subheading2 grid-1">Proof of Serving Notice</div>
   <div class="grid-double">
-    <a *ngFor="let notice of servingNotice" (click)="openFile(notice.uuid)">
+    <a *ngFor="let notice of servingNotice" (click)="openFile(notice)">
       {{ notice.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="servingNotice.length === 0"></app-no-data>
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-tur-details[applicationSubmission]',
@@ -46,7 +46,7 @@ export class TurDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
@@ -43,10 +43,10 @@ export class TurDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/applications/application-details/tur-details/tur-details.component.ts
@@ -4,7 +4,7 @@ import { ApplicationDocumentDto } from '../../../../services/application-documen
 import { ApplicationDocumentService } from '../../../../services/application-document/application-document.service';
 import { ApplicationSubmissionDetailedDto } from '../../../../services/application-submission/application-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-tur-details[applicationSubmission]',
@@ -46,7 +46,7 @@ export class TurDetailsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
@@ -9,7 +9,7 @@ import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { RemoveFileConfirmationDialogComponent } from '../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { StepComponent } from './step.partial';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -86,7 +86,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
@@ -83,10 +83,10 @@ export abstract class FilesStepComponent extends StepComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/files-step.partial.ts
@@ -9,7 +9,7 @@ import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { RemoveFileConfirmationDialogComponent } from '../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { StepComponent } from './step.partial';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -86,7 +86,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/applications/edit-submission/other-attachments/other-attachments.component.html
+++ b/portal-frontend/src/app/features/applications/edit-submission/other-attachments/other-attachments.component.html
@@ -73,7 +73,7 @@
         <ng-container matColumnDef="fileName">
           <th mat-header-cell *matHeaderCellDef>File Name</th>
           <td mat-cell *matCellDef="let element">
-            <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+            <a (click)="openFile(element)">{{ element.fileName }}</a>
           </td>
         </ng-container>
 

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
@@ -21,7 +21,7 @@ import { OwnerDialogComponent } from '../../../../../shared/owner-dialogs/owner-
 import { formatBooleanToString } from '../../../../../shared/utils/boolean-helper';
 import { RemoveFileConfirmationDialogComponent } from '../../../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
-import { openFileIframe } from '../../../../../shared/utils/file';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -346,7 +346,7 @@ export class ParcelEntryComponent implements OnInit {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
@@ -343,10 +343,10 @@ export class ParcelEntryComponent implements OnInit {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/parcel-details/parcel-entry/parcel-entry.component.ts
@@ -21,7 +21,7 @@ import { OwnerDialogComponent } from '../../../../../shared/owner-dialogs/owner-
 import { formatBooleanToString } from '../../../../../shared/utils/boolean-helper';
 import { RemoveFileConfirmationDialogComponent } from '../../../alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -346,7 +346,7 @@ export class ParcelEntryComponent implements OnInit {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
@@ -125,10 +125,10 @@ export class ReviewAttachmentsComponent implements OnInit, OnDestroy {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
@@ -7,7 +7,7 @@ import { ToastService } from '../../../../services/toast/toast.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
 import { FileHandle } from '../../../../shared/file-drag-drop/drag-drop.directive';
 import { ReviewApplicationFngSteps, ReviewApplicationSteps } from '../review-submission.component';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-attachments',
@@ -128,7 +128,7 @@ export class ReviewAttachmentsComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-attachments/review-attachments.component.ts
@@ -7,7 +7,7 @@ import { ToastService } from '../../../../services/toast/toast.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
 import { FileHandle } from '../../../../shared/file-drag-drop/drag-drop.directive';
 import { ReviewApplicationFngSteps, ReviewApplicationSteps } from '../review-submission.component';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-attachments',
@@ -128,7 +128,7 @@ export class ReviewAttachmentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.html
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.html
@@ -46,7 +46,7 @@
         <div>
           <div class="subheading2">Phone Number</div>
           <div>
-            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000'  }}
+            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000' }}
             <app-no-data [showRequired]="showErrors" *ngIf="!_applicationReview.phoneNumber"></app-no-data>
           </div>
         </div>
@@ -85,7 +85,7 @@
         <div>
           <div class="subheading2">Resolution Document</div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of resolutionDocument">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of resolutionDocument">{{
               document.fileName
             }}</a>
             <app-no-data [showRequired]="showErrors" *ngIf="resolutionDocument.length === 0"></app-no-data>
@@ -95,7 +95,7 @@
           <div class="subheading2">Other Attachments (optional):</div>
           <div>
             <div class="document" *ngFor="let document of otherAttachments">
-              <a class="link" (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+              <a class="link" (click)="openFile(document)">{{ document.fileName }}</a>
             </div>
             <app-no-data *ngIf="otherAttachments.length === 0"></app-no-data>
           </div>
@@ -153,7 +153,7 @@
         <div>
           <div class="subheading2">Phone Number</div>
           <div>
-            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000'  }}
+            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000' }}
             <app-no-data [showRequired]="showErrors" *ngIf="!_applicationReview.phoneNumber"></app-no-data>
           </div>
         </div>
@@ -196,7 +196,7 @@
         <div>
           <div class="subheading2">Resolution Document</div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of resolutionDocument">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of resolutionDocument">{{
               document.fileName
             }}</a>
             <app-no-data [showRequired]="showErrors" *ngIf="resolutionDocument.length === 0"></app-no-data>
@@ -206,7 +206,7 @@
           <div class="subheading2">Other Attachments (optional):</div>
           <div>
             <div *ngFor="let document of otherAttachments">
-              <a class="link" (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+              <a class="link" (click)="openFile(document)">{{ document.fileName }}</a>
             </div>
             <app-no-data *ngIf="otherAttachments.length === 0"></app-no-data>
           </div>

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
@@ -16,7 +16,7 @@ import { MOBILE_BREAKPOINT } from '../../../../shared/utils/breakpoints';
 import { ReviewApplicationFngSteps } from '../review-submission.component';
 import { ToastService } from '../../../../services/toast/toast.service';
 import { SubmitConfirmationDialogComponent } from '../submit-confirmation-dialog/submit-confirmation-dialog.component';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-submit-fng[stepper]',
@@ -124,7 +124,7 @@ export class ReviewSubmitFngComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
@@ -121,10 +121,10 @@ export class ReviewSubmitFngComponent implements OnInit, OnDestroy {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit-fng/review-submit-fng.component.ts
@@ -16,7 +16,7 @@ import { MOBILE_BREAKPOINT } from '../../../../shared/utils/breakpoints';
 import { ReviewApplicationFngSteps } from '../review-submission.component';
 import { ToastService } from '../../../../services/toast/toast.service';
 import { SubmitConfirmationDialogComponent } from '../submit-confirmation-dialog/submit-confirmation-dialog.component';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-submit-fng[stepper]',
@@ -124,7 +124,7 @@ export class ReviewSubmitFngComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.html
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.html
@@ -46,7 +46,7 @@
         <div>
           <div class="subheading2">Phone Number</div>
           <div>
-            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000'  }}
+            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000' }}
             <app-no-data [showRequired]="showErrors" *ngIf="!_applicationReview.phoneNumber"></app-no-data>
           </div>
         </div>
@@ -215,7 +215,7 @@
         <div *ngIf="_applicationReview.isOCPDesignation || _applicationReview.isSubjectToZoning">
           <div class="subheading2">Resolution Document</div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of resolutionDocument">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of resolutionDocument">{{
               document.fileName
             }}</a>
             <app-no-data [showRequired]="showErrors" *ngIf="resolutionDocument.length === 0"></app-no-data>
@@ -226,7 +226,7 @@
             Staff Report <span *ngIf="_applicationReview.isAuthorized === false">(optional)</span>
           </div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of staffReport">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of staffReport">{{
               document.fileName
             }}</a>
             <app-no-data
@@ -239,7 +239,7 @@
           <div class="subheading2">Other Attachments (optional):</div>
           <div>
             <div class="document" *ngFor="let document of otherAttachments">
-              <a class="link" (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+              <a class="link" (click)="openFile(document)">{{ document.fileName }}</a>
             </div>
             <app-no-data *ngIf="otherAttachments.length === 0"></app-no-data>
           </div>
@@ -297,7 +297,7 @@
         <div>
           <div class="subheading2">Phone Number</div>
           <div>
-            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000'  }}
+            {{ _applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000' }}
             <app-no-data [showRequired]="showErrors" *ngIf="!_applicationReview.phoneNumber"></app-no-data>
           </div>
         </div>
@@ -467,7 +467,7 @@
         <div *ngIf="_applicationReview.isOCPDesignation || _applicationReview.isSubjectToZoning">
           <div class="subheading2">Resolution Document</div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of resolutionDocument">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of resolutionDocument">{{
               document.fileName
             }}</a>
             <app-no-data [showRequired]="showErrors" *ngIf="resolutionDocument.length === 0"></app-no-data>
@@ -478,7 +478,7 @@
             Staff Report <span *ngIf="_applicationReview.isAuthorized === false">(optional)</span>
           </div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of staffReport">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of staffReport">{{
               document.fileName
             }}</a>
             <app-no-data
@@ -491,7 +491,7 @@
           <div class="subheading2">Other Attachments (optional):</div>
           <div>
             <div class="document" *ngFor="let document of otherAttachments">
-              <a class="link" (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+              <a class="link" (click)="openFile(document)">{{ document.fileName }}</a>
             </div>
             <app-no-data *ngIf="otherAttachments.length === 0"></app-no-data>
           </div>

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
@@ -129,10 +129,10 @@ export class ReviewSubmitComponent implements OnInit, OnDestroy {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
@@ -15,7 +15,7 @@ import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.
 import { MOBILE_BREAKPOINT } from '../../../../shared/utils/breakpoints';
 import { ReviewApplicationSteps } from '../review-submission.component';
 import { SubmitConfirmationDialogComponent } from '../submit-confirmation-dialog/submit-confirmation-dialog.component';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-submit[stepper]',
@@ -132,7 +132,7 @@ export class ReviewSubmitComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-submit/review-submit.component.ts
@@ -15,7 +15,7 @@ import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.
 import { MOBILE_BREAKPOINT } from '../../../../shared/utils/breakpoints';
 import { ReviewApplicationSteps } from '../review-submission.component';
 import { SubmitConfirmationDialogComponent } from '../submit-confirmation-dialog/submit-confirmation-dialog.component';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-review-submit[stepper]',
@@ -132,7 +132,7 @@ export class ReviewSubmitComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.html
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.html
@@ -20,21 +20,21 @@
       <div class="subheading2">Decision Document</div>
       <div class="document split" *ngFor="let document of decision.documents">
         <div>
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
           &nbsp;({{ document.fileSize | filesize }})
         </div>
-        <button class="center" mat-button (click)="openFile(document.uuid)">
+        <button class="center" mat-button (click)="openFile(document)">
           <mat-icon>file_download</mat-icon>
           Download
         </button>
       </div>
       <div class="document responsive left" *ngFor="let document of decision.documents">
         <div class="document-name">
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
         </div>
         <div class="split">
           <div>{{ document.fileSize | filesize }}</div>
-          <button class="center" mat-button (click)="openFile(document.uuid)">
+          <button class="center" mat-button (click)="openFile(document)">
             <mat-icon>file_download</mat-icon>
             Download
           </button>

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
@@ -26,7 +26,7 @@ export class DecisionsComponent implements OnInit, OnChanges {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-decisions[fileNumber]',
@@ -24,7 +25,7 @@ export class DecisionsComponent implements OnInit, OnChanges {
   async openFile(uuid: string) {
     const res = await this.decisionService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/decisions/decisions.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/cor
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
 import { openFileWindow } from '../../../../../shared/utils/file';
+import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
   selector: 'app-decisions[fileNumber]',
@@ -22,10 +23,10 @@ export class DecisionsComponent implements OnInit, OnChanges {
     this.loadDecisions();
   }
 
-  async openFile(uuid: string) {
-    const res = await this.decisionService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.html
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.html
@@ -1,43 +1,43 @@
 <h4>Application Documents</h4>
-<div class='table-container'>
-  <table mat-table [dataSource]='dataSource' matSort class='mat-elevation-z3 documents'>
-    <ng-container matColumnDef='type'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by type'>Type</th>
-      <td mat-cell *matCellDef='let element'>
+<div class="table-container">
+  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z3 documents">
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by type">Type</th>
+      <td mat-cell *matCellDef="let element">
         {{ element.type?.label }}
       </td>
     </ng-container>
 
-    <ng-container matColumnDef='fileName'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by name'>Document Name</th>
-      <td mat-cell *matCellDef='let element'>
-        <a (click)='openFile(element.uuid)'>{{ element.fileName }}</a>
+    <ng-container matColumnDef="fileName">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
+      <td mat-cell *matCellDef="let element">
+        <a (click)="openFile(element)">{{ element.fileName }}</a>
       </td>
     </ng-container>
 
-    <ng-container matColumnDef='source'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by source'>Source</th>
-      <td mat-cell *matCellDef='let element'>{{ element.source }}</td>
+    <ng-container matColumnDef="source">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by source">Source</th>
+      <td mat-cell *matCellDef="let element">{{ element.source }}</td>
     </ng-container>
 
-    <ng-container matColumnDef='uploadedAt'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by date'>Upload Date</th>
-      <td mat-cell *matCellDef='let element'>{{ element.uploadedAt | date }}</td>
+    <ng-container matColumnDef="uploadedAt">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by date">Upload Date</th>
+      <td mat-cell *matCellDef="let element">{{ element.uploadedAt | date }}</td>
     </ng-container>
 
-    <ng-container matColumnDef='actions'>
+    <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef>Actions</th>
-      <td mat-cell *matCellDef='let element'>
-        <button mat-icon-button (click)='downloadFile(element.uuid)'>
+      <td mat-cell *matCellDef="let element">
+        <button mat-icon-button (click)="downloadFile(element.uuid)">
           <mat-icon>file_download</mat-icon>
         </button>
       </td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef='displayedColumns'></tr>
-    <tr mat-row *matRowDef='let row; columns: displayedColumns'></tr>
-    <tr class='mat-row' *matNoDataRow>
-      <td class='text-center' colspan='6'>Documents will be visible here once provided by ALC</td>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="text-center" colspan="6">Documents will be visible here once provided by ALC</td>
     </tr>
   </table>
 </div>

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 import { ApplicationDocumentService } from '../../../../../services/application-document/application-document.service';
-import { openFileIframe } from '../../../../../shared/utils/file';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -33,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 import { ApplicationDocumentService } from '../../../../../services/application-document/application-document.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -33,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -30,10 +30,10 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
     });
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.html
+++ b/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.html
@@ -13,20 +13,29 @@
       >
         Download PDF
       </button>
-      <button mat-flat-button color="primary" *ngIf="application && application.canEdit"
-        [routerLink]="'/application/' + application.fileNumber + '/edit'">
+      <button
+        mat-flat-button
+        color="primary"
+        *ngIf="application && application.canEdit"
+        [routerLink]="'/application/' + application.fileNumber + '/edit'"
+      >
         <div class="continue-button-content">
           <span>Continue Application</span>
           <mat-icon>keyboard_double_arrow_right</mat-icon>
         </div>
       </button>
-      <button (click)="onReview(application.fileNumber)"  mat-flat-button color="primary"
+      <button
+        (click)="onReview(application.fileNumber)"
+        mat-flat-button
+        color="primary"
         *ngIf="
-          application && application.canReview && (
-          application.status.code === SUBMISSION_STATUS.IN_REVIEW_BY_LG ||
-          application.status.code === SUBMISSION_STATUS.RETURNED_TO_LG ||
-          application.status.code === SUBMISSION_STATUS.SUBMITTED_TO_LG)
-        ">
+          application &&
+          application.canReview &&
+          (application.status.code === SUBMISSION_STATUS.IN_REVIEW_BY_LG ||
+            application.status.code === SUBMISSION_STATUS.RETURNED_TO_LG ||
+            application.status.code === SUBMISSION_STATUS.SUBMITTED_TO_LG)
+        "
+      >
         <div class="continue-button-content">
           <span
             *ngIf="
@@ -51,8 +60,8 @@
   <div
     *ngIf="
       (application.status.code === SUBMISSION_STATUS.IN_PROGRESS ||
-      application.status.code === SUBMISSION_STATUS.WRONG_GOV ||
-      application.status.code === SUBMISSION_STATUS.INCOMPLETE) &&
+        application.status.code === SUBMISSION_STATUS.WRONG_GOV ||
+        application.status.code === SUBMISSION_STATUS.INCOMPLETE) &&
       !isTurOrCov
     "
     class="warning"
@@ -62,8 +71,8 @@
   <div
     *ngIf="
       (application.status.code === SUBMISSION_STATUS.IN_PROGRESS ||
-      application.status.code === SUBMISSION_STATUS.WRONG_GOV ||
-      application.status.code === SUBMISSION_STATUS.INCOMPLETE ) &&
+        application.status.code === SUBMISSION_STATUS.WRONG_GOV ||
+        application.status.code === SUBMISSION_STATUS.INCOMPLETE) &&
       isTurOrCov
     "
     class="warning"
@@ -128,7 +137,7 @@
         <div>
           <div class="subheading2">Phone Number</div>
           <div>
-            {{ applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000'  }}
+            {{ applicationReview.phoneNumber ?? '' | mask : '(000) 000-0000' }}
             <app-no-data *ngIf="!applicationReview.phoneNumber"></app-no-data>
           </div>
         </div>
@@ -275,7 +284,7 @@
         >
           <div class="subheading2">Resolution Document</div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of resolutionDocument">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of resolutionDocument">{{
               document.fileName
             }}</a>
           </div>
@@ -286,7 +295,7 @@
             Staff Report <span *ngIf="applicationReview.isAuthorized === false">(optional)</span>
           </div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of staffReport">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of staffReport">{{
               document.fileName
             }}</a>
           </div>
@@ -296,7 +305,7 @@
           <div class="subheading2">Other Attachments (optional):</div>
           <div>
             <div class="document" *ngFor="let document of governmentOtherAttachments">
-              <a class="link" (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+              <a class="link" (click)="openFile(document)">{{ document.fileName }}</a>
             </div>
             <app-no-data *ngIf="governmentOtherAttachments.length === 0"></app-no-data>
           </div>

--- a/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
@@ -107,10 +107,10 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../services/application-submission/application-submission.dto';
 import { PdfGenerationService } from '../../../../services/pdf-generation/pdf-generation.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-lfng-review',
@@ -110,7 +110,7 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/lfng-review/lfng-review.component.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../services/application-submission/application-submission.dto';
 import { PdfGenerationService } from '../../../../services/pdf-generation/pdf-generation.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-lfng-review',
@@ -110,7 +110,7 @@ export class LfngReviewComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
@@ -12,7 +12,7 @@ import {
 import { ApplicationSubmissionService } from '../../../services/application-submission/application-submission.service';
 import { PdfGenerationService } from '../../../services/pdf-generation/pdf-generation.service';
 import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/confirmation-dialog.service';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-view-application-submission',
@@ -97,7 +97,7 @@ export class ViewApplicationSubmissionComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.applicationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
@@ -94,10 +94,10 @@ export class ViewApplicationSubmissionComponent implements OnInit, OnDestroy {
     this.isLoading = false;
   }
 
-  async openFile(uuid: string) {
-    const res = await this.applicationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
+++ b/portal-frontend/src/app/features/applications/view-submission/view-application-submission.component.ts
@@ -12,7 +12,7 @@ import {
 import { ApplicationSubmissionService } from '../../../services/application-submission/application-submission.service';
 import { PdfGenerationService } from '../../../services/pdf-generation/pdf-generation.service';
 import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/confirmation-dialog.service';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-view-application-submission',
@@ -97,7 +97,7 @@ export class ViewApplicationSubmissionComponent implements OnInit, OnDestroy {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.applicationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
@@ -9,7 +9,7 @@ import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { RemoveFileConfirmationDialogComponent } from '../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { StepComponent } from './step.partial';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -86,7 +86,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
@@ -9,7 +9,7 @@ import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { RemoveFileConfirmationDialogComponent } from '../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { StepComponent } from './step.partial';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -86,7 +86,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/files-step.partial.ts
@@ -83,10 +83,10 @@ export abstract class FilesStepComponent extends StepComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/other-attachments/other-attachments.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/other-attachments/other-attachments.component.html
@@ -73,7 +73,7 @@
         <ng-container matColumnDef="fileName">
           <th mat-header-cell *matHeaderCellDef>File Name</th>
           <td mat-cell *matCellDef="let element">
-            <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+            <a (click)="openFile(element)">{{ element.fileName }}</a>
           </td>
         </ng-container>
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/other-attachments/other-attachments.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/other-attachments/other-attachments.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { Router } from '@angular/router';
 import { takeUntil } from 'rxjs';
 import { CodeService } from '../../../../services/code/code.service';
 import {
@@ -9,7 +8,6 @@ import {
   NoticeOfIntentDocumentUpdateDto,
 } from '../../../../services/notice-of-intent-document/notice-of-intent-document.dto';
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
-import { NoticeOfIntentSubmissionService } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.service';
 import { ToastService } from '../../../../services/toast/toast.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE, DocumentTypeDto } from '../../../../shared/dto/document.dto';
 import { FileHandle } from '../../../../shared/file-drag-drop/drag-drop.directive';
@@ -37,8 +35,6 @@ export class OtherAttachmentsComponent extends FilesStepComponent implements OnI
   showVirusError = false;
 
   constructor(
-    private router: Router,
-    private noticeOfIntentSubmissionService: NoticeOfIntentSubmissionService,
     private codeService: CodeService,
     noticeOfIntentDocumentService: NoticeOfIntentDocumentService,
     dialog: MatDialog,

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
@@ -341,10 +341,10 @@ export class ParcelEntryComponent implements OnInit {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
@@ -20,7 +20,7 @@ import { formatBooleanToString } from '../../../../../shared/utils/boolean-helpe
 import { RemoveFileConfirmationDialogComponent } from '../../../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
 import { scrollToElement } from '../../../../../shared/utils/scroll-helper';
-import { openFileIframe } from '../../../../../shared/utils/file';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -344,7 +344,7 @@ export class ParcelEntryComponent implements OnInit {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/parcels/parcel-entry/parcel-entry.component.ts
@@ -20,7 +20,7 @@ import { formatBooleanToString } from '../../../../../shared/utils/boolean-helpe
 import { RemoveFileConfirmationDialogComponent } from '../../../../applications/alcs-edit-submission/remove-file-confirmation-dialog/remove-file-confirmation-dialog.component';
 import { ParcelEntryConfirmationDialogComponent } from './parcel-entry-confirmation-dialog/parcel-entry-confirmation-dialog.component';
 import { scrollToElement } from '../../../../../shared/utils/scroll-helper';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 export interface ParcelEntryFormData {
   uuid: string;
@@ -344,7 +344,7 @@ export class ParcelEntryComponent implements OnInit {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.html
@@ -84,7 +84,7 @@
 
     <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of buildingPlans" (click)="openFile(file.uuid)">
+      <a *ngFor="let file of buildingPlans" (click)="openFile(file)">
         {{ file.fileName }}
       </a>
       <app-no-data [showRequired]="showErrors" *ngIf="buildingPlans.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
@@ -8,7 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../edit-submission/additional-information/additional-information.component';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -103,7 +103,7 @@ export class AdditionalInformationComponent {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
@@ -100,10 +100,10 @@ export class AdditionalInformationComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/additional-information/additional-information.component.ts
@@ -8,7 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../edit-submission/additional-information/additional-information.component';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -103,7 +103,7 @@ export class AdditionalInformationComponent {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.html
@@ -42,7 +42,7 @@
     </div>
     <div class="subheading2 grid-1">Phone</div>
     <div class="grid-double">
-      {{ primaryContact?.phoneNumber ?? '' | mask : '(000) 000-0000'  }}
+      {{ primaryContact?.phoneNumber ?? '' | mask : '(000) 000-0000' }}
       <app-no-data [showRequired]="showErrors" *ngIf="!primaryContact?.phoneNumber"></app-no-data>
       <app-validation-error *ngIf="!(primaryContact?.phoneNumber || '' | phoneValid)"
         >Invalid Format</app-validation-error
@@ -62,7 +62,7 @@
           *ngIf="authorizationLetters.length === 0"
         ></app-no-data>
         <div *ngFor="let file of authorizationLetters">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <app-validation-error *ngIf="!needsAuthorizationLetter && authorizationLetters.length > 0">
           Authorization letters are not required, please remove them
@@ -215,7 +215,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div class="grid-1">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <div class="grid-2">
           {{ file.type?.label }}

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
@@ -10,7 +10,7 @@ import { NoticeOfIntentParcelService } from '../../../services/notice-of-intent-
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-noi-details',
@@ -85,7 +85,7 @@ export class NoticeOfIntentDetailsComponent implements OnInit, OnDestroy {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
@@ -82,10 +82,10 @@ export class NoticeOfIntentDetailsComponent implements OnInit, OnDestroy {
     this.$destroy.complete();
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.ts
@@ -10,7 +10,7 @@ import { NoticeOfIntentParcelService } from '../../../services/notice-of-intent-
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-noi-details',
@@ -85,7 +85,7 @@ export class NoticeOfIntentDetailsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.html
@@ -94,7 +94,7 @@
       <div class="subheading2 grid-1">Certificate Of Title</div>
       <div class="grid-double">
         <div *ngIf="parcel.certificateOfTitle">
-          <a (click)="onOpenFile(parcel.certificateOfTitle.uuid)">{{ parcel.certificateOfTitle.fileName }}</a>
+          <a (click)="onOpenFile(parcel.certificateOfTitle)">{{ parcel.certificateOfTitle.fileName }}</a>
         </div>
         <app-no-data
           [showRequired]="showErrors && !!parcel.validation?.isCertificateRequired"
@@ -110,16 +110,12 @@
             {{ parcel.owners[0].firstName }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].firstName"></app-no-data>
           </div>
-          <div class="subheading2 grid-1">
-            Last Name
-          </div>
+          <div class="subheading2 grid-1">Last Name</div>
           <div class="grid-double">
             {{ parcel.owners[0].lastName }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].lastName"></app-no-data>
           </div>
-          <div class="subheading2 grid-1">
-            Ministry or Department
-          </div>
+          <div class="subheading2 grid-1">Ministry or Department</div>
           <div class="grid-double">
             {{ parcel.owners[0].organizationName }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].organizationName"></app-no-data>
@@ -134,9 +130,7 @@
             {{ parcel.owners[0].email }}
             <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0].email"></app-no-data>
           </div>
-          <div class="subheading2 grid-1">
-            Crown Type
-          </div>
+          <div class="subheading2 grid-1">Crown Type</div>
           <div class="grid-double">
             {{ parcel.owners[0].crownLandOwnerType === 'provincial' ? 'Provincial Crown' : '' }}
             {{ parcel.owners[0].crownLandOwnerType === 'federal' ? 'Federal Crown' : '' }}
@@ -146,17 +140,12 @@
         <app-no-data [showRequired]="showErrors" *ngIf="!parcel.owners[0]"></app-no-data>
       </ng-container>
 
-      <div
-        class="full-width owner-information"
-        *ngIf="parcel.ownershipTypeCode !== PARCEL_OWNERSHIP_TYPES.CROWN"
-      >
+      <div class="full-width owner-information" *ngIf="parcel.ownershipTypeCode !== PARCEL_OWNERSHIP_TYPES.CROWN">
         <div class="subheading2">Land Owner(s)</div>
         <div class="subheading2">Organization</div>
         <div class="subheading2">Phone</div>
         <div class="subheading2">Email</div>
-        <div class="subheading2">
-          Corporate Summary
-        </div>
+        <div class="subheading2">Corporate Summary</div>
         <ng-container *ngFor="let owner of parcel.owners">
           <div>{{ owner.displayName }}</div>
           <div>
@@ -166,7 +155,7 @@
           <div>{{ owner.phoneNumber ?? '' | mask : '(000) 000-0000' }}</div>
           <div>{{ owner.email }}</div>
           <div>
-            <a *ngIf="owner.corporateSummary" (click)="onOpenFile(owner.corporateSummary.uuid)">{{
+            <a *ngIf="owner.corporateSummary" (click)="onOpenFile(owner.corporateSummary)">{{
               owner.corporateSummary.fileName
             }}</a>
             <app-no-data [showRequired]="false" *ngIf="!owner.corporateSummary"></app-no-data>

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
@@ -14,7 +14,7 @@ import { NoticeOfIntentParcelService } from '../../../../services/notice-of-inte
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { BaseCodeDto } from '../../../../shared/dto/base.dto';
 import { formatBooleanToYesNoString } from '../../../../shared/utils/boolean-helper';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 export class NoticeOfIntentParcelBasicValidation {
   // indicates general validity check state, including owner related information
@@ -100,7 +100,7 @@ export class ParcelComponent {
   async onOpenFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
@@ -14,7 +14,7 @@ import { NoticeOfIntentParcelService } from '../../../../services/notice-of-inte
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { BaseCodeDto } from '../../../../shared/dto/base.dto';
 import { formatBooleanToYesNoString } from '../../../../shared/utils/boolean-helper';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 export class NoticeOfIntentParcelBasicValidation {
   // indicates general validity check state, including owner related information
@@ -100,7 +100,7 @@ export class ParcelComponent {
   async onOpenFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/parcel/parcel.component.ts
@@ -97,10 +97,10 @@ export class ParcelComponent {
     }
   }
 
-  async onOpenFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async onOpenFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.html
@@ -171,7 +171,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -197,7 +197,7 @@
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double">
       <div *ngFor="let file of crossSections">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>
@@ -207,7 +207,7 @@
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double">
       <div *ngFor="let file of reclamationPlans">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>
@@ -230,7 +230,7 @@
       <div class="subheading2 grid-1">Notice of Work</div>
       <div class="grid-double">
         <div *ngFor="let file of noticeOfWorks">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <app-no-data [showRequired]="showErrors" *ngIf="noticeOfWorks.length === 0"></app-no-data>
       </div>

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
@@ -48,10 +48,10 @@ export class PfrsDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
@@ -4,7 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[noiSubmission]',
@@ -51,7 +51,7 @@ export class PfrsDetailsComponent {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pfrs-details/pfrs-details.component.ts
@@ -4,7 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[noiSubmission]',
@@ -51,7 +51,7 @@ export class PfrsDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.html
@@ -107,7 +107,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -125,7 +125,7 @@
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double">
       <div *ngFor="let file of crossSections">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>
@@ -135,7 +135,7 @@
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double">
       <div *ngFor="let file of reclamationPlans">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
       </div>

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
@@ -4,7 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[noiSubmission]',
@@ -51,7 +51,7 @@ export class PofoDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
@@ -4,7 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[noiSubmission]',
@@ -51,7 +51,7 @@ export class PofoDetailsComponent {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/pofo-details/pofo-details.component.ts
@@ -48,10 +48,10 @@ export class PofoDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.html
@@ -106,7 +106,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="proposalMap.length === 0"></app-no-data>
@@ -123,7 +123,7 @@
   <ng-container *ngIf="_noiSubmission?.soilIsExtractionOrMining">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+      <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>
       <app-no-data [showRequired]="showErrors" *ngIf="crossSections.length === 0"></app-no-data>
@@ -131,7 +131,7 @@
 
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of reclamationPlans" (click)="openFile(file.uuid)">
+      <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
         {{ file.fileName }}
       </a>
       <app-no-data [showRequired]="showErrors" *ngIf="reclamationPlans.length === 0"></app-no-data>
@@ -150,7 +150,7 @@
     <ng-container *ngIf="_noiSubmission.soilHasSubmittedNotice">
       <div class="subheading2 grid-1">Notice of Work</div>
       <div class="grid-double multiple-documents">
-        <a *ngFor="let file of noticeOfWorks" (click)="openFile(file.uuid)">
+        <a *ngFor="let file of noticeOfWorks" (click)="openFile(file)">
           {{ file.fileName }}
         </a>
         <app-no-data [showRequired]="showErrors" *ngIf="noticeOfWorks.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
@@ -4,7 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[noiSubmission]',
@@ -51,7 +51,7 @@ export class RosoDetailsComponent {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
@@ -4,7 +4,7 @@ import { NoticeOfIntentDocumentDto } from '../../../../services/notice-of-intent
 import { NoticeOfIntentDocumentService } from '../../../../services/notice-of-intent-document/notice-of-intent-document.service';
 import { NoticeOfIntentSubmissionDetailedDto } from '../../../../services/notice-of-intent-submission/notice-of-intent-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[noiSubmission]',
@@ -51,7 +51,7 @@ export class RosoDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/roso-details/roso-details.component.ts
@@ -48,10 +48,10 @@ export class RosoDetailsComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.html
@@ -20,21 +20,21 @@
       <div class="subheading2">Decision Document</div>
       <div class="document split" *ngFor="let document of decision.documents">
         <div>
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
           &nbsp;({{ document.fileSize | filesize }})
         </div>
-        <button class="center" mat-button (click)="openFile(document.uuid)">
+        <button class="center" mat-button (click)="openFile(document)">
           <mat-icon>file_download</mat-icon>
           Download
         </button>
       </div>
       <div class="document responsive left" *ngFor="let document of decision.documents">
         <div class="document-name">
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
         </div>
         <div class="split">
           <div>{{ document.fileSize | filesize }}</div>
-          <button class="center" mat-button (click)="openFile(document.uuid)">
+          <button class="center" mat-button (click)="openFile(document)">
             <mat-icon>file_download</mat-icon>
             Download
           </button>

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/cor
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
 import { openFileWindow } from '../../../../../shared/utils/file';
+import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
   selector: 'app-decisions[fileNumber]',
@@ -22,10 +23,10 @@ export class DecisionsComponent implements OnInit, OnChanges {
     this.loadDecisions();
   }
 
-  async openFile(uuid: string) {
-    const res = await this.decisionService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
@@ -26,7 +26,7 @@ export class DecisionsComponent implements OnInit, OnChanges {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/decisions/decisions.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-decisions[fileNumber]',
@@ -24,7 +25,7 @@ export class DecisionsComponent implements OnInit, OnChanges {
   async openFile(uuid: string) {
     const res = await this.decisionService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.html
@@ -11,7 +11,7 @@
     <ng-container matColumnDef="fileName">
       <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
       <td mat-cell *matCellDef="let element">
-        <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+        <a (click)="openFile(element)">{{ element.fileName }}</a>
       </td>
     </ng-container>
 

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -30,10 +30,10 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
     });
   }
 
-  async openFile(uuid: string) {
-    const res = await this.noticeOfIntentDocumentService.openFile(uuid);
+  async openFile(file: NoticeOfIntentDocumentDto) {
+    const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { NoticeOfIntentDocumentDto } from '../../../../../services/notice-of-intent-document/notice-of-intent-document.dto';
 import { NoticeOfIntentDocumentService } from '../../../../../services/notice-of-intent-document/notice-of-intent-document.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -33,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(file: NoticeOfIntentDocumentDto) {
     const res = await this.noticeOfIntentDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { NoticeOfIntentDocumentDto } from '../../../../../services/notice-of-intent-document/notice-of-intent-document.dto';
 import { NoticeOfIntentDocumentService } from '../../../../../services/notice-of-intent-document/notice-of-intent-document.service';
-import { openFileIframe } from '../../../../../shared/utils/file';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -33,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.noticeOfIntentDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
@@ -9,7 +9,7 @@ import { ToastService } from '../../../services/toast/toast.service';
 import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { StepComponent } from './step.partial';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -72,7 +72,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
@@ -9,7 +9,7 @@ import { ToastService } from '../../../services/toast/toast.service';
 import { DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { FileHandle } from '../../../shared/file-drag-drop/drag-drop.directive';
 import { StepComponent } from './step.partial';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-file-step',
@@ -72,7 +72,7 @@ export abstract class FilesStepComponent extends StepComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/files-step.partial.ts
@@ -69,10 +69,10 @@ export abstract class FilesStepComponent extends StepComponent {
     }
   }
 
-  async openFile(uuid: string) {
-    const res = await this.notificationDocumentService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/edit-submission/other-attachments/other-attachments.component.html
+++ b/portal-frontend/src/app/features/notifications/edit-submission/other-attachments/other-attachments.component.html
@@ -16,7 +16,7 @@
         <ng-container matColumnDef="fileName">
           <th mat-header-cell *matHeaderCellDef>File Name</th>
           <td mat-cell *matCellDef="let element">
-            <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+            <a (click)="openFile(element)">{{ element.fileName }}</a>
           </td>
         </ng-container>
 

--- a/portal-frontend/src/app/features/notifications/edit-submission/proposal/proposal.component.html
+++ b/portal-frontend/src/app/features/notifications/edit-submission/proposal/proposal.component.html
@@ -133,7 +133,7 @@
       <ng-container matColumnDef="fileName">
         <th mat-header-cell *matHeaderCellDef>File Name</th>
         <td mat-cell *matCellDef="let element">
-          <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+          <a (click)="openFile(element)">{{ element.fileName }}</a>
         </td>
       </ng-container>
 

--- a/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.html
+++ b/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.html
@@ -23,7 +23,7 @@
           <app-no-data [showRequired]="false" *ngIf="!transferee.organizationName"></app-no-data>
         </div>
         <div>
-          <span *ngIf="transferee.phoneNumber">{{ transferee.phoneNumber | mask: '(000) 000-0000' }}</span>
+          <span *ngIf="transferee.phoneNumber">{{ transferee.phoneNumber | mask : '(000) 000-0000' }}</span>
         </div>
         <div>{{ transferee.email }}</div>
       </ng-container>
@@ -60,7 +60,7 @@
     </div>
     <div class="subheading2 grid-1">Phone</div>
     <div class="grid-double">
-      {{ notificationSubmission.contactPhone ?? '' | mask : '(000) 000-0000'  }}
+      {{ notificationSubmission.contactPhone ?? '' | mask : '(000) 000-0000' }}
       <app-no-data [showRequired]="showErrors" *ngIf="!notificationSubmission.contactPhone"></app-no-data>
       <app-validation-error *ngIf="!(notificationSubmission.contactPhone || '' | phoneValid)"
         >Invalid Format</app-validation-error
@@ -122,7 +122,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div class="grid-1">
-          <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+          <a (click)="openFile(file)">{{ file.fileName }}</a>
         </div>
         <div class="grid-2">
           {{ file.type?.label }}

--- a/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
@@ -8,7 +8,7 @@ import { NotificationDocumentService } from '../../../services/notification-docu
 import { NotificationSubmissionDetailedDto } from '../../../services/notification-submission/notification-submission.dto';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
-import { openFileWindow } from '../../../shared/utils/file';
+import { openFileInline } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-notification-details',
@@ -67,7 +67,7 @@ export class NotificationDetailsComponent implements OnInit, OnDestroy {
   async openFile(file: NotificationDocumentDto) {
     const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
@@ -8,7 +8,7 @@ import { NotificationDocumentService } from '../../../services/notification-docu
 import { NotificationSubmissionDetailedDto } from '../../../services/notification-submission/notification-submission.dto';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/dto/document.dto';
 import { OWNER_TYPE } from '../../../shared/dto/owner.dto';
-import { openFileIframe } from '../../../shared/utils/file';
+import { openFileWindow } from '../../../shared/utils/file';
 
 @Component({
   selector: 'app-notification-details',
@@ -67,7 +67,7 @@ export class NotificationDetailsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.ts
@@ -64,10 +64,10 @@ export class NotificationDetailsComponent implements OnInit, OnDestroy {
     this.$destroy.complete();
   }
 
-  async openFile(uuid: string) {
-    const res = await this.notificationDocumentService.openFile(uuid);
+  async openFile(file: NotificationDocumentDto) {
+    const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.html
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.html
@@ -19,7 +19,7 @@
 
   <div class="subheading2 grid-1">Upload Terms of the SRW</div>
   <div class="grid-double">
-    <a *ngFor="let file of srwTerms" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of srwTerms" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data [showRequired]="showErrors" *ngIf="srwTerms.length === 0"></app-no-data>
@@ -39,7 +39,7 @@
     <div><strong>Control Number</strong></div>
     <ng-container *ngFor="let file of surveyPlans">
       <div>
-        <a (click)="openFile(file.uuid)">{{ file.fileName }}</a>
+        <a (click)="openFile(file)">{{ file.fileName }}</a>
       </div>
       <div>
         {{ file.surveyPlanNumber }}

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
@@ -4,7 +4,7 @@ import { NotificationDocumentDto } from '../../../../services/notification-docum
 import { NotificationDocumentService } from '../../../../services/notification-document/notification-document.service';
 import { NotificationSubmissionDetailedDto } from '../../../../services/notification-submission/notification-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileIframe } from '../../../../shared/utils/file';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-proposal-details[notificationSubmission]',
@@ -40,7 +40,7 @@ export class ProposalDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
@@ -37,10 +37,10 @@ export class ProposalDetailsComponent {
     await this.router.navigateByUrl(`notification/${this._notificationSubmission?.fileNumber}/edit/${step}?errors=t`);
   }
 
-  async openFile(uuid: string) {
-    const res = await this.notificationDocumentService.openFile(uuid);
+  async openFile(file: NotificationDocumentDto) {
+    const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
+++ b/portal-frontend/src/app/features/notifications/notification-details/proposal-details/proposal-details.component.ts
@@ -4,7 +4,7 @@ import { NotificationDocumentDto } from '../../../../services/notification-docum
 import { NotificationDocumentService } from '../../../../services/notification-document/notification-document.service';
 import { NotificationSubmissionDetailedDto } from '../../../../services/notification-submission/notification-submission.dto';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-proposal-details[notificationSubmission]',
@@ -40,7 +40,7 @@ export class ProposalDetailsComponent {
   async openFile(file: NotificationDocumentDto) {
     const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.html
+++ b/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.html
@@ -1,43 +1,43 @@
 <h4>SRW Documents</h4>
-<div class='table-container'>
-  <table mat-table [dataSource]='dataSource' matSort class='mat-elevation-z3 documents'>
-    <ng-container matColumnDef='type'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by type'>Type</th>
-      <td mat-cell *matCellDef='let element'>
+<div class="table-container">
+  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z3 documents">
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by type">Type</th>
+      <td mat-cell *matCellDef="let element">
         {{ element.type?.label }}
       </td>
     </ng-container>
 
-    <ng-container matColumnDef='fileName'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by name'>Document Name</th>
-      <td mat-cell *matCellDef='let element'>
-        <a (click)='openFile(element.uuid)'>{{ element.fileName }}</a>
+    <ng-container matColumnDef="fileName">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
+      <td mat-cell *matCellDef="let element">
+        <a (click)="openFile(element)">{{ element.fileName }}</a>
       </td>
     </ng-container>
 
-    <ng-container matColumnDef='source'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by source'>Source</th>
-      <td mat-cell *matCellDef='let element'>{{ element.source }}</td>
+    <ng-container matColumnDef="source">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by source">Source</th>
+      <td mat-cell *matCellDef="let element">{{ element.source }}</td>
     </ng-container>
 
-    <ng-container matColumnDef='uploadedAt'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by date'>Upload Date</th>
-      <td mat-cell *matCellDef='let element'>{{ element.uploadedAt | date }}</td>
+    <ng-container matColumnDef="uploadedAt">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by date">Upload Date</th>
+      <td mat-cell *matCellDef="let element">{{ element.uploadedAt | date }}</td>
     </ng-container>
 
-    <ng-container matColumnDef='actions'>
+    <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef>Actions</th>
-      <td mat-cell *matCellDef='let element'>
-        <button mat-icon-button (click)='downloadFile(element.uuid)'>
+      <td mat-cell *matCellDef="let element">
+        <button mat-icon-button (click)="downloadFile(element.uuid)">
           <mat-icon>file_download</mat-icon>
         </button>
       </td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef='displayedColumns'></tr>
-    <tr mat-row *matRowDef='let row; columns: displayedColumns'></tr>
-    <tr class='mat-row' *matNoDataRow>
-      <td class='text-center' colspan='6'>Documents will be visible here once provided by ALC</td>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="text-center" colspan="6">Documents will be visible here once provided by ALC</td>
     </tr>
   </table>
 </div>

--- a/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { NotificationDocumentDto } from '../../../../../services/notification-document/notification-document.dto';
 import { NotificationDocumentService } from '../../../../../services/notification-document/notification-document.service';
-import { openFileIframe } from '../../../../../shared/utils/file';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -33,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.notificationDocumentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -4,7 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
 import { NotificationDocumentDto } from '../../../../../services/notification-document/notification-document.dto';
 import { NotificationDocumentService } from '../../../../../services/notification-document/notification-document.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -33,7 +33,7 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(file: NotificationDocumentDto) {
     const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/notifications/view-submission/alc-review/submission-documents/submission-documents.component.ts
@@ -30,10 +30,10 @@ export class SubmissionDocumentsComponent implements OnInit, OnDestroy {
     });
   }
 
-  async openFile(uuid: string) {
-    const res = await this.notificationDocumentService.openFile(uuid);
+  async openFile(file: NotificationDocumentDto) {
+    const res = await this.notificationDocumentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.html
+++ b/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.html
@@ -20,21 +20,21 @@
       <div class="subheading2">Decision Document</div>
       <div class="document split" *ngFor="let document of decision.documents">
         <div>
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
           &nbsp;({{ document.fileSize | filesize }})
         </div>
-        <button class="center" mat-button (click)="openFile(document.uuid)">
+        <button class="center" mat-button (click)="openFile(document)">
           <mat-icon>file_download</mat-icon>
           Download
         </button>
       </div>
       <div class="document responsive left" *ngFor="let document of decision.documents">
         <div class="document-name">
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
         </div>
         <div class="split">
           <div>{{ document.fileSize | filesize }}</div>
-          <button class="center" mat-button (click)="openFile(document.uuid)">
+          <button class="center" mat-button (click)="openFile(document)">
             <mat-icon>file_download</mat-icon>
             Download
           </button>

--- a/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
@@ -17,7 +17,7 @@ export class PublicDecisionsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-public-decisions',
@@ -15,7 +16,7 @@ export class PublicDecisionsComponent {
   async openFile(uuid: string) {
     const res = await this.decisionService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/decisions/decisions.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { ApplicationPortalDecisionDto } from '../../../../../services/application-decision/application-decision.dto';
 import { ApplicationDecisionService } from '../../../../../services/application-decision/application-decision.service';
 import { openFileWindow } from '../../../../../shared/utils/file';
+import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
   selector: 'app-public-decisions',
@@ -13,10 +14,10 @@ export class PublicDecisionsComponent {
 
   constructor(private decisionService: ApplicationDecisionService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.decisionService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.html
+++ b/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.html
@@ -1,43 +1,43 @@
 <h4>Application Documents</h4>
-<div class='table-container'>
-  <table mat-table [dataSource]='dataSource' matSort class='mat-elevation-z3 documents'>
-    <ng-container matColumnDef='type'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by type'>Type</th>
-      <td mat-cell *matCellDef='let element'>
+<div class="table-container">
+  <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z3 documents">
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by type">Type</th>
+      <td mat-cell *matCellDef="let element">
         {{ element.type?.label }}
       </td>
     </ng-container>
 
-    <ng-container matColumnDef='fileName'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by name'>Document Name</th>
-      <td mat-cell *matCellDef='let element'>
-        <a (click)='openFile(element.uuid)'>{{ element.fileName }}</a>
+    <ng-container matColumnDef="fileName">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
+      <td mat-cell *matCellDef="let element">
+        <a (click)="openFile(element)">{{ element.fileName }}</a>
       </td>
     </ng-container>
 
-    <ng-container matColumnDef='source'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by source'>Source</th>
-      <td mat-cell *matCellDef='let element'>{{ element.source }}</td>
+    <ng-container matColumnDef="source">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by source">Source</th>
+      <td mat-cell *matCellDef="let element">{{ element.source }}</td>
     </ng-container>
 
-    <ng-container matColumnDef='uploadedAt'>
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription='Sort by date'>Upload Date</th>
-      <td mat-cell *matCellDef='let element'>{{ element.uploadedAt | date }}</td>
+    <ng-container matColumnDef="uploadedAt">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by date">Upload Date</th>
+      <td mat-cell *matCellDef="let element">{{ element.uploadedAt | date }}</td>
     </ng-container>
 
-    <ng-container matColumnDef='actions'>
+    <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef>Actions</th>
-      <td mat-cell *matCellDef='let element'>
-        <button mat-icon-button (click)='downloadFile(element.uuid)'>
+      <td mat-cell *matCellDef="let element">
+        <button mat-icon-button (click)="downloadFile(element.uuid)">
           <mat-icon>file_download</mat-icon>
         </button>
       </td>
     </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef='displayedColumns'></tr>
-    <tr mat-row *matRowDef='let row; columns: displayedColumns'></tr>
-    <tr class='mat-row' *matNoDataRow>
-      <td class='text-center' colspan='6'>Documents will be visible here once provided by ALC</td>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    <tr class="mat-row" *matNoDataRow>
+      <td class="text-center" colspan="6">Documents will be visible here once provided by ALC</td>
     </tr>
   </table>
 </div>

--- a/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { PublicApplicationSubmissionDto } from '../../../../../services/public/public-application.dto';
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents[applicationSubmission]',
@@ -33,7 +33,7 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { PublicApplicationSubmissionDto } from '../../../../../services/public/public-application.dto';
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents[applicationSubmission]',
@@ -30,9 +31,9 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   }
 
   async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationDownloadFileUrl(this.applicationSubmission.fileNumber, uuid);
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
@@ -30,10 +30,10 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
     this.dataSource = new MatTableDataSource(this.applicationDocuments);
   }
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.html
+++ b/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.html
@@ -145,7 +145,7 @@
         <div>
           <div class="subheading2">Resolution Document</div>
           <div>
-            <a class="link" (click)="openFile(document.uuid)" *ngFor="let document of resolutionDocument">{{
+            <a class="link" (click)="openFile(document)" *ngFor="let document of resolutionDocument">{{
               document.fileName
             }}</a>
           </div>

--- a/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.ts
@@ -30,10 +30,10 @@ export class PublicLfngReviewComponent implements OnInit {
     );
   }
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.ts
@@ -7,6 +7,7 @@ import {
 import { PublicDocumentDto } from '../../../../services/public/public.dto';
 import { PublicService } from '../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-public-lfng-review',
@@ -32,7 +33,7 @@ export class PublicLfngReviewComponent implements OnInit {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.ts
+++ b/portal-frontend/src/app/features/public/application/lfng-review/lfng-review.component.ts
@@ -7,7 +7,7 @@ import {
 import { PublicDocumentDto } from '../../../../services/public/public.dto';
 import { PublicService } from '../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../shared/utils/file';
+import { openFileInline } from '../../../../shared/utils/file';
 
 @Component({
   selector: 'app-public-lfng-review',
@@ -33,7 +33,7 @@ export class PublicLfngReviewComponent implements OnInit {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.html
@@ -34,7 +34,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.ts
@@ -3,6 +3,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto, PublicOwnerDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-cove-details',
@@ -23,6 +24,8 @@ export class CoveDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(uuid, this.applicationSubmission.fileNumber);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileWindow(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.ts
@@ -3,7 +3,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto, PublicOwnerDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-cove-details',
@@ -25,7 +25,7 @@ export class CoveDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/cove-details/cove-details.component.ts
@@ -22,10 +22,10 @@ export class CoveDetailsComponent {
 
   constructor(private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(uuid, this.applicationSubmission.fileNumber);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.html
@@ -34,7 +34,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -43,7 +43,7 @@
   <div class="subheading2 grid-1">Report of Public Hearing</div>
   <div class="grid-double">
     <div *ngFor="let file of reportOfPublicHearing">
-      <a (click)="openFile(file.uuid)">
+      <a (click)="openFile(file)">
         {{ file.fileName }}
       </a>
     </div>

--- a/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-excl-details',
@@ -29,7 +29,7 @@ export class ExclDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.ts
@@ -26,10 +26,10 @@ export class ExclDetailsComponent {
 
   constructor(private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/excl-details/excl-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-excl-details',
@@ -28,7 +29,7 @@ export class ExclDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.html
@@ -27,7 +27,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -48,7 +48,7 @@
     <div class="subheading2 grid-1">Report of Public Hearing</div>
     <div class="grid-double">
       <div *ngFor="let file of reportOfPublicHearing">
-        <a (click)="openFile(file.uuid)">
+        <a (click)="openFile(file)">
           {{ file.fileName }}
         </a>
         <app-no-data *ngIf="reportOfPublicHearing.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-incl-details',
@@ -28,7 +29,7 @@ export class InclDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.ts
@@ -26,10 +26,10 @@ export class InclDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/incl-details/incl-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-incl-details',
@@ -29,7 +29,7 @@ export class InclDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.html
@@ -135,7 +135,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-naru-details[applicationSubmission]',
@@ -23,7 +24,7 @@ export class NaruDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.ts
@@ -21,10 +21,10 @@ export class NaruDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/naru-details/naru-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-naru-details[applicationSubmission]',
@@ -24,7 +24,7 @@ export class NaruDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.html
@@ -22,7 +22,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.ts
@@ -22,10 +22,10 @@ export class NfuDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-nfu-details[applicationSubmission]',
@@ -24,7 +25,7 @@ export class NfuDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/nfu-details/nfu-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-nfu-details[applicationSubmission]',
@@ -25,7 +25,7 @@ export class NfuDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.html
@@ -173,7 +173,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -181,7 +181,7 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data *ngIf="crossSections.length === 0"></app-no-data>
@@ -189,7 +189,7 @@
 
   <div class="subheading2 grid-1">Reclamation Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data *ngIf="crossSections.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[applicationSubmission]',
@@ -26,7 +27,7 @@ export class PfrsDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.ts
@@ -24,10 +24,10 @@ export class PfrsDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[applicationSubmission]',
@@ -27,7 +27,7 @@ export class PfrsDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.html
@@ -51,18 +51,14 @@
     <div>
       {{ applicationSubmission.soilToPlaceMaximumDepth }}
       <span *ngIf="applicationSubmission.soilToPlaceMaximumDepth !== null">m</span>
-      <app-no-data
-        *ngIf="applicationSubmission.soilToPlaceMaximumDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="applicationSubmission.soilToPlaceMaximumDepth === null"></app-no-data>
     </div>
 
     <div class="subheading2">Average Depth</div>
     <div>
       {{ applicationSubmission.soilToPlaceAverageDepth }}
       <span *ngIf="applicationSubmission.soilToPlaceAverageDepth !== null">m</span>
-      <app-no-data
-        *ngIf="applicationSubmission.soilToPlaceAverageDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="applicationSubmission.soilToPlaceAverageDepth === null"></app-no-data>
     </div>
 
     <div></div>
@@ -72,36 +68,28 @@
     <div>
       {{ applicationSubmission.soilAlreadyPlacedVolume }}
       <span *ngIf="applicationSubmission.soilAlreadyPlacedVolume !== null">m<sup>3</sup></span>
-      <app-no-data
-        *ngIf="applicationSubmission.soilAlreadyPlacedVolume === null"
-      ></app-no-data>
+      <app-no-data *ngIf="applicationSubmission.soilAlreadyPlacedVolume === null"></app-no-data>
     </div>
 
     <div class="subheading2">Area</div>
     <div>
       {{ applicationSubmission.soilAlreadyPlacedArea }}
       <span *ngIf="applicationSubmission.soilAlreadyPlacedArea !== null">m<sup>2</sup></span>
-      <app-no-data
-        *ngIf="applicationSubmission.soilAlreadyPlacedArea === null"
-      ></app-no-data>
+      <app-no-data *ngIf="applicationSubmission.soilAlreadyPlacedArea === null"></app-no-data>
     </div>
 
     <div class="subheading2">Maximum Depth</div>
     <div>
       {{ applicationSubmission.soilAlreadyPlacedMaximumDepth }}
       <span *ngIf="applicationSubmission.soilAlreadyPlacedMaximumDepth !== null">m</span>
-      <app-no-data
-        *ngIf="applicationSubmission.soilAlreadyPlacedMaximumDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="applicationSubmission.soilAlreadyPlacedMaximumDepth === null"></app-no-data>
     </div>
 
     <div class="subheading2">Average Depth</div>
     <div>
       {{ applicationSubmission.soilAlreadyPlacedAverageDepth }}
       <span *ngIf="applicationSubmission.soilAlreadyPlacedAverageDepth !== null">m</span>
-      <app-no-data
-        *ngIf="applicationSubmission.soilAlreadyPlacedAverageDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="applicationSubmission.soilAlreadyPlacedAverageDepth === null"></app-no-data>
     </div>
   </div>
 
@@ -127,7 +115,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -135,7 +123,7 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data *ngIf="crossSections.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[applicationSubmission]',
@@ -27,7 +27,7 @@ export class PofoDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[applicationSubmission]',
@@ -26,7 +27,7 @@ export class PofoDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.ts
@@ -24,10 +24,10 @@ export class PofoDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.html
@@ -107,7 +107,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -115,7 +115,7 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double">
-    <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data *ngIf="crossSections.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[applicationSubmission]',
@@ -26,7 +27,7 @@ export class RosoDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[applicationSubmission]',
@@ -27,7 +27,7 @@ export class RosoDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.ts
@@ -24,10 +24,10 @@ export class RosoDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.html
@@ -38,7 +38,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-subd-details[applicationSubmission]',
@@ -24,7 +25,7 @@ export class SubdDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.ts
@@ -22,10 +22,10 @@ export class SubdDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/subd-details/subd-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-subd-details[applicationSubmission]',
@@ -25,7 +25,7 @@ export class SubdDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.html
@@ -33,7 +33,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file.uuid)">
+    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.ts
@@ -21,10 +21,10 @@ export class TurDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.ts
@@ -4,7 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-tur-details[applicationSubmission]',
@@ -24,7 +24,7 @@ export class TurDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.ts
+++ b/portal-frontend/src/app/features/public/application/submission/tur-details/tur-details.component.ts
@@ -4,6 +4,7 @@ import { PublicApplicationSubmissionDto } from '../../../../../services/public/p
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-tur-details[applicationSubmission]',
@@ -23,7 +24,7 @@ export class TurDetailsComponent {
   async openFile(uuid: string) {
     const res = await this.publicService.getApplicationOpenFileUrl(this.applicationSubmission.fileNumber, uuid);
     if (res) {
-      window.open(res?.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.html
@@ -20,21 +20,21 @@
       <div class="subheading2">Decision Document</div>
       <div class="document split" *ngFor="let document of decision.documents">
         <div>
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
           &nbsp;({{ document.fileSize | filesize }})
         </div>
-        <button class="center" mat-button (click)="openFile(document.uuid)">
+        <button class="center" mat-button (click)="openFile(document)">
           <mat-icon>file_download</mat-icon>
           Download
         </button>
       </div>
       <div class="document responsive left" *ngFor="let document of decision.documents">
         <div class="document-name">
-          <a (click)="openFile(document.uuid)">{{ document.fileName }}</a>
+          <a (click)="openFile(document)">{{ document.fileName }}</a>
         </div>
         <div class="split">
           <div>{{ document.fileSize | filesize }}</div>
-          <button class="center" mat-button (click)="openFile(document.uuid)">
+          <button class="center" mat-button (click)="openFile(document)">
             <mat-icon>file_download</mat-icon>
             Download
           </button>

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
@@ -17,7 +17,7 @@ export class PublicDecisionsComponent {
   async openFile(file: ApplicationDocumentDto) {
     const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
 import { openFileWindow } from '../../../../../shared/utils/file';
+import { ApplicationDocumentDto } from '../../../../../services/application-document/application-document.dto';
 
 @Component({
   selector: 'app-public-decisions',
@@ -13,10 +14,10 @@ export class PublicDecisionsComponent {
 
   constructor(private decisionService: NoticeOfIntentDecisionService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.decisionService.openFile(uuid);
+  async openFile(file: ApplicationDocumentDto) {
+    const res = await this.decisionService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/decisions/decisions.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { NoticeOfIntentPortalDecisionDto } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.dto';
 import { NoticeOfIntentDecisionService } from '../../../../../services/notice-of-intent-decision/notice-of-intent-decision.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-public-decisions',
@@ -15,7 +16,7 @@ export class PublicDecisionsComponent {
   async openFile(uuid: string) {
     const res = await this.decisionService.openFile(uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.html
@@ -11,7 +11,7 @@
     <ng-container matColumnDef="fileName">
       <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
       <td mat-cell *matCellDef="let element">
-        <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+        <a (click)="openFile(element)">{{ element.fileName }}</a>
       </td>
     </ng-container>
 

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/public/public-notice-of-intent.dto';
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -31,7 +31,7 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.submission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.ts
@@ -28,10 +28,10 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
     this.dataSource = new MatTableDataSource(this.documents);
   }
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.submission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.submission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/alc-review/submission-documents/submission-documents.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/public/public-notice-of-intent.dto';
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -30,7 +31,7 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.submission.fileNumber, uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/additional-information/additional-information.component.ts
@@ -8,6 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../../../notice-of-intents/edit-submission/additional-information/additional-information.component';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -72,6 +73,8 @@ export class AdditionalInformationComponent implements OnInit {
 
   async openFile(uuid: string) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileWindow(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/additional-information/additional-information.component.ts
@@ -71,10 +71,10 @@ export class AdditionalInformationComponent implements OnInit {
     );
   }
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/additional-information/additional-information.component.ts
@@ -8,7 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../../../notice-of-intents/edit-submission/additional-information/additional-information.component';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -74,7 +74,7 @@ export class AdditionalInformationComponent implements OnInit {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.html
@@ -159,7 +159,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -184,7 +184,7 @@
   <ng-container *ngIf="noiSubmission.soilIsExtractionOrMining || noiSubmission.soilIsAreaWideFilling">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double">
-      <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+      <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="crossSections.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.ts
@@ -24,10 +24,10 @@ export class PfrsDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.ts
@@ -4,6 +4,7 @@ import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/publi
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[noiSubmission]',
@@ -25,6 +26,8 @@ export class PfrsDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileWindow(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.ts
@@ -4,7 +4,7 @@ import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/publi
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pfrs-details[noiSubmission]',
@@ -27,7 +27,7 @@ export class PfrsDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.html
@@ -32,9 +32,7 @@
     <div *ngIf="noiSubmission.soilProjectDuration">
       {{ noiSubmission.soilProjectDuration }}
     </div>
-    <app-no-data
-      *ngIf="!noiSubmission.soilProjectDuration"
-    ></app-no-data>
+    <app-no-data *ngIf="!noiSubmission.soilProjectDuration"></app-no-data>
   </div>
 
   <div *ngIf="noiSubmission" class="full-width soil-table">
@@ -59,18 +57,14 @@
     <div>
       {{ noiSubmission.soilToPlaceMaximumDepth }}
       <span *ngIf="noiSubmission.soilToPlaceMaximumDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilToPlaceMaximumDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilToPlaceMaximumDepth === null"></app-no-data>
     </div>
 
     <div class="subheading2">Average Depth</div>
     <div>
       {{ noiSubmission.soilToPlaceAverageDepth }}
       <span *ngIf="noiSubmission.soilToPlaceAverageDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilToPlaceAverageDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilToPlaceAverageDepth === null"></app-no-data>
     </div>
 
     <div></div>
@@ -80,42 +74,34 @@
     <div>
       {{ noiSubmission.soilAlreadyPlacedVolume }}
       <span *ngIf="noiSubmission.soilAlreadyPlacedVolume !== null">m<sup>3</sup></span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyPlacedVolume === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyPlacedVolume === null"></app-no-data>
     </div>
 
     <div class="subheading2">Area</div>
     <div>
       {{ noiSubmission.soilAlreadyPlacedArea }}
       <span *ngIf="noiSubmission.soilAlreadyPlacedArea !== null">m<sup>2</sup></span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyPlacedArea === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyPlacedArea === null"></app-no-data>
     </div>
 
     <div class="subheading2">Maximum Depth</div>
     <div>
       {{ noiSubmission.soilAlreadyPlacedMaximumDepth }}
       <span *ngIf="noiSubmission.soilAlreadyPlacedMaximumDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyPlacedMaximumDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyPlacedMaximumDepth === null"></app-no-data>
     </div>
 
     <div class="subheading2">Average Depth</div>
     <div>
       {{ noiSubmission.soilAlreadyPlacedAverageDepth }}
       <span *ngIf="noiSubmission.soilAlreadyPlacedAverageDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyPlacedAverageDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyPlacedAverageDepth === null"></app-no-data>
     </div>
   </div>
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -132,7 +118,7 @@
   <ng-container *ngIf="noiSubmission.soilIsAreaWideFilling">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double">
-      <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+      <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="crossSections.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.ts
@@ -4,6 +4,7 @@ import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/publi
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[noiSubmission]',
@@ -25,6 +26,8 @@ export class PofoDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileWindow(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.ts
@@ -24,10 +24,10 @@ export class PofoDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.ts
@@ -4,7 +4,7 @@ import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/publi
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-pofo-details[noiSubmission]',
@@ -27,7 +27,7 @@ export class PofoDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.html
@@ -32,9 +32,7 @@
     <div *ngIf="noiSubmission.soilProjectDuration">
       {{ noiSubmission.soilProjectDuration }}
     </div>
-    <app-no-data
-      *ngIf="!noiSubmission.soilProjectDuration"
-    ></app-no-data>
+    <app-no-data *ngIf="!noiSubmission.soilProjectDuration"></app-no-data>
   </div>
 
   <div class="full-width soil-table">
@@ -59,18 +57,14 @@
     <div>
       {{ noiSubmission.soilToRemoveMaximumDepth }}
       <span *ngIf="noiSubmission.soilToRemoveMaximumDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilToRemoveMaximumDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilToRemoveMaximumDepth === null"></app-no-data>
     </div>
 
     <div class="subheading2">Average Depth</div>
     <div>
       {{ noiSubmission.soilToRemoveAverageDepth }}
       <span *ngIf="noiSubmission.soilToRemoveAverageDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilToRemoveAverageDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilToRemoveAverageDepth === null"></app-no-data>
     </div>
 
     <div></div>
@@ -80,42 +74,34 @@
     <div>
       {{ noiSubmission.soilAlreadyRemovedVolume }}
       <span *ngIf="noiSubmission.soilAlreadyRemovedVolume !== null">m<sup>3</sup></span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyRemovedVolume === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyRemovedVolume === null"></app-no-data>
     </div>
 
     <div class="subheading2">Area</div>
     <div>
       {{ noiSubmission.soilAlreadyRemovedArea }}
       <span *ngIf="noiSubmission.soilAlreadyRemovedArea !== null">m<sup>2</sup></span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyRemovedArea === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyRemovedArea === null"></app-no-data>
     </div>
 
     <div class="subheading2">Maximum Depth</div>
     <div>
       {{ noiSubmission.soilAlreadyRemovedMaximumDepth }}
       <span *ngIf="noiSubmission.soilAlreadyRemovedMaximumDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyRemovedMaximumDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyRemovedMaximumDepth === null"></app-no-data>
     </div>
 
     <div class="subheading2">Average Depth</div>
     <div>
       {{ noiSubmission.soilAlreadyRemovedAverageDepth }}
       <span *ngIf="noiSubmission.soilAlreadyRemovedAverageDepth !== null">m</span>
-      <app-no-data
-        *ngIf="noiSubmission.soilAlreadyRemovedAverageDepth === null"
-      ></app-no-data>
+      <app-no-data *ngIf="noiSubmission.soilAlreadyRemovedAverageDepth === null"></app-no-data>
     </div>
   </div>
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map.uuid)">
+    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -132,7 +118,7 @@
   <ng-container *ngIf="noiSubmission?.soilIsExtractionOrMining">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double">
-      <a *ngFor="let file of crossSections" (click)="openFile(file.uuid)">
+      <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="crossSections.length === 0"></app-no-data>

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.ts
@@ -24,10 +24,10 @@ export class RosoDetailsComponent {
 
   constructor(private router: Router, private publicService: PublicService) {}
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.ts
@@ -4,7 +4,7 @@ import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/publi
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[noiSubmission]',
@@ -27,7 +27,7 @@ export class RosoDetailsComponent {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.ts
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.ts
@@ -4,6 +4,7 @@ import { PublicNoticeOfIntentSubmissionDto } from '../../../../../services/publi
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { DOCUMENT_TYPE } from '../../../../../shared/dto/document.dto';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-roso-details[noiSubmission]',
@@ -25,6 +26,8 @@ export class RosoDetailsComponent {
 
   async openFile(uuid: string) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileWindow(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.html
+++ b/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.html
@@ -11,7 +11,7 @@
     <ng-container matColumnDef="fileName">
       <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
       <td mat-cell *matCellDef="let element">
-        <a (click)="openFile(element.uuid)">{{ element.fileName }}</a>
+        <a (click)="openFile(element)">{{ element.fileName }}</a>
       </td>
     </ng-container>
 

--- a/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { PublicNotificationSubmissionDto } from '../../../../../services/public/public-notification.dto';
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -31,7 +31,7 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNotificationOpenFileUrl(this.submission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.ts
@@ -28,10 +28,10 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
     this.dataSource = new MatTableDataSource(this.documents);
   }
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNotificationOpenFileUrl(this.submission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNotificationOpenFileUrl(this.submission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 

--- a/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/notification/alc-review/submission-documents/submission-documents.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { PublicNotificationSubmissionDto } from '../../../../../services/public/public-notification.dto';
 import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-submission-documents',
@@ -30,7 +31,7 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   async openFile(uuid: string) {
     const res = await this.publicService.getNotificationOpenFileUrl(this.submission.fileNumber, uuid);
     if (res) {
-      window.open(res.url, '_blank');
+      openFileWindow(res);
     }
   }
 

--- a/portal-frontend/src/app/features/public/notification/submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/public/notification/submission/additional-information/additional-information.component.ts
@@ -8,6 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../../../notice-of-intents/edit-submission/additional-information/additional-information.component';
+import { openFileWindow } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -72,6 +73,8 @@ export class AdditionalInformationComponent implements OnInit {
 
   async openFile(uuid: string) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
-    window.open(res?.url, '_blank');
+    if (res) {
+      openFileWindow(res);
+    }
   }
 }

--- a/portal-frontend/src/app/features/public/notification/submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/public/notification/submission/additional-information/additional-information.component.ts
@@ -71,10 +71,10 @@ export class AdditionalInformationComponent implements OnInit {
     );
   }
 
-  async openFile(uuid: string) {
-    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, uuid);
+  async openFile(file: PublicDocumentDto) {
+    const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/features/public/notification/submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/public/notification/submission/additional-information/additional-information.component.ts
@@ -8,7 +8,7 @@ import {
   RESIDENTIAL_STRUCTURE_TYPES,
   STRUCTURE_TYPES,
 } from '../../../../notice-of-intents/edit-submission/additional-information/additional-information.component';
-import { openFileWindow } from '../../../../../shared/utils/file';
+import { openFileInline } from '../../../../../shared/utils/file';
 
 @Component({
   selector: 'app-additional-information',
@@ -74,7 +74,7 @@ export class AdditionalInformationComponent implements OnInit {
   async openFile(file: PublicDocumentDto) {
     const res = await this.publicService.getNoticeOfIntentOpenFileUrl(this.noiSubmission.fileNumber, file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/services/application-decision/application-decision.service.ts
+++ b/portal-frontend/src/app/services/application-decision/application-decision.service.ts
@@ -27,9 +27,7 @@ export class ApplicationDecisionService {
 
   async openFile(documentUuid: string) {
     try {
-      return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${documentUuid}/open`)
-      );
+      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${documentUuid}/open`));
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/application-decision/application-decision.service.ts
+++ b/portal-frontend/src/app/services/application-decision/application-decision.service.ts
@@ -27,7 +27,9 @@ export class ApplicationDecisionService {
 
   async openFile(documentUuid: string) {
     try {
-      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${documentUuid}/open`));
+      return await firstValueFrom(
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${documentUuid}/open`)
+      );
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/application-document/application-document.service.ts
+++ b/portal-frontend/src/app/services/application-document/application-document.service.ts
@@ -51,9 +51,7 @@ export class ApplicationDocumentService {
 
   async openFile(fileUuid: string) {
     try {
-      return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${fileUuid}/open`)
-      );
+      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${fileUuid}/open`));
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/notice-of-intent-decision/notice-of-intent-decision.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-decision/notice-of-intent-decision.service.ts
@@ -27,9 +27,7 @@ export class NoticeOfIntentDecisionService {
 
   async openFile(documentUuid: string) {
     try {
-      return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${documentUuid}/open`)
-      );
+      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${documentUuid}/open`));
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/notice-of-intent-decision/notice-of-intent-decision.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-decision/notice-of-intent-decision.service.ts
@@ -27,7 +27,9 @@ export class NoticeOfIntentDecisionService {
 
   async openFile(documentUuid: string) {
     try {
-      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${documentUuid}/open`));
+      return await firstValueFrom(
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${documentUuid}/open`)
+      );
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-document/notice-of-intent-document.service.ts
@@ -51,9 +51,7 @@ export class NoticeOfIntentDocumentService {
 
   async openFile(fileUuid: string) {
     try {
-      return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${fileUuid}/open`)
-      );
+      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${fileUuid}/open`));
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/notification-document/notification-document.service.ts
+++ b/portal-frontend/src/app/services/notification-document/notification-document.service.ts
@@ -51,9 +51,7 @@ export class NotificationDocumentService {
 
   async openFile(fileUuid: string) {
     try {
-      return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/${fileUuid}/open`)
-      );
+      return await firstValueFrom(this.httpClient.get<{ url: string }>(`${this.serviceUrl}/${fileUuid}/open`));
     } catch (e) {
       console.error(e);
       this.toastService.showErrorToast('Failed to open the document, please try again');

--- a/portal-frontend/src/app/services/public/public.service.ts
+++ b/portal-frontend/src/app/services/public/public.service.ts
@@ -30,7 +30,7 @@ export class PublicService {
   async getApplicationOpenFileUrl(fileId: string, uuid: string) {
     try {
       return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/application/${fileId}/${uuid}/open`)
+        this.httpClient.get<{ url: string }>(`${this.serviceUrl}/application/${fileId}/${uuid}/open`)
       );
     } catch (e) {
       console.error(e);
@@ -66,9 +66,7 @@ export class PublicService {
   async getNoticeOfIntentOpenFileUrl(fileId: string, uuid: string) {
     try {
       return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(
-          `${this.serviceUrl}/notice-of-intent/${fileId}/${uuid}/open`
-        )
+        this.httpClient.get<{ url: string }>(`${this.serviceUrl}/notice-of-intent/${fileId}/${uuid}/open`)
       );
     } catch (e) {
       console.error(e);
@@ -104,7 +102,7 @@ export class PublicService {
   async getNotificationOpenFileUrl(fileId: string, uuid: string) {
     try {
       return await firstValueFrom(
-        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/notification/${fileId}/${uuid}/open`)
+        this.httpClient.get<{ url: string }>(`${this.serviceUrl}/notification/${fileId}/${uuid}/open`)
       );
     } catch (e) {
       console.error(e);

--- a/portal-frontend/src/app/services/public/public.service.ts
+++ b/portal-frontend/src/app/services/public/public.service.ts
@@ -30,7 +30,7 @@ export class PublicService {
   async getApplicationOpenFileUrl(fileId: string, uuid: string) {
     try {
       return await firstValueFrom(
-        this.httpClient.get<{ url: string }>(`${this.serviceUrl}/application/${fileId}/${uuid}/open`)
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/application/${fileId}/${uuid}/open`)
       );
     } catch (e) {
       console.error(e);
@@ -66,7 +66,9 @@ export class PublicService {
   async getNoticeOfIntentOpenFileUrl(fileId: string, uuid: string) {
     try {
       return await firstValueFrom(
-        this.httpClient.get<{ url: string }>(`${this.serviceUrl}/notice-of-intent/${fileId}/${uuid}/open`)
+        this.httpClient.get<{ url: string; fileName: string }>(
+          `${this.serviceUrl}/notice-of-intent/${fileId}/${uuid}/open`
+        )
       );
     } catch (e) {
       console.error(e);
@@ -102,7 +104,7 @@ export class PublicService {
   async getNotificationOpenFileUrl(fileId: string, uuid: string) {
     try {
       return await firstValueFrom(
-        this.httpClient.get<{ url: string }>(`${this.serviceUrl}/notification/${fileId}/${uuid}/open`)
+        this.httpClient.get<{ url: string; fileName: string }>(`${this.serviceUrl}/notification/${fileId}/${uuid}/open`)
       );
     } catch (e) {
       console.error(e);

--- a/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.html
+++ b/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.html
@@ -7,7 +7,7 @@
         error: !!file.errorMessage && !disabled
       }"
     >
-      <a class="file-name" (click)="fileOpened(file.uuid)">{{ file.fileName }}</a>
+      <a class="file-name" (click)="fileOpened(file)">{{ file.fileName }}</a>
       <div class="file-size-cta-container">
         <div class="file-size">
           <span class="file-size-parentheses">(</span>

--- a/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.ts
+++ b/portal-frontend/src/app/shared/file-drag-drop/file-drag-drop.component.ts
@@ -11,7 +11,7 @@ import { FileHandle } from './drag-drop.directive';
 export class FileDragDropComponent implements OnInit {
   @Output() uploadFiles: EventEmitter<FileHandle> = new EventEmitter();
   @Output() deleteFile: EventEmitter<ApplicationDocumentDto> = new EventEmitter();
-  @Output() openFile: EventEmitter<string> = new EventEmitter();
+  @Output() openFile: EventEmitter<ApplicationDocumentDto> = new EventEmitter();
   @Output() beforeFileUploadOpened: EventEmitter<void> = new EventEmitter();
 
   @Input() allowMultiple = false;
@@ -46,8 +46,8 @@ export class FileDragDropComponent implements OnInit {
     this.uploadFiles.emit($event);
   }
 
-  fileOpened(uuid: string) {
-    this.openFile.emit(uuid);
+  fileOpened(file: ApplicationDocumentDto) {
+    this.openFile.emit(file);
   }
 
   onFileUploadClicked() {

--- a/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
@@ -19,7 +19,7 @@ import { ConfirmationDialogService } from '../../confirmation-dialog/confirmatio
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE, DocumentTypeDto } from '../../dto/document.dto';
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { FileHandle } from '../../file-drag-drop/drag-drop.directive';
-import { openFileWindow } from '../../utils/file';
+import { openFileInline } from '../../utils/file';
 
 @Component({
   selector: 'app-owner-dialog',
@@ -241,11 +241,11 @@ export class OwnerDialogComponent {
   async openCorporateSummary() {
     if (this.pendingFile) {
       const fileURL = URL.createObjectURL(this.pendingFile);
-      openFileWindow(fileURL, this.pendingFile.name);
+      openFileInline(fileURL, this.pendingFile.name);
     } else if (this.existingUuid && this.data.existingOwner?.corporateSummary?.uuid) {
       const res = await this.data.documentService.openFile(this.data.existingOwner?.corporateSummary?.uuid);
       if (res) {
-        openFileWindow(res.url, this.data.existingOwner?.corporateSummary?.fileName);
+        openFileInline(res.url, this.data.existingOwner?.corporateSummary?.fileName);
       }
     }
   }

--- a/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
@@ -241,11 +241,11 @@ export class OwnerDialogComponent {
   async openCorporateSummary() {
     if (this.pendingFile) {
       const fileURL = URL.createObjectURL(this.pendingFile);
-      openFileWindow({ url: fileURL, fileName: this.pendingFile.name });
+      openFileWindow(fileURL, this.pendingFile.name);
     } else if (this.existingUuid && this.data.existingOwner?.corporateSummary?.uuid) {
       const res = await this.data.documentService.openFile(this.data.existingOwner?.corporateSummary?.uuid);
       if (res) {
-        openFileWindow(res);
+        openFileWindow(res.url, this.data.existingOwner?.corporateSummary?.fileName);
       }
     }
   }

--- a/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
@@ -19,6 +19,7 @@ import { ConfirmationDialogService } from '../../confirmation-dialog/confirmatio
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE, DocumentTypeDto } from '../../dto/document.dto';
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { FileHandle } from '../../file-drag-drop/drag-drop.directive';
+import { openFileWindow } from '../../utils/file';
 
 @Component({
   selector: 'app-owner-dialog',
@@ -240,11 +241,11 @@ export class OwnerDialogComponent {
   async openCorporateSummary() {
     if (this.pendingFile) {
       const fileURL = URL.createObjectURL(this.pendingFile);
-      window.open(fileURL, '_blank');
+      openFileWindow({ url: fileURL, fileName: this.pendingFile.name });
     } else if (this.existingUuid && this.data.existingOwner?.corporateSummary?.uuid) {
       const res = await this.data.documentService.openFile(this.data.existingOwner?.corporateSummary?.uuid);
       if (res) {
-        window.open(res.url, '_blank');
+        openFileWindow(res);
       }
     }
   }

--- a/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.html
+++ b/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.html
@@ -38,7 +38,7 @@
       <th mat-header-cell *matHeaderCellDef>Corporate Summary</th>
       <td mat-cell *matCellDef="let element">
         <div *ngIf="element.ownershipTypeCode !== PARCEL_OWNERSHIP_TYPES.CROWN">
-          <a *ngIf="element.corporateSummary" (click)="onOpenFile(element.corporateSummary.uuid)">{{
+          <a *ngIf="element.corporateSummary" (click)="onOpenFile(element.corporateSummary)">{{
             element.corporateSummary.fileName
           }}</a>
           <div class="no-data" *ngIf="!element.corporateSummary">

--- a/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
@@ -11,7 +11,7 @@ import { NoticeOfIntentOwnerService } from '../../../services/notice-of-intent-o
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { CrownOwnerDialogComponent } from '../crown-owner-dialog/crown-owner-dialog.component';
 import { OwnerDialogComponent } from '../owner-dialog/owner-dialog.component';
-import { openFileWindow } from '../../utils/file';
+import { openFileInline } from '../../utils/file';
 import { ApplicationDocumentDto } from '../../../services/application-document/application-document.dto';
 import { NoticeOfIntentDocumentDto } from '../../../services/notice-of-intent-document/notice-of-intent-document.dto';
 
@@ -110,7 +110,7 @@ export class ParcelOwnersComponent {
   async onOpenFile(file: ApplicationDocumentDto | NoticeOfIntentDocumentDto) {
     const res = await this.documentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res.url, file.fileName);
+      openFileInline(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
@@ -11,7 +11,7 @@ import { NoticeOfIntentOwnerService } from '../../../services/notice-of-intent-o
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { CrownOwnerDialogComponent } from '../crown-owner-dialog/crown-owner-dialog.component';
 import { OwnerDialogComponent } from '../owner-dialog/owner-dialog.component';
-import { openFileIframe } from '../../utils/file';
+import { openFileWindow } from '../../utils/file';
 
 @Component({
   selector: 'app-parcel-owners[owners][fileId][submissionUuid][ownerService]',
@@ -108,7 +108,7 @@ export class ParcelOwnersComponent {
   async onOpenFile(uuid: string) {
     const res = await this.documentService.openFile(uuid);
     if (res) {
-      openFileIframe(res);
+      openFileWindow(res);
     }
   }
 }

--- a/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/parcel-owners/parcel-owners.component.ts
@@ -12,6 +12,8 @@ import { OWNER_TYPE } from '../../dto/owner.dto';
 import { CrownOwnerDialogComponent } from '../crown-owner-dialog/crown-owner-dialog.component';
 import { OwnerDialogComponent } from '../owner-dialog/owner-dialog.component';
 import { openFileWindow } from '../../utils/file';
+import { ApplicationDocumentDto } from '../../../services/application-document/application-document.dto';
+import { NoticeOfIntentDocumentDto } from '../../../services/notice-of-intent-document/notice-of-intent-document.dto';
 
 @Component({
   selector: 'app-parcel-owners[owners][fileId][submissionUuid][ownerService]',
@@ -105,10 +107,10 @@ export class ParcelOwnersComponent {
     this.onOwnerRemoved.emit(uuid);
   }
 
-  async onOpenFile(uuid: string) {
-    const res = await this.documentService.openFile(uuid);
+  async onOpenFile(file: ApplicationDocumentDto | NoticeOfIntentDocumentDto) {
+    const res = await this.documentService.openFile(file.uuid);
     if (res) {
-      openFileWindow(res);
+      openFileWindow(res.url, file.fileName);
     }
   }
 }

--- a/portal-frontend/src/app/shared/utils/file.ts
+++ b/portal-frontend/src/app/shared/utils/file.ts
@@ -12,7 +12,7 @@ export const openPdfFile = (fileName: string, data: any) => {
   downloadLink.click();
 };
 
-export const openFileWindow = (url: string, fileName: string) => {
+export const openFileInline = (url: string, fileName: string) => {
   const newWindow = window.open('', '_blank');
   if (newWindow) {
     newWindow.document.title = fileName;

--- a/portal-frontend/src/app/shared/utils/file.ts
+++ b/portal-frontend/src/app/shared/utils/file.ts
@@ -12,7 +12,7 @@ export const openPdfFile = (fileName: string, data: any) => {
   downloadLink.click();
 };
 
-export const openFileIframe = (data: { url: string; fileName: string }) => {
+export const openFileWindow = (data: { url: string; fileName: string }) => {
   const newWindow = window.open('', '_blank');
   if (newWindow) {
     newWindow.document.title = data.fileName;
@@ -24,7 +24,7 @@ export const openFileIframe = (data: { url: string; fileName: string }) => {
     object.style.height = '100%';
 
     newWindow.document.body.appendChild(object);
-    newWindow.document.body.style.backgroundColor = 'rgb(82, 86, 89)';
+    newWindow.document.body.style.backgroundColor = 'rgb(14, 14, 14)';
     newWindow.document.body.style.height = '100%';
     newWindow.document.body.style.width = '100%';
     newWindow.document.body.style.margin = '0';

--- a/portal-frontend/src/app/shared/utils/file.ts
+++ b/portal-frontend/src/app/shared/utils/file.ts
@@ -12,13 +12,13 @@ export const openPdfFile = (fileName: string, data: any) => {
   downloadLink.click();
 };
 
-export const openFileWindow = (data: { url: string; fileName: string }) => {
+export const openFileWindow = (url: string, fileName: string) => {
   const newWindow = window.open('', '_blank');
   if (newWindow) {
-    newWindow.document.title = data.fileName;
+    newWindow.document.title = fileName;
 
     const object = newWindow.document.createElement('object');
-    object.data = data.url;
+    object.data = url;
     object.style.borderWidth = '0';
     object.style.width = '100%';
     object.style.height = '100%';

--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
@@ -790,7 +790,7 @@ export class ApplicationDecisionV2Service {
     );
   }
 
-  private async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
+  async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
     const decisionDocument = await this.decisionDocumentRepository.findOne({
       where: {
         uuid: decisionDocumentUuid,

--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
@@ -790,7 +790,7 @@ export class ApplicationDecisionV2Service {
     );
   }
 
-  async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
+  private async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
     const decisionDocument = await this.decisionDocumentRepository.findOne({
       where: {
         uuid: decisionDocumentUuid,

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
@@ -668,7 +668,7 @@ export class NoticeOfIntentDecisionV2Service {
     );
   }
 
-  async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
+  private async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
     const decisionDocument = await this.decisionDocumentRepository.findOne({
       where: {
         uuid: decisionDocumentUuid,

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
@@ -668,7 +668,7 @@ export class NoticeOfIntentDecisionV2Service {
     );
   }
 
-  private async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
+  async getDecisionDocumentOrFail(decisionDocumentUuid: string) {
     const decisionDocument = await this.decisionDocumentRepository.findOne({
       where: {
         uuid: decisionDocumentUuid,

--- a/services/apps/alcs/src/portal/application-document/application-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/application-document/application-document.controller.spec.ts
@@ -138,7 +138,6 @@ describe('ApplicationDocumentController', () => {
 
     expect(appDocumentService.getInlineUrl).toHaveBeenCalledTimes(1);
     expect(res.url).toEqual(fakeUrl);
-    expect(res.fileName).toEqual(mockDocument.document.fileName);
   });
 
   it('should call through for download', async () => {

--- a/services/apps/alcs/src/portal/application-document/application-document.controller.ts
+++ b/services/apps/alcs/src/portal/application-document/application-document.controller.ts
@@ -75,8 +75,7 @@ export class ApplicationDocumentController {
 
     if (canAccessDocument) {
       const url = await this.applicationDocumentService.getInlineUrl(document);
-      const { fileName } = document.document;
-      return { url, fileName };
+      return { url };
     }
 
     throw new NotFoundException('Failed to find document');

--- a/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.spec.ts
@@ -122,7 +122,6 @@ describe('NoticeOfIntentDocumentController', () => {
 
     expect(noiDocumentService.getInlineUrl).toHaveBeenCalledTimes(1);
     expect(res.url).toEqual(fakeUrl);
-    expect(res.fileName).toEqual(mockDocument.document.fileName);
   });
 
   it('should call through for download', async () => {

--- a/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.ts
+++ b/services/apps/alcs/src/portal/notice-of-intent-document/notice-of-intent-document.controller.ts
@@ -80,8 +80,7 @@ export class NoticeOfIntentDocumentController {
     if (canAccessDocument) {
       const url =
         await this.noticeOfIntentDocumentService.getInlineUrl(document);
-      const { fileName } = document.document;
-      return { url, fileName };
+      return { url };
     }
 
     throw new NotFoundException('Failed to find document');

--- a/services/apps/alcs/src/portal/notification-document/notification-document.controller.spec.ts
+++ b/services/apps/alcs/src/portal/notification-document/notification-document.controller.spec.ts
@@ -140,7 +140,6 @@ describe('NotificationDocumentController', () => {
       1,
     );
     expect(res.url).toEqual(fakeUrl);
-    expect(res.fileName).toEqual(mockDocument.document.fileName);
   });
 
   it('should call through for download', async () => {

--- a/services/apps/alcs/src/portal/notification-document/notification-document.controller.ts
+++ b/services/apps/alcs/src/portal/notification-document/notification-document.controller.ts
@@ -78,8 +78,7 @@ export class NotificationDocumentController {
 
     if (canAccessDocument) {
       const url = await this.notificationDocumentService.getInlineUrl(document);
-      const { fileName } = document.document;
-      return { url, fileName };
+      return { url };
     }
 
     throw new NotFoundException('Failed to find document');

--- a/services/apps/alcs/src/portal/public/application/application-decision.controller.ts
+++ b/services/apps/alcs/src/portal/public/application/application-decision.controller.ts
@@ -32,11 +32,7 @@ export class ApplicationDecisionController {
   async openFile(@Param('uuid') fileUuid: string) {
     const url = await this.decisionService.getDownloadForPortal(fileUuid);
 
-    const document =
-      await this.decisionService.getDecisionDocumentOrFail(fileUuid);
-    const { fileName } = document.document;
-
-    return { url, fileName };
+    return { url };
   }
 
   @Get('/:uuid/email')

--- a/services/apps/alcs/src/portal/public/application/application-decision.controller.ts
+++ b/services/apps/alcs/src/portal/public/application/application-decision.controller.ts
@@ -32,7 +32,11 @@ export class ApplicationDecisionController {
   async openFile(@Param('uuid') fileUuid: string) {
     const url = await this.decisionService.getDownloadForPortal(fileUuid);
 
-    return { url };
+    const document =
+      await this.decisionService.getDecisionDocumentOrFail(fileUuid);
+    const { fileName } = document.document;
+
+    return { url, fileName };
   }
 
   @Get('/:uuid/email')

--- a/services/apps/alcs/src/portal/public/application/public-application.service.ts
+++ b/services/apps/alcs/src/portal/public/application/public-application.service.ts
@@ -152,8 +152,7 @@ export class PublicApplicationService {
     }
 
     const url = await this.applicationDocumentService.getInlineUrl(document);
-    const { fileName } = document.document;
 
-    return { url, fileName };
+    return { url };
   }
 }

--- a/services/apps/alcs/src/portal/public/application/public-application.service.ts
+++ b/services/apps/alcs/src/portal/public/application/public-application.service.ts
@@ -152,9 +152,8 @@ export class PublicApplicationService {
     }
 
     const url = await this.applicationDocumentService.getInlineUrl(document);
+    const { fileName } = document.document;
 
-    return {
-      url,
-    };
+    return { url, fileName };
   }
 }

--- a/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.ts
+++ b/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.ts
@@ -32,11 +32,7 @@ export class NoticeOfIntentDecisionController {
   async openFile(@Param('uuid') fileUuid: string) {
     const url = await this.decisionService.getDownloadForPortal(fileUuid);
 
-    const document =
-      await this.decisionService.getDecisionDocumentOrFail(fileUuid);
-    const { fileName } = document.document;
-
-    return { url, fileName };
+    return { url };
   }
 
   @Get('/:uuid/email')

--- a/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.ts
+++ b/services/apps/alcs/src/portal/public/notice-of-intent/notice-of-intent-decision.controller.ts
@@ -32,7 +32,11 @@ export class NoticeOfIntentDecisionController {
   async openFile(@Param('uuid') fileUuid: string) {
     const url = await this.decisionService.getDownloadForPortal(fileUuid);
 
-    return { url };
+    const document =
+      await this.decisionService.getDecisionDocumentOrFail(fileUuid);
+    const { fileName } = document.document;
+
+    return { url, fileName };
   }
 
   @Get('/:uuid/email')

--- a/services/apps/alcs/src/portal/public/notice-of-intent/public-notice-of-intent.service.ts
+++ b/services/apps/alcs/src/portal/public/notice-of-intent/public-notice-of-intent.service.ts
@@ -113,8 +113,7 @@ export class PublicNoticeOfIntentService {
     }
 
     const url = await this.noticeOfIntentDocumentService.getInlineUrl(document);
-    const { fileName } = document.document;
 
-    return { url, fileName };
+    return { url };
   }
 }

--- a/services/apps/alcs/src/portal/public/notice-of-intent/public-notice-of-intent.service.ts
+++ b/services/apps/alcs/src/portal/public/notice-of-intent/public-notice-of-intent.service.ts
@@ -113,9 +113,8 @@ export class PublicNoticeOfIntentService {
     }
 
     const url = await this.noticeOfIntentDocumentService.getInlineUrl(document);
+    const { fileName } = document.document;
 
-    return {
-      url,
-    };
+    return { url, fileName };
   }
 }

--- a/services/apps/alcs/src/portal/public/notification/public-notification.service.ts
+++ b/services/apps/alcs/src/portal/public/notification/public-notification.service.ts
@@ -98,9 +98,8 @@ export class PublicNotificationService {
     }
 
     const url = await this.notificationDocumentService.getInlineUrl(document);
+    const { fileName } = document.document;
 
-    return {
-      url,
-    };
+    return { url, fileName };
   }
 }

--- a/services/apps/alcs/src/portal/public/notification/public-notification.service.ts
+++ b/services/apps/alcs/src/portal/public/notification/public-notification.service.ts
@@ -98,8 +98,7 @@ export class PublicNotificationService {
     }
 
     const url = await this.notificationDocumentService.getInlineUrl(document);
-    const { fileName } = document.document;
 
-    return { url, fileName };
+    return { url };
   }
 }


### PR DESCRIPTION
- Update alcs CSP to allow frame plugin source from document storage
- Update alcs `openFileInline` logic to open file in new window with file name as browser tab title
- Update portal `openFileWindow` to use the same logic as ALCS `openFileInline` and also renamed it
- Update all portal usage of util method
- Revert backend changes done in https://github.com/bcgov/alcs/pull/1495 (already have filename in frontend parent wrapper)