### PR TITLE
Add Production Routes to API Guard

### DIFF
--- a/services/apps/alcs/src/portal/guards/maintenance.guard.ts
+++ b/services/apps/alcs/src/portal/guards/maintenance.guard.ts
@@ -30,7 +30,9 @@ export class MaintenanceGuard implements CanActivate {
 
     if (
       req.routeOptions.url.startsWith('/portal') ||
-      req.routeOptions.url.startsWith('/public')
+      req.routeOptions.url.startsWith('/public') ||
+      req.routeOptions.url.startsWith('/api/portal') ||
+      req.routeOptions.url.startsWith('/api/public')
     ) {
       const maintenanceMode = await this.configurationRepository.findOne({
         where: {


### PR DESCRIPTION
* Production is set to have /api/ added to all routes breaking how the maintenance guard normally checks.