### PR TITLE
Allow statuses to come in later than results

### DIFF
--- a/portal-frontend/src/app/features/public/search/application-search-table/application-search-table.component.ts
+++ b/portal-frontend/src/app/features/public/search/application-search-table/application-search-table.component.ts
@@ -16,17 +16,22 @@ export class ApplicationSearchTableComponent {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort?: MatSort;
 
-  _applications: ApplicationSearchResultDto[] = [];
   @Input() pageIndex: number = 0;
+  @Input() totalCount: number | undefined;
 
+  _applications!: ApplicationSearchResultDto[];
   @Input() set applications(applications: ApplicationSearchResultDto[]) {
     this._applications = applications;
     this.isLoading = false;
-    this.dataSource = new MatTableDataSource<SearchResult>(this.mapApplications(applications));
+    this.mapApplications();
   }
 
-  @Input() totalCount: number | undefined;
-  @Input() statuses: ApplicationStatusDto[] = [];
+  _statuses!: ApplicationStatusDto[];
+  @Input() set statuses(statuses: ApplicationStatusDto[]) {
+    this._statuses = statuses;
+    this.mapApplications();
+  }
+
   @Output() tableChange = new EventEmitter<TableChange>();
 
   displayedColumns = displayedColumns;
@@ -70,14 +75,18 @@ export class ApplicationSearchTableComponent {
     await this.router.navigateByUrl(`/public/application/${record.referenceId}`);
   }
 
-  private mapApplications(applications: ApplicationSearchResultDto[]): SearchResult[] {
-    return applications.map((e) => {
-      const status = this.statuses.find((st) => st.code === e.status);
+  private mapApplications() {
+    if (!this._applications || !this._statuses) {
+      return;
+    }
+    const results = this._applications.map((e) => {
+      const status = this._statuses.find((st) => st.code === e.status);
 
       return {
         ...e,
         status,
       };
     });
+    this.dataSource = new MatTableDataSource<SearchResult>(results);
   }
 }

--- a/portal-frontend/src/app/features/public/search/notice-of-intent-search-table/notice-of-intent-search-table.component.ts
+++ b/portal-frontend/src/app/features/public/search/notice-of-intent-search-table/notice-of-intent-search-table.component.ts
@@ -16,16 +16,22 @@ export class NoticeOfIntentSearchTableComponent {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort?: MatSort;
 
+  @Input() pageIndex: number = 0;
+  @Input() totalCount: number | undefined;
+
   _noticeOfIntents: NoticeOfIntentSearchResultDto[] = [];
   @Input() set noticeOfIntents(noticeOfIntents: NoticeOfIntentSearchResultDto[]) {
     this._noticeOfIntents = noticeOfIntents;
-    this.dataSource = new MatTableDataSource<SearchResult>(this.mapNoticeOfIntent(noticeOfIntents));
+    this.mapNoticeOfIntent();
     this.isLoading = false;
   }
 
-  @Input() pageIndex: number = 0;
-  @Input() totalCount: number | undefined;
-  @Input() statuses: ApplicationStatusDto[] = [];
+  _statuses!: ApplicationStatusDto[];
+  @Input() set statuses(statuses: ApplicationStatusDto[]) {
+    this._statuses = statuses;
+    this.mapNoticeOfIntent();
+  }
+
   @Output() tableChange = new EventEmitter<TableChange>();
 
   displayedColumns = displayedColumns;
@@ -69,14 +75,18 @@ export class NoticeOfIntentSearchTableComponent {
     await this.router.navigateByUrl(`/public/notice-of-intent/${record.referenceId}`);
   }
 
-  private mapNoticeOfIntent(applications: NoticeOfIntentSearchResultDto[]): SearchResult[] {
-    return applications.map((e) => {
-      const status = this.statuses.find((st) => st.code === e.status);
+  private mapNoticeOfIntent() {
+    if (!this._noticeOfIntents || !this._statuses) {
+      return;
+    }
+    const results = this._noticeOfIntents.map((e) => {
+      const status = this._statuses.find((st) => st.code === e.status);
 
       return {
         ...e,
         status,
       };
     });
+    this.dataSource = new MatTableDataSource<SearchResult>(results);
   }
 }

--- a/portal-frontend/src/app/features/public/search/notification-search-table/notification-search-table.component.ts
+++ b/portal-frontend/src/app/features/public/search/notification-search-table/notification-search-table.component.ts
@@ -1,9 +1,8 @@
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
 import { Sort, SortDirection } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { Router } from '@angular/router';
-import { Subject } from 'rxjs';
 import { ApplicationStatusDto } from '../../../../services/application-submission/application-submission.dto';
 import { NotificationSearchResultDto } from '../../../../services/search/search.dto';
 import { SearchResult, TableChange } from '../search.interface';
@@ -14,17 +13,22 @@ import { SearchResult, TableChange } from '../search.interface';
   styleUrls: ['./notification-search-table.component.scss'],
 })
 export class NotificationSearchTableComponent {
-  _notifications: NotificationSearchResultDto[] = [];
-
-  @Input() statuses: ApplicationStatusDto[] = [];
-
-  @Input() set notifications(notifications: NotificationSearchResultDto[]) {
-    this._notifications = notifications;
-    this.dataSource = new MatTableDataSource<SearchResult>(this.mapNotifications(notifications));
-  }
-
   @Input() totalCount: number | undefined;
   @Input() pageIndex: number = 0;
+
+  _notifications: NotificationSearchResultDto[] = [];
+  @Input() set notifications(notifications: NotificationSearchResultDto[]) {
+    this._notifications = notifications;
+    this.mapNotifications();
+    this.isLoading = false;
+  }
+
+  _statuses!: ApplicationStatusDto[];
+  @Input() set statuses(statuses: ApplicationStatusDto[]) {
+    this._statuses = statuses;
+    this.mapNotifications();
+  }
+
   @Output() tableChange = new EventEmitter<TableChange>();
 
   displayedColumns = ['fileId', 'ownerName', 'type', 'portalStatus', 'lastUpdate', 'government'];
@@ -33,7 +37,7 @@ export class NotificationSearchTableComponent {
   total = 0;
   sortDirection: SortDirection = 'desc';
   sortField = 'lastUpdate';
-  isLoading = false;
+  isLoading = true;
 
   constructor(private router: Router) {}
 
@@ -65,14 +69,18 @@ export class NotificationSearchTableComponent {
     await this.router.navigateByUrl(`/public/notification/${record.referenceId}`);
   }
 
-  private mapNotifications(notifications: NotificationSearchResultDto[]): SearchResult[] {
-    return notifications.map((e) => {
-      const status = this.statuses.find((st) => st.code === e.status);
+  private mapNotifications() {
+    if (!this._notifications || !this._statuses) {
+      return;
+    }
+    const results = this._notifications.map((e) => {
+      const status = this._statuses.find((st) => st.code === e.status);
 
       return {
         ...e,
         status,
       };
     });
+    this.dataSource = new MatTableDataSource<SearchResult>(results);
   }
 }

--- a/portal-frontend/src/app/features/public/search/public-search.component.ts
+++ b/portal-frontend/src/app/features/public/search/public-search.component.ts
@@ -416,15 +416,14 @@ export class PublicSearchComponent implements OnInit, OnDestroy {
 
   private async loadStatuses() {
     const statuses = await this.statusService.getStatuses();
-
     if (statuses) {
       this.populateAllStatuses(statuses);
     }
   }
 
   private populateAllStatuses(statuses: ApplicationStatusDto[]) {
+    statuses.sort((a, b) => (a.label > b.label ? 1 : -1));
     this.statuses = statuses;
-    this.statuses.sort((a, b) => (a.label > b.label ? 1 : -1));
   }
 
   private populateForm(storedSearch: SearchRequestDto) {

--- a/portal-frontend/src/app/features/public/search/search-list/search-list.component.html
+++ b/portal-frontend/src/app/features/public/search/search-list/search-list.component.html
@@ -1,5 +1,5 @@
 <div class="result-list" *ngIf="totalCount > 0">
-  <div *ngFor="let result of _results" (click)="onSelectRecord(result)" class="result">
+  <div *ngFor="let result of mappedResults" (click)="onSelectRecord(result)" class="result">
     <div class="subheading2">{{ result.fileNumber }} - {{ result.ownerName }}</div>
     <div [title]="result.type">{{ result.type }}</div>
     <div [title]="result.localGovernmentName">{{ result.localGovernmentName }}</div>

--- a/portal-frontend/src/app/features/public/search/search-list/search-list.component.ts
+++ b/portal-frontend/src/app/features/public/search/search-list/search-list.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { ApplicationStatusDto } from '../../../../services/application-submission/application-submission.dto';
-import { ApplicationSearchResultDto, BaseSearchResultDto } from '../../../../services/search/search.dto';
+import { BaseSearchResultDto } from '../../../../services/search/search.dto';
 import { SearchResult } from '../search.interface';
 
 const CLASS_TO_URL_MAP: Record<string, string> = {
@@ -20,15 +20,23 @@ export class SearchListComponent implements OnDestroy {
   $destroy = new Subject<void>();
 
   @Input() totalCount = 0;
-  @Input() statuses: ApplicationStatusDto[] = [];
   @Input() pageIndex: number = 0;
   @Input() type = '';
 
-  _results: SearchResult[] = [];
-  @Input() set results(results: BaseSearchResultDto[]) {
-    this._results = this.mapResults(results);
-    this.visibleCount = this._results.length;
+  _statuses!: ApplicationStatusDto[];
+  @Input() set statuses(statuses: ApplicationStatusDto[]) {
+    this._statuses = statuses;
+    this.mapResults();
   }
+
+  _results: BaseSearchResultDto[] = [];
+  @Input() set results(results: BaseSearchResultDto[]) {
+    this._results = results;
+    this.visibleCount = this._results.length;
+    this.mapResults();
+  }
+
+  mappedResults: SearchResult[] = [];
 
   @Output() loadMore = new EventEmitter<void>();
   visibleCount = 0;
@@ -45,9 +53,13 @@ export class SearchListComponent implements OnDestroy {
     await this.router.navigateByUrl(`/public/${targetUrl}/${record.referenceId}`);
   }
 
-  private mapResults(applications: ApplicationSearchResultDto[]): SearchResult[] {
-    return applications.map((e) => {
-      const status = this.statuses.find((st) => st.code === e.status);
+  private mapResults() {
+    if (!this._results || !this._statuses) {
+      return;
+    }
+
+    this.mappedResults = this._results.map((e) => {
+      const status = this._statuses.find((st) => st.code === e.status);
 
       return {
         ...e,


### PR DESCRIPTION
* The input setters are called in any order, this results that even if all of the inputs are populated in the parent they may not be populated in the child yet
* Add logic so that when either the statuses or results are set, we re-hydrated the results