### PR TITLE
Block Null and Zero Values for Released Decisions' ALR Inline Editor for Applications and NOIs

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-component/basic/basic.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-component/basic/basic.component.html
@@ -8,5 +8,6 @@
     [value]="component.alrArea?.toString()"
     (save)="onSaveAlrArea($event)"
     [decimals]="5"
+    [nonZeroEmptyValidation]="nonZeroEmptyValidation"
   ></app-inline-number>
 </div>

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-component/basic/basic.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-component/basic/basic.component.ts
@@ -9,6 +9,7 @@ import { ApplicationDecisionComponentDto } from '../../../../../../services/appl
 export class BasicComponent {
   @Input() component!: ApplicationDecisionComponentDto;
   @Input() fillRow = false;
+  @Input() nonZeroEmptyValidation = false;
   @Output() saveAlrArea = new EventEmitter<string | null>();
 
   constructor() {}

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.html
@@ -184,6 +184,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic>
               </app-nfup>
 
@@ -199,6 +200,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-expiry-date>
 
@@ -211,6 +213,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-app-pofo>
 
@@ -223,6 +226,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-app-roso>
 
@@ -235,6 +239,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-app-pfrs>
 
@@ -247,6 +252,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-naru>
 
@@ -259,6 +265,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-subd>
 
@@ -274,6 +281,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-app-basic
               ></app-incl-excl>
 

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.html
@@ -3,8 +3,7 @@
   <app-inline-number
     [value]="component.alrArea?.toString()"
     (save)="onSaveAlrArea($event)"
-    [disableSaveOnEmpty]="true"
-    [disableSaveOnZero]="true"
+    [nonZeroEmptyValidation]="inlineValidation"
     [decimals]="5"
   ></app-inline-number>
 </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.html
@@ -3,7 +3,7 @@
   <app-inline-number
     [value]="component.alrArea?.toString()"
     (save)="onSaveAlrArea($event)"
-    [nonZeroEmptyValidation]="inlineValidation"
+    [nonZeroEmptyValidation]="nonZeroEmptyValidation"
     [decimals]="5"
   ></app-inline-number>
 </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.html
@@ -3,6 +3,8 @@
   <app-inline-number
     [value]="component.alrArea?.toString()"
     (save)="onSaveAlrArea($event)"
+    [disableSaveOnEmpty]="true"
+    [disableSaveOnZero]="true"
     [decimals]="5"
   ></app-inline-number>
 </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.ts
@@ -9,7 +9,7 @@ import { NoticeOfIntentDecisionComponentDto } from '../../../../../../services/n
 export class BasicComponent {
   @Input() component!: NoticeOfIntentDecisionComponentDto;
   @Input() fillRow = false;
-  @Input() inlineValidation = false;
+  @Input() nonZeroEmptyValidation = false;
   @Output() saveAlrArea = new EventEmitter<string | null>();
 
   constructor() {}

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-component/basic/basic.component.ts
@@ -9,6 +9,7 @@ import { NoticeOfIntentDecisionComponentDto } from '../../../../../../services/n
 export class BasicComponent {
   @Input() component!: NoticeOfIntentDecisionComponentDto;
   @Input() fillRow = false;
+  @Input() inlineValidation = false;
   @Output() saveAlrArea = new EventEmitter<string | null>();
 
   constructor() {}

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-v2.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-v2.component.html
@@ -175,7 +175,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
-                  [inlineValidation]="decision.wasReleased"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-noi-basic>
               </app-noi-pofo>
 
@@ -188,7 +188,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
-                  [inlineValidation]="decision.wasReleased"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-noi-basic>
               </app-noi-roso>
 
@@ -201,7 +201,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
-                  [inlineValidation]="decision.wasReleased"
+                  [nonZeroEmptyValidation]="decision.wasReleased"
                 ></app-noi-basic>
               </app-noi-pfrs>
 

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-v2.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-v2.component.html
@@ -175,6 +175,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [inlineValidation]="decision.wasReleased"
                 ></app-noi-basic>
               </app-noi-pofo>
 
@@ -187,6 +188,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [inlineValidation]="decision.wasReleased"
                 ></app-noi-basic>
               </app-noi-roso>
 
@@ -199,6 +201,7 @@
                   [component]="component"
                   [fillRow]="true"
                   (saveAlrArea)="onSaveAlrArea(decision.uuid, component.uuid, $event)"
+                  [inlineValidation]="decision.wasReleased"
                 ></app-noi-basic>
               </app-noi-pfrs>
 

--- a/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.html
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.html
@@ -25,21 +25,22 @@
           name="value"
           [placeholder]="placeholder"
           #editInput
-          [(ngModel)]="pendingValue"
           (keydown.enter)="confirmEdit()"
           (keydown.escape)="cancelEdit()"
+          [formControl]="valueControl"
         />
       </mat-form-field>
-      <mat-error *ngIf="isSaveDisabledOnZero"><mat-icon>warning</mat-icon>&nbsp;Value cannot be 0</mat-error>
-      <mat-error *ngIf="isSaveDisabledOnEmpty"><mat-icon>warning</mat-icon>&nbsp;Value cannot be empty</mat-error>
+      <mat-error *ngIf="valueControl.errors?.['nonZero']"><mat-icon>warning</mat-icon>&nbsp;Value cannot be 0</mat-error>
+      <mat-error *ngIf="valueControl.errors?.['required']"><mat-icon>warning</mat-icon>&nbsp;Value cannot be Empty</mat-error>
     </form>
     <div class="button-container">
       <button mat-button (click)="cancelEdit()">CANCEL</button>
       <button 
         mat-button 
-        class="save" 
+        [class.disabled] = "valueControl.invalid"
+        [class.save] = "!valueControl.invalid"
         (click)="confirmEdit()"
-        [disabled]="isSaveDisabledOnEmpty || isSaveDisabledOnZero">
+        [disabled]="valueControl.invalid">
         SAVE
       </button>
       

--- a/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.html
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.html
@@ -30,10 +30,19 @@
           (keydown.escape)="cancelEdit()"
         />
       </mat-form-field>
+      <mat-error *ngIf="isSaveDisabledOnZero"><mat-icon>warning</mat-icon>&nbsp;Value cannot be 0</mat-error>
+      <mat-error *ngIf="isSaveDisabledOnEmpty"><mat-icon>warning</mat-icon>&nbsp;Value cannot be empty</mat-error>
     </form>
     <div class="button-container">
       <button mat-button (click)="cancelEdit()">CANCEL</button>
-      <button mat-button class="save" (click)="confirmEdit()">SAVE</button>
+      <button 
+        mat-button 
+        class="save" 
+        (click)="confirmEdit()"
+        [disabled]="isSaveDisabledOnEmpty || isSaveDisabledOnZero">
+        SAVE
+      </button>
+      
     </div>
   </div>
 </div>

--- a/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.scss
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.scss
@@ -41,6 +41,10 @@
   color: colors.$primary-color;
 }
 
+.disabled {
+  color: colors.$grey;
+}
+
 :host::ng-deep {
   .mat-form-field-wrapper {
     padding: 0 !important;

--- a/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.ts
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.ts
@@ -1,4 +1,6 @@
 import { AfterContentChecked, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
+import { NonZeroValidator } from '../../validators/value-validator';
 
 @Component({
   selector: 'app-inline-number[value]',
@@ -9,20 +11,26 @@ export class InlineNumberComponent implements AfterContentChecked {
   @Input() value?: string | null;
   @Input() placeholder: string = 'Enter a value';
   @Input() decimals = 2;
-  @Input() disableSaveOnZero: boolean = false;
-  @Input() disableSaveOnEmpty: boolean = false;
+  @Input() nonZeroEmptyValidation: boolean = false;
   @Output() save = new EventEmitter<string | null>();
 
   @ViewChild('editInput') textInput!: ElementRef;
 
   isEditing = false;
-  pendingValue: null | string | undefined;
+
+  valueControl = new FormControl<string | null | undefined>(null, []);
 
   constructor() {}
 
+  ngOnInit() {
+    if (this.nonZeroEmptyValidation) {
+      this.valueControl.setValidators([NonZeroValidator, Validators.required]);
+    }
+  }
+
   startEdit() {
     this.isEditing = true;
-    this.pendingValue = this.value;
+    this.valueControl.setValue(this.value);
   }
 
   ngAfterContentChecked(): void {
@@ -32,9 +40,10 @@ export class InlineNumberComponent implements AfterContentChecked {
   }
 
   confirmEdit() {
-    if (this.pendingValue !== this.value) {
-      this.save.emit(this.pendingValue?.toString() ?? null);
-      this.value = this.pendingValue;
+    console.log(this.valueControl.value);
+    if (this.valueControl.value !== this.value) {
+      this.save.emit(this.valueControl.value?.toString() ?? null);
+      this.value = this.valueControl.value;
     }
 
     this.isEditing = false;
@@ -42,15 +51,6 @@ export class InlineNumberComponent implements AfterContentChecked {
 
   cancelEdit() {
     this.isEditing = false;
-    this.pendingValue = this.value;
-  }
-
-  get isSaveDisabledOnZero(): boolean {
-    const valueAsNumber = this.pendingValue !== '' ? parseFloat(this.pendingValue!) : null;
-    return this.disableSaveOnZero && valueAsNumber === 0;
-  }
-
-  get isSaveDisabledOnEmpty(): boolean {
-    return this.disableSaveOnEmpty && this.pendingValue === '';
+    this.valueControl.setValue(this.value);
   }
 }

--- a/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.ts
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.ts
@@ -9,6 +9,8 @@ export class InlineNumberComponent implements AfterContentChecked {
   @Input() value?: string | null;
   @Input() placeholder: string = 'Enter a value';
   @Input() decimals = 2;
+  @Input() disableSaveOnZero: boolean = false;
+  @Input() disableSaveOnEmpty: boolean = false;
   @Output() save = new EventEmitter<string | null>();
 
   @ViewChild('editInput') textInput!: ElementRef;
@@ -41,5 +43,14 @@ export class InlineNumberComponent implements AfterContentChecked {
   cancelEdit() {
     this.isEditing = false;
     this.pendingValue = this.value;
+  }
+
+  get isSaveDisabledOnZero(): boolean {
+    const valueAsNumber = this.pendingValue !== '' ? parseFloat(this.pendingValue!) : null;
+    return this.disableSaveOnZero && valueAsNumber === 0;
+  }
+
+  get isSaveDisabledOnEmpty(): boolean {
+    return this.disableSaveOnEmpty && this.pendingValue === '';
   }
 }

--- a/alcs-frontend/src/app/shared/validators/value-validator.ts
+++ b/alcs-frontend/src/app/shared/validators/value-validator.ts
@@ -1,0 +1,9 @@
+import { AbstractControl, ValidationErrors } from "@angular/forms";
+
+export const NonZeroValidator = (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    if (value === 0) {
+        return { nonZero: true };
+    }
+    return null;
+}


### PR DESCRIPTION
**This PR covers both ALCS-2065 and ALCS-2077 tickets requirements.**

Following changes have been made:

- Added non zero and required validators to detect zero and empty values on ALR inline edit
- Added form control to inline-number component to have validation and prevent user from submission
- Add conditions to decisions components to have validation only on released decisions in NOIs and Applications 