### PR TITLE
Downgrade NGX Mask to avoid input Issues

### DIFF
--- a/alcs-frontend/package-lock.json
+++ b/alcs-frontend/package-lock.json
@@ -28,7 +28,7 @@
         "jwt-decode": "^4.0.0",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
-        "ngx-mask": "^17.0.7",
+        "ngx-mask": "17.0.4",
         "rxjs": "~7.8.1",
         "source-map-support": "^0.5.21",
         "tslib": "^2.6.2",
@@ -14070,9 +14070,9 @@
       }
     },
     "node_modules/ngx-mask": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-17.0.7.tgz",
-      "integrity": "sha512-pmiCkAIDi5HqWwicHsOThPsJALF3fdMR21aoDJd/boJoEo1HoS34NJNUkqJ11qB2ZBVu5PX8R9KB617OCMkXXQ==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-17.0.4.tgz",
+      "integrity": "sha512-Rfox/zLIcuEc+t8xGvDYL83KYw0P80Ctvx+uy3v/F901XLhzEXKEgPOEFRKNkQu4Eu5Y7SjnX44mGdk/1cqh3w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/alcs-frontend/package.json
+++ b/alcs-frontend/package.json
@@ -34,7 +34,7 @@
     "jwt-decode": "^4.0.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",
-    "ngx-mask": "^17.0.7",
+    "ngx-mask": "17.0.4",
     "rxjs": "~7.8.1",
     "source-map-support": "^0.5.21",
     "tslib": "^2.6.2",

--- a/portal-frontend/package-lock.json
+++ b/portal-frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@bcgov/bc-sans": "^2.1.0",
         "@types/uuid": "^9.0.8",
         "jwt-decode": "^4.0.0",
-        "ngx-mask": "^17.0.7",
+        "ngx-mask": "17.0.4",
         "rxjs": "~7.8.1",
         "source-map-support": "^0.5.21",
         "tslib": "^2.6.2",
@@ -13639,9 +13639,9 @@
       "dev": true
     },
     "node_modules/ngx-mask": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-17.0.7.tgz",
-      "integrity": "sha512-pmiCkAIDi5HqWwicHsOThPsJALF3fdMR21aoDJd/boJoEo1HoS34NJNUkqJ11qB2ZBVu5PX8R9KB617OCMkXXQ==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-17.0.4.tgz",
+      "integrity": "sha512-Rfox/zLIcuEc+t8xGvDYL83KYw0P80Ctvx+uy3v/F901XLhzEXKEgPOEFRKNkQu4Eu5Y7SjnX44mGdk/1cqh3w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/portal-frontend/package.json
+++ b/portal-frontend/package.json
@@ -26,7 +26,7 @@
     "@bcgov/bc-sans": "^2.1.0",
     "@types/uuid": "^9.0.8",
     "jwt-decode": "^4.0.0",
-    "ngx-mask": "^17.0.7",
+    "ngx-mask": "17.0.4",
     "rxjs": "~7.8.1",
     "source-map-support": "^0.5.21",
     "tslib": "^2.6.2",


### PR DESCRIPTION
* Currrently open issue breaking NGX Mask when it has decimal separators https://github.com/JsDaddy/ngx-mask/issues/1349
* Downgrade to 17.0.4 which does not have the issue