### PR TITLE
Use lowest decision date as minimum instead of highest

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -206,7 +206,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
                 minDate = decision.date;
               }
 
-              if (minDate && decision.date && decision.date > minDate) {
+              if (minDate && decision.date && decision.date < minDate) {
                 minDate = decision.date;
               }
 

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -177,7 +177,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
                 minDate = decision.date;
               }
 
-              if (minDate && decision.date && decision.date > minDate) {
+              if (minDate && decision.date && decision.date < minDate) {
                 minDate = decision.date;
               }
 


### PR DESCRIPTION
* This means subsequent decisions will have to come after the first rather than requiring each decision to come after the ones already done