### PR TITLE
show the deactivated LG on overview page of PR

### DIFF
--- a/alcs-frontend/src/app/features/planning-review/overview/overview.component.ts
+++ b/alcs-frontend/src/app/features/planning-review/overview/overview.component.ts
@@ -37,6 +37,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
       this.planningReview = review;
       if (review) {
         this.loadEvents(review.fileNumber);
+        this.loadGovernments(review.localGovernment.uuid);
       }
     });
 
@@ -47,7 +48,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
       }));
     });
     this.loadTypes();
-    this.loadGovernments();
   }
 
   private async loadTypes() {
@@ -60,13 +60,17 @@ export class OverviewComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async loadGovernments() {
-    const governments = await this.localGovernmentService.list();
+  private async loadGovernments(uuidToInclude?: string) {
+    const governments = await this.localGovernmentService.listAll();
+
     if (governments) {
-      this.localGovernments = governments.map((government) => ({
-        label: government.name,
-        value: government.uuid,
-      }));
+      this.localGovernments = governments
+        .filter((gov) => gov.isActive || gov.uuid === this.planningReview?.localGovernment?.uuid)
+        .map((government) => ({
+          label: government.name,
+          value: government.uuid,
+          disabled: !government.isActive,
+        }));
     }
   }
 

--- a/alcs-frontend/src/app/services/application/application-local-government/application-local-government.dto.ts
+++ b/alcs-frontend/src/app/services/application/application-local-government/application-local-government.dto.ts
@@ -3,4 +3,5 @@ export interface ApplicationLocalGovernmentDto {
   name: string;
   preferredRegionCode: string;
   isFirstNation: boolean;
+  isActive: boolean;
 }

--- a/alcs-frontend/src/app/services/application/application-local-government/application-local-government.service.ts
+++ b/alcs-frontend/src/app/services/application/application-local-government/application-local-government.service.ts
@@ -15,4 +15,8 @@ export class ApplicationLocalGovernmentService {
   async list() {
     return firstValueFrom(this.http.get<ApplicationLocalGovernmentDto[]>(`${this.baseUrl}`));
   }
+
+  async listAll() {
+    return firstValueFrom(this.http.get<ApplicationLocalGovernmentDto[]>(`${this.baseUrl}/all`));
+  }
 }

--- a/services/apps/alcs/src/alcs/local-government/local-government.controller.spec.ts
+++ b/services/apps/alcs/src/alcs/local-government/local-government.controller.spec.ts
@@ -1,9 +1,10 @@
-import { classes } from 'automapper-classes';
-import { AutomapperModule } from 'automapper-nestjs';
 import { createMock, DeepMocked } from '@golevelup/nestjs-testing';
 import { Test, TestingModule } from '@nestjs/testing';
+import { classes } from 'automapper-classes';
+import { AutomapperModule } from 'automapper-nestjs';
 import { ClsService } from 'nestjs-cls';
 import { mockKeyCloakProviders } from '../../../test/mocks/mockTypes';
+import { ApplicationRegion } from '../code/application-code/application-region/application-region.entity';
 import { LocalGovernmentController } from './local-government.controller';
 import { LocalGovernment } from './local-government.entity';
 import { LocalGovernmentService } from './local-government.service';
@@ -44,14 +45,33 @@ describe('LocalGovernmentController', () => {
   });
 
   it('should call through for list', async () => {
-    const mockGovernment = {
+    const mockGovernment = new LocalGovernment({
       name: 'Government',
       uuid: 'uuid',
       preferredRegion: {
         code: 'code',
         label: 'label',
-      },
-    } as LocalGovernment;
+      } as ApplicationRegion,
+      isActive: false,
+    });
+    mockService.listActive.mockResolvedValue([mockGovernment]);
+    const res = await mockService.listActive();
+
+    expect(mockService.listActive).toHaveBeenCalledTimes(1);
+    expect(res.length).toEqual(1);
+    expect(res[0].name).toEqual(mockGovernment.name);
+  });
+
+  it('should call through for list of all governments', async () => {
+    const mockGovernment = new LocalGovernment({
+      name: 'Government',
+      uuid: 'uuid',
+      preferredRegion: {
+        code: 'code',
+        label: 'label',
+      } as ApplicationRegion,
+      isActive: false,
+    });
     mockService.list.mockResolvedValue([mockGovernment]);
     const res = await mockService.list();
 

--- a/services/apps/alcs/src/alcs/local-government/local-government.controller.ts
+++ b/services/apps/alcs/src/alcs/local-government/local-government.controller.ts
@@ -5,6 +5,7 @@ import { ANY_AUTH_ROLE } from '../../common/authorization/roles';
 import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { UserRoles } from '../../common/authorization/roles.decorator';
 import { LocalGovernmentDto } from './local-government.dto';
+import { LocalGovernment } from './local-government.entity';
 import { LocalGovernmentService } from './local-government.service';
 
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
@@ -21,11 +22,25 @@ export class LocalGovernmentController {
     const localGovernments =
       await this.applicationLocalGovernmentService.listActive();
 
-    return localGovernments.map((government) => ({
+    return localGovernments.map((government) => this.mapGovernment(government));
+  }
+
+  @Get('/all')
+  @UserRoles(...ANY_AUTH_ROLE)
+  async listAll(): Promise<LocalGovernmentDto[]> {
+    const localGovernments =
+      await this.applicationLocalGovernmentService.list();
+
+    return localGovernments.map((government) => this.mapGovernment(government));
+  }
+
+  private mapGovernment(government: LocalGovernment): LocalGovernmentDto {
+    return {
       name: government.name,
       preferredRegionCode: government.preferredRegion.code,
       uuid: government.uuid,
       isFirstNation: government.isFirstNation,
-    }));
+      isActive: government.isActive,
+    };
   }
 }

--- a/services/apps/alcs/src/alcs/local-government/local-government.dto.ts
+++ b/services/apps/alcs/src/alcs/local-government/local-government.dto.ts
@@ -3,4 +3,5 @@ export class LocalGovernmentDto {
   name: string;
   preferredRegionCode: string;
   isFirstNation: boolean;
+  isActive: boolean;
 }

--- a/services/apps/alcs/src/alcs/local-government/local-government.service.ts
+++ b/services/apps/alcs/src/alcs/local-government/local-government.service.ts
@@ -30,9 +30,7 @@ export class LocalGovernmentService {
 
   async listActive() {
     return await this.repository.find({
-      where: {
-        isActive: true,
-      },
+      where: { isActive: true },
       order: {
         name: 'ASC',
       },


### PR DESCRIPTION
- add an endpoint to return all governments
- do not show inactive governments on overview page of PR unless it is assigned to PR
   - if the gov is inactive mark it as disabled