### PR TITLE
Fix ALC intake email updating even when not confirmed

### DIFF
--- a/alcs-frontend/src/app/features/notification/intake/intake.component.html
+++ b/alcs-frontend/src/app/features/notification/intake/intake.component.html
@@ -44,6 +44,11 @@
   </div>
   <div *ngIf="contactEmail">
     <div class="subheading2">Primary Contact Email</div>
-    <app-inline-text [value]="contactEmail" [required]="true" (save)="updateSubmissionEmail($event)"></app-inline-text>
+    <app-inline-text
+      [updateOnSave]="false"
+      [value]="contactEmail"
+      [required]="true"
+      (save)="updateSubmissionEmail($event)"
+    ></app-inline-text>
   </div>
 </div>

--- a/alcs-frontend/src/app/features/notification/intake/intake.component.ts
+++ b/alcs-frontend/src/app/features/notification/intake/intake.component.ts
@@ -77,6 +77,7 @@ export class IntakeComponent implements OnInit {
             const update = await this.notificationSubmissionService.setContactEmail(email, notification.fileNumber);
             if (update) {
               this.toastService.showSuccessToast('Notification updated');
+              this.contactEmail = email;
             }
           }
         }

--- a/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.ts
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.ts
@@ -15,6 +15,7 @@ import {
   styleUrls: ['./inline-text.component.scss'],
 })
 export class InlineTextComponent implements AfterContentChecked {
+  @Input() updateOnSave: boolean = true;
   @Input() value?: string | undefined;
   @Input() placeholder: string = 'Enter a value';
   @Input() required = false;
@@ -41,7 +42,10 @@ export class InlineTextComponent implements AfterContentChecked {
   confirmEdit() {
     if (this.pendingValue !== this.value) {
       this.save.emit(this.pendingValue?.toString() ?? null);
-      this.value = this.pendingValue;
+
+      if (this.updateOnSave) {
+        this.value = this.pendingValue;
+      }
     }
 
     this.isEditing = false;
@@ -49,6 +53,5 @@ export class InlineTextComponent implements AfterContentChecked {
 
   cancelEdit() {
     this.isEditing = false;
-    this.pendingValue = this.value;
   }
 }


### PR DESCRIPTION
- Add `updateOnSave` option to `inline-text` component
- Set `updateOnSave` to false for intake email
