### PR TITLE
Compare rounded lot vs. parcel size to avoid floating non-equality

### DIFF
--- a/services/apps/alcs/src/portal/application-submission/application-submission-validator.service.spec.ts
+++ b/services/apps/alcs/src/portal/application-submission/application-submission-validator.service.spec.ts
@@ -1261,7 +1261,7 @@ describe('ApplicationSubmissionValidatorService', () => {
       ).toBe(true);
     });
 
-    it('should accept matching parcel sizes', async () => {
+    it('should accept exactly matching parcel sizes', async () => {
       const application = new ApplicationSubmission({
         owners: [],
         typeCode: 'SUBD',
@@ -1275,6 +1275,43 @@ describe('ApplicationSubmissionValidatorService', () => {
           {
             type: 'Lot',
             size: 6,
+            planNumbers: null,
+            alrArea: null,
+          },
+        ],
+      });
+
+      mockAppParcelService.fetchByApplicationFileId.mockResolvedValue([
+        new ApplicationParcel({
+          mapAreaHectares: 12,
+          owners: [],
+        }),
+      ]);
+
+      const res = await service.validateSubmission(application);
+
+      expect(
+        includesError(
+          res.errors,
+          new Error(`SUBD parcels area is different from proposed lot area`),
+        ),
+      ).toBe(false);
+    });
+
+    it('should accept matching parcel sizes up to 5 decimal places', async () => {
+      const application = new ApplicationSubmission({
+        owners: [],
+        typeCode: 'SUBD',
+        subdProposedLots: [
+          {
+            type: 'Lot',
+            size: 6.0,
+            planNumbers: null,
+            alrArea: null,
+          },
+          {
+            type: 'Lot',
+            size: 6.000001,
             planNumbers: null,
             alrArea: null,
           },

--- a/services/apps/alcs/src/portal/application-submission/application-submission-validator.service.ts
+++ b/services/apps/alcs/src/portal/application-submission/application-submission-validator.service.ts
@@ -506,13 +506,21 @@ export class ApplicationSubmissionValidatorService {
       }
     }
 
-    const initialArea = parcels.reduce(
-      (totalSize, parcel) => totalSize + (parcel.mapAreaHectares ?? 0),
-      0,
+    const initialArea = parseFloat(
+      parcels
+        .reduce(
+          (totalSize, parcel) => totalSize + (parcel.mapAreaHectares ?? 0),
+          0,
+        )
+        .toFixed(5),
     );
-    const subdividedArea = applicationSubmission.subdProposedLots.reduce(
-      (totalSize, proposedLot) => totalSize + (proposedLot.size ?? 0),
-      0,
+    const subdividedArea = parseFloat(
+      applicationSubmission.subdProposedLots
+        .reduce(
+          (totalSize, proposedLot) => totalSize + (proposedLot.size ?? 0),
+          0,
+        )
+        .toFixed(5),
     );
 
     if (initialArea !== subdividedArea) {


### PR DESCRIPTION
- Floating point error can cause lot total to register as different than parcel size when they should be equal
- Rounding to the 5 decimals allowed by UI to account for thi