### PR TITLE
Add CHES-like validation to all email fields

### DIFF
--- a/alcs-frontend/package-lock.json
+++ b/alcs-frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@bcgov/bc-sans": "^2.1.0",
         "@ng-matero/extensions": "^17.2.0",
         "@ng-select/ng-option-highlight": "^12.0.6",
+        "@types/validator": "^13.12.0",
         "angular-mentions": "^1.5.0",
         "jwt-decode": "^4.0.0",
         "moment": "^2.30.1",
@@ -32,6 +33,7 @@
         "rxjs": "~7.8.1",
         "source-map-support": "^0.5.21",
         "tslib": "^2.6.2",
+        "validator": "^13.12.0",
         "zone.js": "~0.14.4"
       },
       "devDependencies": {
@@ -6176,6 +6178,11 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-nH45Lk7oPIJ1RVOF6JgFI6Dy0QpHEzq4QecZhvguxYPDwT8c93prCMqAtiIttm39voZ+DDR+qkNnMpJmMBRqag=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -17676,6 +17683,14 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/alcs-frontend/package.json
+++ b/alcs-frontend/package.json
@@ -30,6 +30,7 @@
     "@bcgov/bc-sans": "^2.1.0",
     "@ng-matero/extensions": "^17.2.0",
     "@ng-select/ng-option-highlight": "^12.0.6",
+    "@types/validator": "^13.12.0",
     "angular-mentions": "^1.5.0",
     "jwt-decode": "^4.0.0",
     "moment": "^2.30.1",
@@ -38,6 +39,7 @@
     "rxjs": "~7.8.1",
     "source-map-support": "^0.5.21",
     "tslib": "^2.6.2",
+    "validator": "^13.12.0",
     "zone.js": "~0.14.4"
   },
   "devDependencies": {

--- a/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.html
+++ b/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.html
@@ -60,8 +60,10 @@
           [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
           [matChipInputAddOnBlur]="true"
           (matChipInputTokenEnd)="addEmail($event)"
+          [formControl]="email"
         />
       </mat-form-field>
+      <mat-error *ngIf="email.invalid"><mat-icon>warning</mat-icon>&nbsp;Please type a valid email address</mat-error>
     </div>
 
     <div>

--- a/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.scss
+++ b/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.scss
@@ -18,4 +18,10 @@
   .mat-mdc-form-field-infix {
     display: flex;
   }
+
+  mat-error {
+    display: flex;
+    font-size: 15px;
+    font-weight: bold;
+  }
 }

--- a/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.ts
+++ b/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.ts
@@ -7,6 +7,8 @@ import { LocalGovernmentDto } from '../../../../services/admin-local-government/
 import { AdminLocalGovernmentService } from '../../../../services/admin-local-government/admin-local-government.service';
 import { ApplicationRegionDto } from '../../../../services/application/application-code.dto';
 import { ApplicationService } from '../../../../services/application/application.service';
+import { FormControl } from '@angular/forms';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-admin-local-government-dialog',
@@ -28,6 +30,8 @@ export class LocalGovernmentDialogComponent implements OnInit, OnDestroy {
     emails: string[];
   };
   regions: ApplicationRegionDto[] = [];
+
+  email = new FormControl<string | null>(null, [strictEmailValidator]);
 
   isLoading = false;
 
@@ -100,6 +104,10 @@ export class LocalGovernmentDialogComponent implements OnInit, OnDestroy {
   }
 
   addEmail(event: MatChipInputEvent): void {
+    if (this.email.invalid) {
+      return;
+    }
+
     const value = (event.value || '').trim();
     if (value) {
       this.model.emails.push(value);

--- a/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.ts
+++ b/alcs-frontend/src/app/features/admin/local-government/dialog/local-government-dialog.component.ts
@@ -8,7 +8,7 @@ import { AdminLocalGovernmentService } from '../../../../services/admin-local-go
 import { ApplicationRegionDto } from '../../../../services/application/application-code.dto';
 import { ApplicationService } from '../../../../services/application/application.service';
 import { FormControl } from '@angular/forms';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-admin-local-government-dialog',

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/release-dialog/release-dialog.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/release-dialog/release-dialog.component.html
@@ -47,8 +47,10 @@
         [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
         [matChipInputAddOnBlur]="true"
         (matChipInputTokenEnd)="addEmail($event)"
+        [formControl]="email"
       />
     </mat-form-field>
+    <mat-error *ngIf="email.invalid"><mat-icon>warning</mat-icon>&nbsp;Please type a valid email address</mat-error>
   </div>
 </mat-dialog-content>
 

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/release-dialog/release-dialog.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/release-dialog/release-dialog.component.ts
@@ -9,7 +9,7 @@ import { ApplicationDecisionV2Service } from '../../../../../services/applicatio
 import { NOI_SUBMISSION_STATUS } from '../../../../../services/notice-of-intent/notice-of-intent.dto';
 import { ApplicationSubmissionStatusPill } from '../../../../../shared/application-submission-status-type-pill/application-submission-status-type-pill.component';
 import { FormControl } from '@angular/forms';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-release-dialog',

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/release-dialog/release-dialog.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/release-dialog/release-dialog.component.ts
@@ -8,6 +8,8 @@ import { SUBMISSION_STATUS } from '../../../../../services/application/applicati
 import { ApplicationDecisionV2Service } from '../../../../../services/application/decision/application-decision-v2/application-decision-v2.service';
 import { NOI_SUBMISSION_STATUS } from '../../../../../services/notice-of-intent/notice-of-intent.dto';
 import { ApplicationSubmissionStatusPill } from '../../../../../shared/application-submission-status-type-pill/application-submission-status-type-pill.component';
+import { FormControl } from '@angular/forms';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-release-dialog',
@@ -24,6 +26,8 @@ export class ReleaseDialogComponent implements OnInit, OnDestroy {
 
   readonly separatorKeysCodes = [ENTER, COMMA, SPACE] as const;
   emails: string[] = [];
+
+  email = new FormControl<string | null>(null, [strictEmailValidator]);
 
   constructor(
     private decisionService: ApplicationDecisionV2Service,
@@ -100,6 +104,10 @@ export class ReleaseDialogComponent implements OnInit, OnDestroy {
   }
 
   addEmail(event: MatChipInputEvent): void {
+    if (this.email.invalid) {
+      return;
+    }
+
     const value = (event.value || '').trim();
     if (value) {
       this.emails.push(value);

--- a/alcs-frontend/src/app/features/board/dialogs/inquiry/create/create-inquiry-dialog.component.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/inquiry/create/create-inquiry-dialog.component.ts
@@ -14,7 +14,7 @@ import { CardService } from '../../../../../services/card/card.service';
 import { InquiryParcelCreateDto } from '../../../../../services/inquiry/inquiry-parcel/inquiry-parcel.dto';
 import { CreateInquiryDto, InquiryTypeDto } from '../../../../../services/inquiry/inquiry.dto';
 import { InquiryService } from '../../../../../services/inquiry/inquiry.service';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-create-inquiry',

--- a/alcs-frontend/src/app/features/board/dialogs/inquiry/create/create-inquiry-dialog.component.ts
+++ b/alcs-frontend/src/app/features/board/dialogs/inquiry/create/create-inquiry-dialog.component.ts
@@ -14,6 +14,7 @@ import { CardService } from '../../../../../services/card/card.service';
 import { InquiryParcelCreateDto } from '../../../../../services/inquiry/inquiry-parcel/inquiry-parcel.dto';
 import { CreateInquiryDto, InquiryTypeDto } from '../../../../../services/inquiry/inquiry.dto';
 import { InquiryService } from '../../../../../services/inquiry/inquiry.service';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-create-inquiry',
@@ -38,7 +39,7 @@ export class CreateInquiryDialogComponent implements OnInit, OnDestroy {
   lastName = new FormControl<string | null>(null, []);
   organization = new FormControl<string | null>(null, []);
   phone = new FormControl<string | null>(null, []);
-  email = new FormControl<string | null>(null, [Validators.email]);
+  email = new FormControl<string | null>(null, [strictEmailValidator]);
 
   displayedColumns = ['index', 'address', 'pid', 'pin', 'actions'];
   parcels: InquiryParcelCreateDto[] = [];

--- a/alcs-frontend/src/app/features/inquiry/detail/details.component.html
+++ b/alcs-frontend/src/app/features/inquiry/detail/details.component.html
@@ -72,7 +72,11 @@
 
     <div>
       <div class="subheading2">Email</div>
-      <app-inline-text (save)="onSaveTextField($event, 'inquirerEmail')" [value]="inquiry.inquirerEmail" />
+      <app-inline-text
+        (save)="onSaveTextField($event, 'inquirerEmail')"
+        [value]="inquiry.inquirerEmail"
+        [isEmail]="true"
+      />
     </div>
   </div>
 </section>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/release-dialog/release-dialog.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/release-dialog/release-dialog.component.html
@@ -48,8 +48,10 @@
         [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
         [matChipInputAddOnBlur]="true"
         (matChipInputTokenEnd)="addEmail($event)"
+        [formControl]="email"
       />
     </mat-form-field>
+    <mat-error *ngIf="email.invalid"><mat-icon>warning</mat-icon>&nbsp;Please type a valid email address</mat-error>
   </div>
 </mat-dialog-content>
 

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/release-dialog/release-dialog.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/release-dialog/release-dialog.component.ts
@@ -7,6 +7,8 @@ import { NoticeOfIntentDecisionV2Service } from '../../../../../services/notice-
 import { NoticeOfIntentSubmissionStatusService } from '../../../../../services/notice-of-intent/notice-of-intent-submission-status/notice-of-intent-submission-status.service';
 import { NOI_SUBMISSION_STATUS } from '../../../../../services/notice-of-intent/notice-of-intent.dto';
 import { ApplicationSubmissionStatusPill } from '../../../../../shared/application-submission-status-type-pill/application-submission-status-type-pill.component';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-release-dialog',
@@ -23,6 +25,8 @@ export class ReleaseDialogComponent implements OnInit, OnDestroy {
 
   readonly separatorKeysCodes = [ENTER, COMMA, SPACE] as const;
   emails: string[] = [];
+
+  email = new FormControl<string | null>(null, [strictEmailValidator]);
 
   constructor(
     private decisionService: NoticeOfIntentDecisionV2Service,
@@ -95,6 +99,10 @@ export class ReleaseDialogComponent implements OnInit, OnDestroy {
   }
 
   addEmail(event: MatChipInputEvent): void {
+    if (this.email.invalid) {
+      return;
+    }
+
     const value = (event.value || '').trim();
     if (value) {
       this.emails.push(value);

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/release-dialog/release-dialog.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/release-dialog/release-dialog.component.ts
@@ -7,7 +7,7 @@ import { NoticeOfIntentDecisionV2Service } from '../../../../../services/notice-
 import { NoticeOfIntentSubmissionStatusService } from '../../../../../services/notice-of-intent/notice-of-intent-submission-status/notice-of-intent-submission-status.service';
 import { NOI_SUBMISSION_STATUS } from '../../../../../services/notice-of-intent/notice-of-intent.dto';
 import { ApplicationSubmissionStatusPill } from '../../../../../shared/application-submission-status-type-pill/application-submission-status-type-pill.component';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../../shared/validators/email-validator';
 import { FormControl } from '@angular/forms';
 
 @Component({

--- a/alcs-frontend/src/app/features/notification/intake/intake.component.html
+++ b/alcs-frontend/src/app/features/notification/intake/intake.component.html
@@ -14,7 +14,7 @@
       <mat-icon
         class="icon"
         matTooltip='Portal status updated to "ALC Response Sent" when auto-email is successfully sent.'
-      >info_outline
+        >info_outline
       </mat-icon>
     </div>
     <ng-container *ngIf="responseSent && responseDate">
@@ -39,6 +39,7 @@
     <app-inline-text
       [updateOnSave]="false"
       [value]="contactEmail"
+      [isEmail]="true"
       [required]="true"
       (save)="updateSubmissionEmail($event)"
     ></app-inline-text>

--- a/alcs-frontend/src/app/features/notification/intake/intake.component.html
+++ b/alcs-frontend/src/app/features/notification/intake/intake.component.html
@@ -14,7 +14,8 @@
       <mat-icon
         class="icon"
         matTooltip='Portal status updated to "ALC Response Sent" when auto-email is successfully sent.'
-        >info_outline
+      >
+        info_outline
       </mat-icon>
     </div>
     <ng-container *ngIf="responseSent && responseDate">

--- a/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.html
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.html
@@ -23,6 +23,7 @@
           matInput
           class="editable"
           name="value"
+          [formControl]="textInputControl"
           [required]="required"
           [placeholder]="placeholder"
           #editInput
@@ -39,7 +40,13 @@
         >{{ editInput?.value?.length || 0 }}/{{ maxLength }}</mat-hint
       >
       <button mat-button (click)="cancelEdit()">CANCEL</button>
-      <button mat-button color="primary" class="save" [disabled]="required && !pendingValue" (click)="confirmEdit()">
+      <button
+        mat-button
+        color="primary"
+        class="save"
+        [disabled]="(required && !pendingValue) || textInputControl.invalid"
+        (click)="confirmEdit()"
+      >
         SAVE
       </button>
     </div>

--- a/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.scss
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.scss
@@ -65,4 +65,8 @@
   .mat-mdc-icon-button.mat-mdc-button-base {
     padding: 0 !important;
   }
+
+  .mat-mdc-button-disabled {
+    color: silver;
+  }
 }

--- a/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.ts
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.ts
@@ -8,6 +8,8 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { strictEmailValidator } from '../../validators/email-validator';
 
 @Component({
   selector: 'app-inline-text[value]',
@@ -19,9 +21,12 @@ export class InlineTextComponent implements AfterContentChecked {
   @Input() value?: string | undefined;
   @Input() placeholder: string = 'Enter a value';
   @Input() required = false;
+  @Input() isEmail = false;
   @Output() save = new EventEmitter<string | null>();
   @Input() mask?: string | undefined;
   @Input() maxLength: number | null = null;
+
+  textInputControl = new FormControl<string | null>(null, []);
 
   @ViewChild('editInput') textInput!: ElementRef;
 
@@ -29,6 +34,12 @@ export class InlineTextComponent implements AfterContentChecked {
   pendingValue: undefined | string;
 
   constructor() {}
+
+  ngOnInit() {
+    if (this.isEmail) {
+      this.textInputControl.setValidators([strictEmailValidator]);
+    }
+  }
 
   startEdit() {
     this.isEditing = true;
@@ -42,6 +53,10 @@ export class InlineTextComponent implements AfterContentChecked {
   }
 
   confirmEdit() {
+    if (this.textInputControl.invalid) {
+      return;
+    }
+
     if (this.pendingValue !== this.value) {
       this.save.emit(this.pendingValue?.toString() ?? null);
 

--- a/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.ts
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-text/inline-text.component.ts
@@ -16,7 +16,7 @@ import { strictEmailValidator } from '../../validators/email-validator';
   templateUrl: './inline-text.component.html',
   styleUrls: ['./inline-text.component.scss'],
 })
-export class InlineTextComponent implements AfterContentChecked {
+export class InlineTextComponent implements AfterContentChecked, OnInit {
   @Input() updateOnSave: boolean = true;
   @Input() value?: string | undefined;
   @Input() placeholder: string = 'Enter a value';

--- a/alcs-frontend/src/app/shared/validators/email-validator.ts
+++ b/alcs-frontend/src/app/shared/validators/email-validator.ts
@@ -1,0 +1,12 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+import validator from 'validator';
+
+export const strictEmailValidator = (control: AbstractControl): ValidationErrors | null => {
+  return !control.value || (isString(control.value) && validator.isEmail(control.value, { allow_display_name: true }))
+    ? null
+    : { email: true };
+};
+
+function isString(s: string) {
+  return Object.prototype.toString.call(s) === '[object String]';
+}

--- a/alcs-frontend/src/app/shared/validators/email-validator.ts
+++ b/alcs-frontend/src/app/shared/validators/email-validator.ts
@@ -1,12 +1,18 @@
 import { AbstractControl, ValidationErrors } from '@angular/forms';
 import validator from 'validator';
 
-export const strictEmailValidator = (control: AbstractControl): ValidationErrors | null => {
-  return !control.value || (isString(control.value) && validator.isEmail(control.value, { allow_display_name: true }))
-    ? null
-    : { email: true };
+const isString = (s: string) => {
+  return Object.prototype.toString.call(s) === '[object String]';
 };
 
-function isString(s: string) {
-  return Object.prototype.toString.call(s) === '[object String]';
-}
+const isEmail = (s: string) => {
+  return isString(s) && validator.isEmail(s, { allow_display_name: true });
+};
+
+export const strictEmailValidator = (control: AbstractControl): ValidationErrors | null => {
+  return !control.value || isEmail(control.value) ? null : { email: true };
+};
+
+export const strictEmailListValidator = (control: AbstractControl): ValidationErrors | null => {
+  return !control.value || control.value.every(isEmail) ? null : { email: true };
+};

--- a/portal-frontend/package-lock.json
+++ b/portal-frontend/package-lock.json
@@ -20,12 +20,14 @@
         "@angular/router": "^17.3.3",
         "@bcgov/bc-sans": "^2.1.0",
         "@types/uuid": "^9.0.8",
+        "@types/validator": "^13.12.0",
         "jwt-decode": "^4.0.0",
         "ngx-mask": "17.0.4",
         "rxjs": "~7.8.1",
         "source-map-support": "^0.5.21",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1",
+        "validator": "^13.12.0",
         "zone.js": "~0.14.4"
       },
       "devDependencies": {
@@ -6173,6 +6175,11 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+    },
+    "node_modules/@types/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-nH45Lk7oPIJ1RVOF6JgFI6Dy0QpHEzq4QecZhvguxYPDwT8c93prCMqAtiIttm39voZ+DDR+qkNnMpJmMBRqag=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -16963,6 +16970,14 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/portal-frontend/package.json
+++ b/portal-frontend/package.json
@@ -25,12 +25,14 @@
     "@angular/router": "^17.3.3",
     "@bcgov/bc-sans": "^2.1.0",
     "@types/uuid": "^9.0.8",
+    "@types/validator": "^13.12.0",
     "jwt-decode": "^4.0.0",
     "ngx-mask": "17.0.4",
     "rxjs": "~7.8.1",
     "source-map-support": "^0.5.21",
     "tslib": "^2.6.2",
     "uuid": "^9.0.1",
+    "validator": "^13.12.0",
     "zone.js": "~0.14.4"
   },
   "devDependencies": {

--- a/portal-frontend/src/app/features/applications/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/primary-contact/primary-contact.component.ts
@@ -21,6 +21,7 @@ import { OwnerDialogComponent } from '../../../../shared/owner-dialogs/owner-dia
 import { CrownOwnerDialogComponent } from '../../../../shared/owner-dialogs/crown-owner-dialog/crown-owner-dialog.component';
 import { scrollToElement } from '../../../../shared/utils/scroll-helper';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-primary-contact',
@@ -50,7 +51,7 @@ export class PrimaryContactComponent extends FilesStepComponent implements OnIni
   lastName = new FormControl<string | null>('', [Validators.required]);
   organizationName = new FormControl<string | null>('');
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
 
   form = new FormGroup({
     firstName: this.firstName,

--- a/portal-frontend/src/app/features/applications/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/primary-contact/primary-contact.component.ts
@@ -21,7 +21,7 @@ import { OwnerDialogComponent } from '../../../../shared/owner-dialogs/owner-dia
 import { CrownOwnerDialogComponent } from '../../../../shared/owner-dialogs/crown-owner-dialog/crown-owner-dialog.component';
 import { scrollToElement } from '../../../../shared/utils/scroll-helper';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-primary-contact',

--- a/portal-frontend/src/app/features/applications/edit-submission/proposal/cove-proposal/transferee-dialog/transferee-dialog.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/proposal/cove-proposal/transferee-dialog/transferee-dialog.component.ts
@@ -10,7 +10,7 @@ import {
 import { CovenantTransfereeService } from '../../../../../../services/covenant-transferee/covenant-transferee.service';
 import { OWNER_TYPE } from '../../../../../../shared/dto/owner.dto';
 import { TransfereeDialogComponent } from '../../../../../notifications/edit-submission/transferees/transferee-dialog/transferee-dialog.component';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-transferee-dialog',

--- a/portal-frontend/src/app/features/applications/edit-submission/proposal/cove-proposal/transferee-dialog/transferee-dialog.component.ts
+++ b/portal-frontend/src/app/features/applications/edit-submission/proposal/cove-proposal/transferee-dialog/transferee-dialog.component.ts
@@ -10,6 +10,7 @@ import {
 import { CovenantTransfereeService } from '../../../../../../services/covenant-transferee/covenant-transferee.service';
 import { OWNER_TYPE } from '../../../../../../shared/dto/owner.dto';
 import { TransfereeDialogComponent } from '../../../../../notifications/edit-submission/transferees/transferee-dialog/transferee-dialog.component';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-transferee-dialog',
@@ -23,7 +24,7 @@ export class CovenantTransfereeDialogComponent {
   lastName = new FormControl<string | null>('', [Validators.required]);
   organizationName = new FormControl<string | null>('');
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
 
   isEdit = false;
   isLoading = false;
@@ -45,7 +46,7 @@ export class CovenantTransfereeDialogComponent {
     public data: {
       submissionUuid: string;
       existingTransferee?: CovenantTransfereeDto;
-    }
+    },
   ) {
     if (data && data.existingTransferee) {
       this.onChangeType({

--- a/portal-frontend/src/app/features/applications/review-submission/review-contact-information/review-contact-information.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-contact-information/review-contact-information.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { ApplicationSubmissionReviewService } from '../../../../services/application-submission-review/application-submission-review.service';
 import { ReviewApplicationSteps } from '../review-submission.component';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-review-contact-information',

--- a/portal-frontend/src/app/features/applications/review-submission/review-contact-information/review-contact-information.component.ts
+++ b/portal-frontend/src/app/features/applications/review-submission/review-contact-information/review-contact-information.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { ApplicationSubmissionReviewService } from '../../../../services/application-submission-review/application-submission-review.service';
 import { ReviewApplicationSteps } from '../review-submission.component';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-review-contact-information',
@@ -22,7 +23,7 @@ export class ReviewContactInformationComponent implements OnInit, OnDestroy {
   position = new FormControl<string | null>('', [Validators.required]);
   department = new FormControl<string | null>('', [Validators.required]);
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
   isFirstNationGovernment = false;
   governmentName = '';
 

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/primary-contact/primary-contact.component.ts
@@ -22,7 +22,7 @@ import { PrimaryContactConfirmationDialogComponent } from './primary-contact-con
 import { CrownOwnerDialogComponent } from '../../../../shared/owner-dialogs/crown-owner-dialog/crown-owner-dialog.component';
 import { scrollToElement } from '../../../../shared/utils/scroll-helper';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-primary-contact',

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/primary-contact/primary-contact.component.ts
@@ -22,6 +22,7 @@ import { PrimaryContactConfirmationDialogComponent } from './primary-contact-con
 import { CrownOwnerDialogComponent } from '../../../../shared/owner-dialogs/crown-owner-dialog/crown-owner-dialog.component';
 import { scrollToElement } from '../../../../shared/utils/scroll-helper';
 import { MatButtonToggleChange } from '@angular/material/button-toggle';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-primary-contact',
@@ -51,7 +52,7 @@ export class PrimaryContactComponent extends FilesStepComponent implements OnIni
   lastName = new FormControl<string | null>('', [Validators.required]);
   organizationName = new FormControl<string | null>('');
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
 
   form = new FormGroup({
     firstName: this.firstName,

--- a/portal-frontend/src/app/features/notifications/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/primary-contact/primary-contact.component.ts
@@ -4,7 +4,7 @@ import { takeUntil } from 'rxjs';
 import { NotificationSubmissionService } from '../../../../services/notification-submission/notification-submission.service';
 import { EditNotificationSteps } from '../edit-submission.component';
 import { StepComponent } from '../step.partial';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-primary-contact',

--- a/portal-frontend/src/app/features/notifications/edit-submission/primary-contact/primary-contact.component.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/primary-contact/primary-contact.component.ts
@@ -4,6 +4,7 @@ import { takeUntil } from 'rxjs';
 import { NotificationSubmissionService } from '../../../../services/notification-submission/notification-submission.service';
 import { EditNotificationSteps } from '../edit-submission.component';
 import { StepComponent } from '../step.partial';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-primary-contact',
@@ -17,8 +18,8 @@ export class PrimaryContactComponent extends StepComponent implements OnInit, On
   lastName = new FormControl<string | null>('', [Validators.required]);
   organizationName = new FormControl<string | null>('');
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
-  confirmEmail = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
+  confirmEmail = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
 
   form = new FormGroup({
     firstName: this.firstName,

--- a/portal-frontend/src/app/features/notifications/edit-submission/transferees/transferee-dialog/transferee-dialog.component.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/transferees/transferee-dialog/transferee-dialog.component.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../../services/notification-transferee/notification-transferee.dto';
 import { NotificationTransfereeService } from '../../../../../services/notification-transferee/notification-transferee.service';
 import { OWNER_TYPE } from '../../../../../shared/dto/owner.dto';
+import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
 
 @Component({
   selector: 'app-transferee-dialog',
@@ -22,7 +23,7 @@ export class TransfereeDialogComponent {
   lastName = new FormControl<string | null>('', [Validators.required]);
   organizationName = new FormControl<string | null>('');
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
 
   isEdit = false;
   isLoading = false;

--- a/portal-frontend/src/app/features/notifications/edit-submission/transferees/transferee-dialog/transferee-dialog.component.ts
+++ b/portal-frontend/src/app/features/notifications/edit-submission/transferees/transferee-dialog/transferee-dialog.component.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../../../services/notification-transferee/notification-transferee.dto';
 import { NotificationTransfereeService } from '../../../../../services/notification-transferee/notification-transferee.service';
 import { OWNER_TYPE } from '../../../../../shared/dto/owner.dto';
-import { strictEmailValidator } from 'src/app/shared/validators/email-validator';
+import { strictEmailValidator } from '../../../../../shared/validators/email-validator';
 
 @Component({
   selector: 'app-transferee-dialog',

--- a/portal-frontend/src/app/shared/owner-dialogs/crown-owner-dialog/crown-owner-dialog.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/crown-owner-dialog/crown-owner-dialog.component.ts
@@ -15,6 +15,7 @@ import {
 import { NoticeOfIntentOwnerService } from '../../../services/notice-of-intent-owner/notice-of-intent-owner.service';
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { ConfirmationDialogService } from '../../confirmation-dialog/confirmation-dialog.service';
+import { strictEmailValidator } from '../../validators/email-validator';
 
 @Component({
   selector: 'app-crown-owner-dialog',
@@ -26,7 +27,7 @@ export class CrownOwnerDialogComponent {
   firstName = new FormControl<string | null>('', [Validators.required]);
   lastName = new FormControl<string | null>('', [Validators.required]);
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
   crownLandOwnerType = new FormControl<string | null>('', [Validators.required]);
 
   isEdit = false;
@@ -52,7 +53,7 @@ export class CrownOwnerDialogComponent {
       parcelUuid?: string;
       ownerService: ApplicationOwnerService | NoticeOfIntentOwnerService;
       existingOwner?: ApplicationOwnerDto | NoticeOfIntentOwnerDto;
-    }
+    },
   ) {
     if (data && data.existingOwner) {
       this.isEdit = true;

--- a/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
+++ b/portal-frontend/src/app/shared/owner-dialogs/owner-dialog/owner-dialog.component.ts
@@ -20,6 +20,7 @@ import { DOCUMENT_SOURCE, DOCUMENT_TYPE, DocumentTypeDto } from '../../dto/docum
 import { OWNER_TYPE } from '../../dto/owner.dto';
 import { FileHandle } from '../../file-drag-drop/drag-drop.directive';
 import { openFileInline } from '../../utils/file';
+import { strictEmailValidator } from '../../validators/email-validator';
 
 @Component({
   selector: 'app-owner-dialog',
@@ -33,7 +34,7 @@ export class OwnerDialogComponent {
   lastName = new FormControl<string | null>('', [Validators.required]);
   organizationName = new FormControl<string | null>('');
   phoneNumber = new FormControl<string | null>('', [Validators.required]);
-  email = new FormControl<string | null>('', [Validators.required, Validators.email]);
+  email = new FormControl<string | null>('', [Validators.required, strictEmailValidator]);
   corporateSummary = new FormControl<string | null>(null);
 
   isEdit = false;

--- a/portal-frontend/src/app/shared/validators/email-validator.ts
+++ b/portal-frontend/src/app/shared/validators/email-validator.ts
@@ -2,9 +2,7 @@ import { AbstractControl, ValidationErrors } from '@angular/forms';
 import validator from 'validator';
 
 export const strictEmailValidator = (control: AbstractControl): ValidationErrors | null => {
-  return isString(control.value) &&
-    !validator.isEmpty(control.value, { ignore_whitespace: true }) &&
-    validator.isEmail(control.value, { allow_display_name: true })
+  return !control.value || (isString(control.value) && validator.isEmail(control.value, { allow_display_name: true }))
     ? null
     : { email: true };
 };

--- a/portal-frontend/src/app/shared/validators/email-validator.ts
+++ b/portal-frontend/src/app/shared/validators/email-validator.ts
@@ -1,0 +1,14 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+import validator from 'validator';
+
+export const strictEmailValidator = (control: AbstractControl): ValidationErrors | null => {
+  return isString(control.value) &&
+    !validator.isEmpty(control.value, { ignore_whitespace: true }) &&
+    validator.isEmail(control.value, { allow_display_name: true })
+    ? null
+    : { email: true };
+};
+
+function isString(s: string) {
+  return Object.prototype.toString.call(s) === '[object String]';
+}


### PR DESCRIPTION
- **Install validator and type defs for portal**
- **Create custom stricter email validator**
- **Update all portal email validators with strict one**
- **Consider empty emails valid**
- **Install validator and type defs**
- **Add stricter email validator to ALCS**
- **Update Angular form validator to strict version in ALCS**
- **Add `isEmail` option to `app-inline-text`**
- **Make email inline fields email fields**
- **Add `OnInit` interface to inline text component**
- **Validate email chips and show warning if invalid**
