### PR TITLE
Stop Auto Creation of GIS Subtasks When Submitting New Notifications to ALCS

### DIFF
--- a/services/apps/alcs/src/alcs/notification/notification.service.spec.ts
+++ b/services/apps/alcs/src/alcs/notification/notification.service.spec.ts
@@ -285,12 +285,5 @@ describe('NotificationService', () => {
       undefined,
       'noti',
     );
-    expect(mockSubtaskService.create).toHaveBeenCalledTimes(1);
-    expect(mockSubtaskService.create).toHaveBeenCalledWith(
-      new Card({
-        typeCode: CARD_TYPE.NOTIFICATION,
-      }),
-      CARD_SUBTASK_TYPE.GIS,
-    );
   });
 });

--- a/services/apps/alcs/src/alcs/notification/notification.service.ts
+++ b/services/apps/alcs/src/alcs/notification/notification.service.ts
@@ -329,11 +329,6 @@ export class NotificationService {
 
     const finalNotification = await this.getByFileNumber(createDto.fileNumber);
 
-    await this.subtaskService.create(
-      finalNotification.card!,
-      CARD_SUBTASK_TYPE.GIS,
-    );
-
     return finalNotification;
   }
 

--- a/services/apps/alcs/src/providers/typeorm/migrations/1719506636796-remove_incomplete_gis_subtasks.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1719506636796-remove_incomplete_gis_subtasks.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveIncompleteGisSubtasks1719506636796 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        queryRunner.query(`
+            DELETE FROM alcs.card_subtask 
+            USING alcs.notification
+            WHERE alcs.card_subtask.card_uuid = alcs.notification.card_uuid
+            AND alcs.card_subtask.type_code = 'GIS'
+            AND alcs.card_subtask.completed_at IS NULL
+            AND alcs.card_subtask.audit_created_by = 'alcs-api';
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+}


### PR DESCRIPTION
- Stopped auto creation of GIS subtasks when submitting new SRW notifications to ALCS
- Removed previously automatically created GIS subtasks which were not completed yet