### PR TITLE
Decide reponse sent status and date from events rather than status and last status update

### DIFF
--- a/alcs-frontend/src/app/features/notification/intake/intake.component.ts
+++ b/alcs-frontend/src/app/features/notification/intake/intake.component.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../services/notification/notification.dto';
 import { ToastService } from '../../../services/toast/toast.service';
 import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/confirmation-dialog.service';
+import { NotificationTimelineService } from '../../../services/notification/notification-timeline/notification-timeline.service';
 
 @Component({
   selector: 'app-intake',
@@ -28,9 +29,10 @@ export class IntakeComponent implements OnInit {
   constructor(
     private notificationDetailService: NotificationDetailService,
     private notificationSubmissionService: NotificationSubmissionService,
+    private notificationTimelineService: NotificationTimelineService,
     private localGovernmentService: ApplicationLocalGovernmentService,
     private confirmationDialogService: ConfirmationDialogService,
-    private toastService: ToastService
+    private toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -114,8 +116,11 @@ export class IntakeComponent implements OnInit {
     const submission = await this.notificationSubmissionService.fetchSubmission(fileNumber);
     this.contactEmail = submission.contactEmail;
 
-    this.responseSent = submission.status.code === NOTIFICATION_STATUS.ALC_RESPONSE;
-    this.responseDate = submission.lastStatusUpdate;
+    const events = await this.notificationTimelineService.fetchByFileNumber(fileNumber);
+    const alcResponseEvent = events.find((event) => /alc response sent/i.test(event.htmlText));
+
+    this.responseSent = alcResponseEvent !== undefined;
+    this.responseDate = alcResponseEvent?.startDate ?? null;
   }
 
   async resendResponse() {

--- a/services/apps/alcs/src/alcs/notification/notification-timeline/notification-timeline.controller.ts
+++ b/services/apps/alcs/src/alcs/notification/notification-timeline/notification-timeline.controller.ts
@@ -13,11 +13,13 @@ import { NotificationTimelineService } from './notification-timeline.service';
 @Controller('notification-timeline')
 @UseGuards(RolesGuard)
 export class NotificationTimelineController {
-  constructor(private noiTimelineService: NotificationTimelineService) {}
+  constructor(
+    private notificationTimelineService: NotificationTimelineService,
+  ) {}
 
   @Get('/:fileNumber')
   @UserRoles(...ROLES_ALLOWED_APPLICATIONS)
   async fetchTimelineEvents(@Param('fileNumber') fileNumber: string) {
-    return await this.noiTimelineService.getTimelineEvents(fileNumber);
+    return await this.notificationTimelineService.getTimelineEvents(fileNumber);
   }
 }


### PR DESCRIPTION
- Find status response event in events
- Use existence to set response sent status
- Use date for response date
- Precents cancelled status/date taking precedence
- Fix random typo
