### PR TITLE
Fix ALCS UI/UX bugs

### DIFF
--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.html
@@ -1,3 +1,6 @@
+<div class="split header">
+  <h3>Applicant Info</h3>  
+</div>
 <section>
   <app-parcel *ngIf="submission" [application]="submission"></app-parcel>
   <div class="review-table edit-section">
@@ -9,7 +12,7 @@
   </div>
 </section>
 <section>
-  <h3>Other Owned Parcels</h3>
+  <h4>Other Owned Parcels</h4>
   <div *ngIf="submission" class="review-table">
     <div class="subheading2 grid-1">
       Do any of the land owners added previously own or lease other parcels that might inform this application process?
@@ -39,7 +42,7 @@
   </div>
 </section>
 <section>
-  <h3>Primary Contact Information</h3>
+  <h4>Primary Contact Information</h4>
   <div *ngIf="submission" class="review-table">
     <div class="subheading2 grid-1">Type</div>
     <div class="grid-double" data-testid="primary-contact-type">
@@ -93,10 +96,10 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Land Use</h3>
+  <h4>Land Use</h4>
   <div *ngIf="submission" class="review-table">
     <div class="full-width">
-      <h4>Land Use of Parcel(s) under Application</h4>
+      <h5>Land Use of Parcel(s) under Application</h5>
     </div>
     <div class="subheading2 grid-1">Describe all agriculture that currently takes place on the parcel(s).</div>
     <div class="grid-double" data-testid="parcels-agriculture-description">
@@ -111,7 +114,7 @@
       {{ submission.parcelsNonAgricultureUseDescription }}
     </div>
     <div class="full-width">
-      <h4>Land Use of Adjacent Parcels</h4>
+      <h5>Land Use of Adjacent Parcels</h5>
     </div>
     <div class="adjacent-parcels full-width">
       <div class="grid-1 subheading2"></div>
@@ -154,7 +157,7 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Proposal</h3>
+  <h4>Proposal</h4>
   <app-nfu-details
     *ngIf="submission && applicationType === 'NFUP'"
     [applicationSubmission]="submission"
@@ -217,7 +220,7 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Optional Documents</h3>
+  <h4>Optional Documents</h4>
   <div *ngIf="submission" class="review-table">
     <div class="other-attachments full-width">
       <div class="grid-1 subheading2">File Name</div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.scss
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.scss
@@ -68,7 +68,6 @@
   .adjacent-parcels {
     display: grid;
     grid-template-columns: 1fr 1fr 2fr;
-    overflow-x: auto;
     grid-column-gap: 36px;
     grid-row-gap: 12px;
 
@@ -117,4 +116,8 @@
 
 .edit-section {
   margin-top: -40px;
+}
+
+.header {
+  margin-bottom: 42px;
 }

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/parcel/parcel.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/parcel/parcel.component.html
@@ -1,6 +1,6 @@
-<h3 class="flex-item">
+<h4 class="flex-item">
   {{ pageTitle }}
-</h3>
+</h4>
 
 <div class="review-table">
   <div *ngIf="!parcels" class="center full-width">
@@ -9,7 +9,7 @@
 
   <ng-container *ngFor="let parcel of parcels; let parcelInd = index">
     <div class="full-width flex-space-between-wrap">
-      <h4 [id]="parcel.uuid">Parcel #{{ parcelInd + 1 }}</h4>
+      <h5 [id]="parcel.uuid">Parcel #{{ parcelInd + 1 }}</h5>
     </div>
     <div class="subheading2 grid-1">Ownership Type</div>
     <div class="grid-double" [attr.data-testid]="'parcel-' + (parcelInd + 1) + '-type'">

--- a/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.html
+++ b/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.html
@@ -17,7 +17,7 @@
 </div>
 <section>
   <div *ngIf="!requiresReview" class="warning">
-    <mat-icon>info</mat-icon>Application not subjected to Local/First Nation Government Review.
+    <mat-icon>info</mat-icon>Application not subject to Local/First Nation Government Review.
   </div>
   <div *ngIf="!applicationReview && requiresReview" class="warning">
     <mat-icon>info</mat-icon>Pending Local/First Nation Government review.

--- a/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.scss
+++ b/alcs-frontend/src/app/features/application/lfng-info/lfng-info.component.scss
@@ -14,6 +14,7 @@ h4 {
   padding: 16px;
   display: flex;
   align-items: center;
+  margin-bottom: 24px;
 
   mat-icon {
     margin-right: 12px;

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.html
@@ -1,3 +1,6 @@
+<div class="split header">
+  <h3>Applicant Info</h3>  
+</div>
 <section>
   <app-parcel *ngIf="files && submission" [files]="files" [noticeOfIntent]="submission"></app-parcel>
   <div class="review-table edit-section">
@@ -9,7 +12,7 @@
   </div>
 </section>
 <section>
-  <h3>Primary Contact Information</h3>
+  <h4>Primary Contact Information</h4>
   <div *ngIf="submission" class="review-table">
     <div class="subheading2 grid-1">Type</div>
     <div class="grid-double">
@@ -63,10 +66,10 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Land Use</h3>
+  <h4>Land Use</h4>
   <div *ngIf="submission" class="review-table">
     <div class="full-width">
-      <h4>Land Use of Parcel(s) under Notice of Intent</h4>
+      <h5>Land Use of Parcel(s) under Notice of Intent</h5>
     </div>
     <div class="subheading2 grid-1">Describe all agriculture that currently takes place on the parcel(s).</div>
     <div class="grid-double">
@@ -81,7 +84,7 @@
       {{ submission.parcelsNonAgricultureUseDescription }}
     </div>
     <div class="full-width">
-      <h4>Land Use of Adjacent Parcels</h4>
+      <h5>Land Use of Adjacent Parcels</h5>
     </div>
     <div class="adjacent-parcels full-width">
       <div class="grid-1 subheading2"></div>
@@ -124,7 +127,7 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Proposal</h3>
+  <h4>Proposal</h4>
   <app-roso-details
     *ngIf="submission && noiType === 'ROSO'"
     [noiSubmission]="submission"
@@ -164,7 +167,7 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Optional Documents</h3>
+  <h4>Optional Documents</h4>
   <div *ngIf="submission" class="review-table">
     <div class="other-attachments full-width">
       <div class="grid-1 subheading2">Type</div>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.scss
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.scss
@@ -79,7 +79,6 @@
   .adjacent-parcels {
     display: grid;
     grid-template-columns: 1fr 1fr 2fr;
-    overflow-x: auto;
     grid-column-gap: 36px;
     grid-row-gap: 12px;
 
@@ -128,4 +127,8 @@
 
 .edit-section {
   margin-top: -40px;
+}
+
+.header {
+  margin-bottom: 42px;
 }

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/parcel/parcel.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/parcel/parcel.component.html
@@ -1,4 +1,4 @@
-<h3 class="flex-item">Notice of Intent Parcels</h3>
+<h4 class="flex-item">Notice of Intent Parcels</h4>
 
 <div class="review-table">
   <div *ngIf="!parcels" class="center full-width">
@@ -7,7 +7,7 @@
 
   <ng-container *ngFor="let parcel of parcels; let parcelInd = index">
     <div class="full-width flex-space-between-wrap">
-      <h4 [id]="parcel.uuid">Parcel #{{ parcelInd + 1 }}</h4>
+      <h5 [id]="parcel.uuid">Parcel #{{ parcelInd + 1 }}</h5>
     </div>
     <div class="subheading2 grid-1">Ownership Type</div>
     <div class="grid-double">

--- a/alcs-frontend/src/app/features/notice-of-intent/proposal/proposal.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/proposal/proposal.component.html
@@ -27,7 +27,7 @@
       <app-inline-text [value]="noticeOfIntent.agCapMap" (save)="updateNoiValue('agCapMap', $event)"></app-inline-text>
     </div>
     <div>
-      <div class="subheading2">Agricultural Capability Consultant 2</div>
+      <div class="subheading2">Agricultural Capability Consultant</div>
       <app-inline-text
         [value]="noticeOfIntent.agCapConsultant"
         (save)="updateNoiValue('agCapConsultant', $event)"

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.html
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.html
@@ -1,8 +1,11 @@
+<div class="split header">
+  <h3>Applicant Info</h3>  
+</div>
 <section>
   <app-parcel *ngIf="files && submission" [notificationSubmission]="submission"></app-parcel>
 </section>
 <section>
-  <h3>Transferee(s)</h3>
+  <h4>Transferee(s)</h4>
   <div *ngIf="submission" class="review-table">
     <div class="transferee-table full-width">
       <div class="subheading2">Type</div>
@@ -26,7 +29,7 @@
   </div>
 </section>
 <section>
-  <h3>Primary Contact Information</h3>
+  <h4>Primary Contact Information</h4>
   <div *ngIf="submission" class="review-table">
     <div class="subheading2 grid-1">First Name</div>
     <div class="grid-double">
@@ -56,7 +59,7 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Purpose of SRW</h3>
+  <h4>Purpose of SRW</h4>
   <div *ngIf="submission" class="review-table">
     <div class="subheading2 grid-1">Submitter’s File Number</div>
     <div class="grid-double">
@@ -107,7 +110,7 @@
   </div>
 </section>
 <section *ngIf="showFullApp">
-  <h3>Optional Documents</h3>
+  <h4>Optional Documents</h4>
   <div *ngIf="submission" class="review-table">
     <div class="other-attachments full-width">
       <div class="subheading2">File Name</div>

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.scss
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.scss
@@ -102,3 +102,7 @@
     }
   }
 }
+
+.header {
+  margin-bottom: 42px;
+}

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/parcel/parcel.component.html
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/parcel/parcel.component.html
@@ -1,9 +1,9 @@
-<h3 class="flex-item">Notification Parcels</h3>
+<h4 class="flex-item">Notification Parcels</h4>
 
 <div class="review-table">
   <ng-container *ngFor="let parcel of parcels; let parcelInd = index">
     <div class="full-width flex-space-between-wrap">
-      <h4 [id]="parcel.uuid">Parcel {{ parcelInd + 1 }}</h4>
+      <h5 [id]="parcel.uuid">Parcel {{ parcelInd + 1 }}</h5>
     </div>
     <div class="subheading2 grid-1">Ownership Type</div>
     <div class="grid-double">


### PR DESCRIPTION
- Applicant Info - Applications, NOIs, SRWs
    - Added missing page title, starts at Application or NOI Parcels
    - Resized the section headings to mirror formatting of L/FNG Info
    - Fixed Redundant scroll on Adjacent parcels

- L/FNG Info - Applications
    - Changed 'not subjected to' to just 'not subject to'
    - Added margin between the two yellow banners
pending L/FNG review + comment for L/FNG

- NOI Prep - NOIs
     - Agricultural Capability Consultant has a '2' at the end of the field label