### PR TITLE
Add padding to bottom of Evidentiary Record table

### DIFF
--- a/alcs-frontend/src/app/features/commissioner/application/commissioner-application.component.scss
+++ b/alcs-frontend/src/app/features/commissioner/application/commissioner-application.component.scss
@@ -14,5 +14,5 @@
 
 .content {
   margin-top: 36px;
-  padding: 0 80px;
+  padding: 0 80px 64px;
 }


### PR DESCRIPTION
Added padding to the bottom of the Evidentiary Record table in the Commissioner view 