### PR TITLE
Fix attached corporate summary going not-applicable

### DIFF
--- a/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
@@ -180,6 +180,8 @@ export class OwnerDialogComponent {
       let document;
       if (this.pendingFile) {
         document = await this.uploadPendingFile(this.pendingFile);
+      } else {
+        document = this.data.existingOwner?.corporateSummary;
       }
 
       const orgName = this.type.value === OWNER_TYPE.ORGANIZATION ? this.organizationName.getRawValue() : null;


### PR DESCRIPTION
Fixed the bug that attached corporate summary file changing to not-applicable after opening the edit dialog and saving it without any changes. 