### PR TITLE
Fix not scrolling to spinner on initial search

### DIFF
--- a/portal-frontend/src/app/features/public/search/public-search.component.html
+++ b/portal-frontend/src/app/features/public/search/public-search.component.html
@@ -127,19 +127,18 @@
 
     <div class="button-controls">
       <button type="button" mat-stroked-button color="accent" (click)="onClear()">Clear</button>
-      <button type="submit" mat-flat-button color="primary" [disabled]="formEmpty || !searchForm.valid || isLoading">Search</button>
+      <button type="submit" mat-flat-button color="primary" [disabled]="formEmpty || !searchForm.valid || isLoading">
+        Search
+      </button>
     </div>
   </form>
 
-  <div *ngIf="isLoading && searchResultsHidden" class="center">
-    <mat-spinner></mat-spinner>
-  </div>
-  <div class="search-fields-wrapper search-result-wrapper" *ngIf="!searchResultsHidden">
-    <h3 class="search-title" id="searchResults">Search Results</h3>
-    <div *ngIf="isLoading && !searchResultsHidden" class="center">
+  <div id="searchResultsWrapper" class="search-fields-wrapper search-result-wrapper">
+    <h3 *ngIf="!searchResultsHidden || isLoading" class="search-title">Search Results</h3>
+    <div *ngIf="isLoading" class="center">
       <mat-spinner></mat-spinner>
     </div>
-    <mat-tab-group *ngIf="!isLoading" mat-align-tabs="start" mat-stretch-tabs #searchResultTabs>
+    <mat-tab-group *ngIf="!isLoading && !searchResultsHidden" mat-align-tabs="start" mat-stretch-tabs #searchResultTabs>
       <mat-tab>
         <ng-template mat-tab-label> Applications: {{ applicationTotal }} </ng-template>
         <app-search-list

--- a/portal-frontend/src/app/features/public/search/public-search.component.ts
+++ b/portal-frontend/src/app/features/public/search/public-search.component.ts
@@ -194,7 +194,10 @@ export class PublicSearchComponent implements OnInit, OnDestroy {
     sessionStorage.setItem(SEARCH_SESSION_STORAGE_KEY, searchDto);
 
     this.isLoading = true;
-    scrollToElement({ id: `searchResults`, center: false });
+    // Make sure spinner is rendered before scrolling
+    setTimeout(() => {
+      scrollToElement({ id: `searchResultsWrapper`, center: false });
+    });
     const result = await this.searchService.search(searchParams);
     this.searchResultsHidden = false;
     this.isLoading = false;


### PR DESCRIPTION
- Remove duplicate spinner
- Restructure template conditionals so same spinner is used for both initial load and subsequent loads
- Show 'Search Results' title while loading to be consistent with subsequent loads
- Scroll to now always-visible wrapper div
- Use hack to delay scrolling until spinner is visible
