### PR TITLE
Application, NOI and SRW document description mapping

### DIFF
--- a/services/apps/alcs/src/providers/typeorm/migrations/1716916423632-map_optional_doc_description.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1716916423632-map_optional_doc_description.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MapOptionalDocDescription1716916423632
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'oats') THEN
+                    WITH alcs_application_doc_to_update AS (
+                    SELECT
+                        ad.oats_application_id,
+                        ad.oats_document_id
+                    FROM
+                        alcs.application_document ad
+                    WHERE
+                        audit_created_by = 'oats_etl'
+                        AND description IS NULL
+                    ),
+                    application_doc_description AS (
+                    SELECT
+                        od.document_id, 
+                        od.description
+                    FROM
+                        oats.oats_documents od
+                    JOIN alcs_application_doc_to_update AS alcs_docs ON
+                        alcs_docs.oats_document_id::bigint = od.document_id
+                    WHERE
+                        od.description IS NOT NULL
+                    )
+                    UPDATE alcs.application_document 
+                    SET description = COALESCE(application_doc_description.description, alcs.application_document.description)
+                    FROM application_doc_description
+                    WHERE alcs.application_document.oats_document_id = application_doc_description.document_id::TEXT;
+                END IF;
+            END $$;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    //NONE
+  }
+}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1716925980113-map_optional_doc_description_NOI.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1716925980113-map_optional_doc_description_NOI.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MapOptionalDocDescriptionNOI1716925980113
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'oats') THEN
+                    WITH alcs_noi_doc_to_update AS (
+                    SELECT
+                        ad.oats_application_id,
+                        ad.oats_document_id
+                    FROM
+                        alcs.notice_of_intent_document ad
+                    WHERE
+                        audit_created_by = 'oats_etl'
+                        AND description IS NULL
+                    ),
+                    noi_doc_description AS (
+                    SELECT
+                        od.document_id, 
+                        od.description
+                    FROM
+                        oats.oats_documents od
+                    JOIN alcs_noi_doc_to_update AS alcs_docs ON
+                        alcs_docs.oats_document_id::bigint = od.document_id
+                    WHERE
+                        od.description IS NOT NULL
+                    )
+                    UPDATE alcs.notice_of_intent_document 
+                    SET description = COALESCE(noi_doc_description.description, alcs.notice_of_intent_document.description)
+                    FROM noi_doc_description
+                    WHERE alcs.notice_of_intent_document.oats_document_id = noi_doc_description.document_id::TEXT;
+                END IF;
+            END $$;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    //NONE
+  }
+}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1716926436980-map_optional_doc_description_SRW.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1716926436980-map_optional_doc_description_SRW.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MapOptionalDocDescriptionSRW1716926436980
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'oats') THEN
+                    WITH alcs_srw_doc_to_update AS (
+                    SELECT
+                        ad.oats_application_id,
+                        ad.oats_document_id
+                    FROM
+                        alcs.notification_document ad
+                    WHERE
+                        audit_created_by = 'oats_etl'
+                        AND description IS NULL
+                    ),
+                    srw_doc_description AS (
+                    SELECT
+                        od.document_id, 
+                        od.description
+                    FROM
+                        oats.oats_documents od
+                    JOIN alcs_srw_doc_to_update AS alcs_docs ON
+                        alcs_docs.oats_document_id::bigint = od.document_id
+                    WHERE
+                        od.description IS NOT NULL
+                    )
+                    UPDATE alcs.notification_document 
+                    SET description = COALESCE(srw_doc_description.description, alcs.notification_document.description)
+                    FROM srw_doc_description
+                    WHERE alcs.notification_document.oats_document_id = srw_doc_description.document_id::TEXT;
+                END IF;
+            END $$;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    //NONE
+  }
+}


### PR DESCRIPTION
- Populate optional description field
- SRW was done already but migration will still run and catch anything was missed
- Does not touch inquiry or planning review