### PR TITLE
Fix empty gov email causing emails to fail and success toast on fail

### DIFF
--- a/services/apps/alcs/src/alcs/notification/notification.controller.ts
+++ b/services/apps/alcs/src/alcs/notification/notification.controller.ts
@@ -1,4 +1,7 @@
-import { ServiceNotFoundException } from '@app/common/exceptions/base.exception';
+import {
+  BaseServiceException,
+  ServiceNotFoundException,
+} from '@app/common/exceptions/base.exception';
 import {
   Body,
   Controller,
@@ -120,11 +123,18 @@ export class NotificationController {
     );
 
     if (document) {
-      await this.notificationSubmissionService.sendAndRecordLTSAPackage(
-        submission,
-        document,
-        user,
-      );
+      const emailDidSend =
+        await this.notificationSubmissionService.sendAndRecordLTSAPackage(
+          submission,
+          document,
+          user,
+        );
+
+      if (!emailDidSend) {
+        throw new BaseServiceException(
+          `Failed to send LTSA Package ${fileNumber}`,
+        );
+      }
     } else {
       throw new ServiceNotFoundException(
         `Failed to find LTSA Letter on File Number ${fileNumber}`,

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
@@ -470,7 +470,7 @@ export class NotificationSubmissionService {
       );
 
       if (localGovernment && localGovernment.emails) {
-        ccEmails = localGovernment.emails;
+        ccEmails = localGovernment.emails.filter((email) => email !== '');
       }
     }
 

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
@@ -406,18 +406,19 @@ export class NotificationSubmissionService {
     submission: NotificationSubmission,
     document: NotificationDocument,
     user: User,
-  ) {
+  ): Promise<boolean> {
     const templateData = await this.generateSrwEmailData(submission, document);
 
-    const didSend = await this.emailService.sendEmail({
-      to: [templateData.to],
-      body: templateData.html,
-      subject: `Agricultural Land Commission SRW${submission.fileNumber} (${submission.applicant})`,
-      parentType: PARENT_TYPE.NOTIFICATION,
-      parentId: templateData.parentId,
-      cc: templateData.cc,
-      attachments: [document.document],
-    });
+    const didSend =
+      (await this.emailService.sendEmail({
+        to: [templateData.to],
+        body: templateData.html,
+        subject: `Agricultural Land Commission SRW${submission.fileNumber} (${submission.applicant})`,
+        parentType: PARENT_TYPE.NOTIFICATION,
+        parentId: templateData.parentId,
+        cc: templateData.cc,
+        attachments: [document.document],
+      })) ?? false;
 
     if (didSend) {
       const fileBuffer = Buffer.from(templateData.html);
@@ -442,6 +443,8 @@ export class NotificationSubmissionService {
         NOTIFICATION_STATUS.ALC_RESPONSE_SENT,
       );
     }
+
+    return didSend;
   }
 
   private async generateSrwEmailData(

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
@@ -409,16 +409,15 @@ export class NotificationSubmissionService {
   ): Promise<boolean> {
     const templateData = await this.generateSrwEmailData(submission, document);
 
-    const didSend =
-      (await this.emailService.sendEmail({
-        to: [templateData.to],
-        body: templateData.html,
-        subject: `Agricultural Land Commission SRW${submission.fileNumber} (${submission.applicant})`,
-        parentType: PARENT_TYPE.NOTIFICATION,
-        parentId: templateData.parentId,
-        cc: templateData.cc,
-        attachments: [document.document],
-      })) ?? false;
+    const didSend = await this.emailService.sendEmail({
+      to: [templateData.to],
+      body: templateData.html,
+      subject: `Agricultural Land Commission SRW${submission.fileNumber} (${submission.applicant})`,
+      parentType: PARENT_TYPE.NOTIFICATION,
+      parentId: templateData.parentId,
+      cc: templateData.cc,
+      attachments: [document.document],
+    });
 
     if (didSend) {
       const fileBuffer = Buffer.from(templateData.html);

--- a/services/apps/alcs/src/providers/email/email.service.ts
+++ b/services/apps/alcs/src/providers/email/email.service.ts
@@ -102,7 +102,7 @@ export class EmailService {
     parentId?: string;
     triggerStatus?: string;
     attachments?: Document[];
-  }) {
+  }): Promise<boolean> {
     const serviceUrl = this.config.get<string>('CHES.URL');
     const from = this.config.get<string>('CHES.FROM');
     const token = await this.getToken();
@@ -134,7 +134,7 @@ export class EmailService {
           { to, body, subject, cc, bcc },
           'EmailService did not send the email. Set CHES.MODE to production if you need to send an email.',
         );
-        return;
+        return false;
       }
       const res = await firstValueFrom(
         this.httpService.post<{


### PR DESCRIPTION
- Empty strings as emails were causing SRW government emails to fail
- Return email sent status to resend endpoint
- Fail resend endpoint if email not sent