### PR TITLE
Reorder condition for initial contact selection

### DIFF
--- a/portal-frontend/src/app/features/applications/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/primary-contact/primary-contact.component.ts
@@ -240,10 +240,10 @@ export class PrimaryContactComponent extends FilesStepComponent implements OnIni
     // onSelectOwner only not called on first load of page
     if (selectedOwner) {
       this.onSelectOwner(selectedOwner.uuid);
-    } else if (parcelOwners.length === 1) {
-      this.onSelectOwner(parcelOwners[0].uuid);
     } else if (this.isGovernmentUser) {
       this.onSelectGovernment();
+    } else if (parcelOwners.length === 1) {
+      this.onSelectOwner(parcelOwners[0].uuid);
     }
 
     if (this.isGovernmentUser && this.selectedLocalGovernment) {

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/primary-contact/primary-contact.component.ts
@@ -242,10 +242,10 @@ export class PrimaryContactComponent extends FilesStepComponent implements OnIni
     // onSelectOwner only not called on first load of page
     if (selectedOwner) {
       this.onSelectOwner(selectedOwner.uuid);
-    } else if (parcelOwners.length === 1) {
-      this.onSelectOwner(parcelOwners[0].uuid);
     } else if (this.isGovernmentUser) {
       this.onSelectGovernment();
+    } else if (parcelOwners.length === 1) {
+      this.onSelectOwner(parcelOwners[0].uuid);
     }
 
     if (this.selectedLocalGovernment) {


### PR DESCRIPTION
By putting government user check first, it only
checks the parcel owners length if not a government
user.
