### PR TITLE
Fix NOI Decision Component Empty Fields Errors

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-components/decision-component/decision-component.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-components/decision-component/decision-component.component.ts
@@ -310,22 +310,22 @@ export class DecisionComponentComponent implements OnInit {
   private getPofoDataChange(): PofoDecisionComponentDto {
     return {
       endDate: this.endDate.value ? formatDateForApi(this.endDate.value) : null,
-      soilFillTypeToPlace: this.fillTypeToPlace.value ?? null,
-      soilToPlaceArea: this.areaToPlace.value ?? null,
-      soilToPlaceVolume: this.volumeToPlace.value ?? null,
-      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ?? null,
-      soilToPlaceAverageDepth: this.averageDepthToPlace.value ?? null,
+      soilFillTypeToPlace: this.fillTypeToPlace.value ? this.fillTypeToPlace.value : null,
+      soilToPlaceArea: this.areaToPlace.value ? this.areaToPlace.value : null,
+      soilToPlaceVolume: this.volumeToPlace.value ? this.volumeToPlace.value : null,
+      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ? this.maximumDepthToPlace.value : null,
+      soilToPlaceAverageDepth: this.averageDepthToPlace.value ? this.averageDepthToPlace.value : null,
     };
   }
 
   private getRosoDataChange(): RosoDecisionComponentDto {
     return {
       endDate: this.endDate.value ? formatDateForApi(this.endDate.value) : null,
-      soilTypeRemoved: this.soilTypeRemoved.value ?? null,
-      soilToRemoveArea: this.areaToRemove.value ?? null,
-      soilToRemoveVolume: this.volumeToRemove.value ?? null,
-      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ?? null,
-      soilToRemoveAverageDepth: this.averageDepthToRemove.value ?? null,
+      soilTypeRemoved: this.soilTypeRemoved.value ? this.soilTypeRemoved.value : null,
+      soilToRemoveArea: this.areaToRemove.value ? this.areaToRemove.value : null,
+      soilToRemoveVolume: this.volumeToRemove.value ? this.volumeToRemove.value : null,
+      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ? this.maximumDepthToRemove.value : null,
+      soilToRemoveAverageDepth: this.averageDepthToRemove.value ? this.averageDepthToRemove.value : null,
     };
   }
 
@@ -333,16 +333,16 @@ export class DecisionComponentComponent implements OnInit {
     return {
       endDate: this.endDate.value ? formatDateForApi(this.endDate.value) : null,
       endDate2: this.endDate2.value ? formatDateForApi(this.endDate2.value) : null,
-      soilTypeRemoved: this.soilTypeRemoved.value ?? null,
-      soilToRemoveArea: this.areaToRemove.value ?? null,
-      soilToRemoveVolume: this.volumeToRemove.value ?? null,
-      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ?? null,
-      soilToRemoveAverageDepth: this.averageDepthToRemove.value ?? null,
-      soilFillTypeToPlace: this.fillTypeToPlace.value ?? null,
-      soilToPlaceArea: this.areaToPlace.value ?? null,
-      soilToPlaceVolume: this.volumeToPlace.value ?? null,
-      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ?? null,
-      soilToPlaceAverageDepth: this.averageDepthToPlace.value ?? null,
+      soilTypeRemoved: this.soilTypeRemoved.value ? this.soilTypeRemoved.value : null,
+      soilToRemoveArea: this.areaToRemove.value ? this.areaToRemove.value : null,
+      soilToRemoveVolume: this.volumeToRemove.value ? this.volumeToRemove.value : null,
+      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ? this.maximumDepthToRemove.value : null,
+      soilToRemoveAverageDepth: this.averageDepthToRemove.value ? this.averageDepthToRemove.value : null,
+      soilFillTypeToPlace: this.fillTypeToPlace.value ? this.fillTypeToPlace.value : null,
+      soilToPlaceArea: this.areaToPlace.value ? this.areaToPlace.value : null,
+      soilToPlaceVolume: this.volumeToPlace.value ? this.volumeToPlace.value : null,
+      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ? this.maximumDepthToPlace.value : null,
+      soilToPlaceAverageDepth: this.averageDepthToPlace.value ? this.averageDepthToPlace.value : null,
     };
   }
 
@@ -355,7 +355,11 @@ export class DecisionComponentComponent implements OnInit {
   }
 
   private getSubdDataChange(): SubdDecisionComponentDto {
-    const update = this.subdApprovedLots.value?.map((e) => ({ ...e }) as ProposedDecisionLotDto);
+    const update = this.subdApprovedLots.value?.map((e) => ({ 
+      ...e,
+      size: e.size ? e.size : null,
+      alrArea: e.alrArea ? e.alrArea : null
+    }) as ProposedDecisionLotDto);
     return {
       lots: update ?? undefined,
       expiryDate: this.expiryDate.value ? formatDateForApi(this.expiryDate.value) : null,

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-components/decision-component/decision-component.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-components/decision-component/decision-component.component.ts
@@ -186,21 +186,21 @@ export class DecisionComponentComponent implements OnInit {
     return {
       endDate: this.endDate.value ? formatDateForApi(this.endDate.value) : null,
       soilFillTypeToPlace: this.fillTypeToPlace.value ?? null,
-      soilToPlaceArea: this.areaToPlace.value ?? null,
-      soilToPlaceVolume: this.volumeToPlace.value ?? null,
-      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ?? null,
-      soilToPlaceAverageDepth: this.averageDepthToPlace.value ?? null,
+      soilToPlaceArea: this.areaToPlace.value ? this.areaToPlace.value : null,
+      soilToPlaceVolume: this.volumeToPlace.value ? this.volumeToPlace.value: null,
+      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ? this.maximumDepthToPlace.value : null,
+      soilToPlaceAverageDepth: this.averageDepthToPlace.value ? this.averageDepthToPlace.value : null,
     };
   }
 
   private getRosoDataChange(): RosoDecisionComponentDto {
     return {
       endDate: this.endDate.value ? formatDateForApi(this.endDate.value) : null,
-      soilTypeRemoved: this.soilTypeRemoved.value ?? null,
-      soilToRemoveArea: this.areaToRemove.value ?? null,
-      soilToRemoveVolume: this.volumeToRemove.value ?? null,
-      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ?? null,
-      soilToRemoveAverageDepth: this.averageDepthToRemove.value ?? null,
+      soilTypeRemoved: this.soilTypeRemoved.value ? this.soilTypeRemoved.value : null,
+      soilToRemoveArea: this.areaToRemove.value ? this.areaToRemove.value : null,
+      soilToRemoveVolume: this.volumeToRemove.value ? this.volumeToRemove.value : null,
+      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ? this.maximumDepthToRemove.value : null,
+      soilToRemoveAverageDepth: this.averageDepthToRemove.value ? this.averageDepthToRemove.value : null,
     };
   }
 
@@ -208,16 +208,16 @@ export class DecisionComponentComponent implements OnInit {
     return {
       endDate: this.endDate.value ? formatDateForApi(this.endDate.value) : null,
       endDate2: this.endDate2.value ? formatDateForApi(this.endDate2.value) : null,
-      soilTypeRemoved: this.soilTypeRemoved.value ?? null,
-      soilToRemoveArea: this.areaToRemove.value ?? null,
-      soilToRemoveVolume: this.volumeToRemove.value ?? null,
-      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ?? null,
-      soilToRemoveAverageDepth: this.averageDepthToRemove.value ?? null,
-      soilFillTypeToPlace: this.fillTypeToPlace.value ?? null,
-      soilToPlaceArea: this.areaToPlace.value ?? null,
-      soilToPlaceVolume: this.volumeToPlace.value ?? null,
-      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ?? null,
-      soilToPlaceAverageDepth: this.averageDepthToPlace.value ?? null,
+      soilTypeRemoved: this.soilTypeRemoved.value ? this.soilTypeRemoved.value : null,
+      soilToRemoveArea: this.areaToRemove.value ? this.areaToRemove.value : null,
+      soilToRemoveVolume: this.volumeToRemove.value ? this.volumeToRemove.value : null,
+      soilToRemoveMaximumDepth: this.maximumDepthToRemove.value ? this.maximumDepthToRemove.value : null,
+      soilToRemoveAverageDepth: this.averageDepthToRemove.value ? this.averageDepthToRemove.value : null,
+      soilFillTypeToPlace: this.fillTypeToPlace.value ? this.fillTypeToPlace.value : null,
+      soilToPlaceArea: this.areaToPlace.value ? this.areaToPlace.value : null,
+      soilToPlaceVolume: this.volumeToPlace.value ? this.volumeToPlace.value : null,
+      soilToPlaceMaximumDepth: this.maximumDepthToPlace.value ? this.maximumDepthToPlace.value : null,
+      soilToPlaceAverageDepth: this.averageDepthToPlace.value ? this.averageDepthToPlace.value : null,
     };
   }
 


### PR DESCRIPTION
Fixed 500 server error on submitting decision component with cleared fields which had value before for NOIs and Applications.

The error was on the ALCS-frontend that instead of sending null values for empty fields used to sent '' value which caused 500 error on the server side. 