### PR TITLE
Automap `wasReleased` to get value in frontend

### DIFF
--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision.dto.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision.dto.ts
@@ -130,6 +130,9 @@ export class NoticeOfIntentDecisionDto {
   decisionMakerName: string | null;
 
   @AutoMap(() => Boolean)
+  wasReleased: boolean;
+
+  @AutoMap(() => Boolean)
   isSubjectToConditions: boolean | null;
 
   @AutoMap(() => Boolean)


### PR DESCRIPTION
Automap `wasReleased` from the decision entity to
the DTO when responding to API requests for decisions,
so that the frontend can read that value.
