### PR TITLE
Fix NOI advanced search "submitted to" filter not working properly

### DIFF
--- a/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
@@ -294,7 +294,7 @@ export class NoticeOfIntentAdvancedSearchService {
 
     if (searchDto.dateSubmittedTo !== undefined) {
       query = query.andWhere(
-        'noi.date_submitted_to_alc <= :date_submitted_to',
+        'noi.date_submitted_to_alc < :date_submitted_to',
         {
           date_submitted_to: getNextDayToPacific(
             searchDto.dateSubmittedTo,

--- a/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
@@ -285,7 +285,9 @@ export class NoticeOfIntentAdvancedSearchService {
       query = query.andWhere(
         'noi.date_submitted_to_alc >= :date_submitted_from',
         {
-          date_submitted_from: new Date(searchDto.dateSubmittedFrom),
+          date_submitted_from: getStartOfDayToPacific(
+            searchDto.dateSubmittedFrom,
+          ),
         },
       );
     }
@@ -294,7 +296,9 @@ export class NoticeOfIntentAdvancedSearchService {
       query = query.andWhere(
         'noi.date_submitted_to_alc <= :date_submitted_to',
         {
-          date_submitted_to: new Date(searchDto.dateSubmittedTo),
+          date_submitted_to: getNextDayToPacific(
+            searchDto.dateSubmittedTo,
+          ),
         },
       );
     }


### PR DESCRIPTION
In NOIs Advanced search, the "Submitted to ALC - End Date" field used the beginning of the mentioned date (12:00 AM) as a filter. For example, If the AOI was submitted on June 6th, 2:00 PM, it would be after 12:00 AM so it would not be in results. To fix, the filter is now set to the beginning of the next day. 