### PR TITLE
Return Owner with Corporate Summary on Save/Updated

### DIFF
--- a/services/apps/alcs/src/portal/application-submission/application-owner/application-owner.service.spec.ts
+++ b/services/apps/alcs/src/portal/application-submission/application-owner/application-owner.service.spec.ts
@@ -90,6 +90,7 @@ describe('ApplicationOwnerService', () => {
 
   it('should load the type and then call save for create', async () => {
     mockRepo.save.mockResolvedValue(new ApplicationOwner());
+    mockRepo.findOneOrFail.mockResolvedValue(new ApplicationOwner());
     mockTypeRepo.findOneOrFail.mockResolvedValue(new OwnerType());
 
     await service.create(
@@ -103,6 +104,7 @@ describe('ApplicationOwnerService', () => {
     );
 
     expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    expect(mockRepo.findOneOrFail).toHaveBeenCalledTimes(1);
     expect(mockTypeRepo.findOneOrFail).toHaveBeenCalledTimes(1);
   });
 
@@ -159,7 +161,7 @@ describe('ApplicationOwnerService', () => {
 
     expect(owner.firstName).toEqual('I Am');
     expect(owner.lastName).toEqual('Batman');
-    expect(mockRepo.findOneOrFail).toHaveBeenCalledTimes(1);
+    expect(mockRepo.findOneOrFail).toHaveBeenCalledTimes(2);
     expect(mockRepo.save).toHaveBeenCalledTimes(1);
   });
 
@@ -186,7 +188,7 @@ describe('ApplicationOwnerService', () => {
 
     expect(owner.corporateSummary).toBe(mockDocument);
     expect(mockAppDocumentService.delete).toHaveBeenCalledTimes(1);
-    expect(mockRepo.findOneOrFail).toHaveBeenCalledTimes(1);
+    expect(mockRepo.findOneOrFail).toHaveBeenCalledTimes(2);
     expect(mockRepo.save).toHaveBeenCalledTimes(1);
   });
 

--- a/services/apps/alcs/src/portal/application-submission/application-owner/application-owner.service.ts
+++ b/services/apps/alcs/src/portal/application-submission/application-owner/application-owner.service.ts
@@ -70,7 +70,8 @@ export class ApplicationOwnerService {
       type,
     });
 
-    return await this.repository.save(newOwner);
+    const res = await this.repository.save(newOwner);
+    return this.getOwner(res.uuid);
   }
 
   async attachToParcel(uuid: string, parcelUuid: string) {
@@ -198,7 +199,7 @@ export class ApplicationOwnerService {
       existingOwner.applicationSubmissionUuid,
     );
 
-    return result;
+    return this.getOwner(result.uuid);
   }
 
   async delete(owner: ApplicationOwner) {


### PR DESCRIPTION
Looks like Application / NOI now work differently and Application uses the returned owner. The returned owner was not being loaded with their corporate summary resulting in it showing as Not Applicable.