### PR TITLE
Fix Zero Optional Attachment Bug on Submission in Applications and NOIs

### DIFF
--- a/portal-frontend/src/app/features/applications/application-details/application-details.component.html
+++ b/portal-frontend/src/app/features/applications/application-details/application-details.component.html
@@ -343,7 +343,7 @@
         [isLast]="last"
         (fileClicked)="openFile(file)">
       </app-optional-attachments-mobile-card>
-      <app-no-data *ngIf="otherFiles.length === 0" [showRequired]="showErrors"></app-no-data>
+      <app-no-data *ngIf="otherFiles.length === 0" [showRequired]="false"></app-no-data>
     </div>
     <div *ngIf="showEdit" class="edit-button">
       <button (click)="onNavigateToStep(6)" color="accent" mat-flat-button>Edit Section</button>

--- a/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/notice-of-intent-details/notice-of-intent-details.component.html
@@ -239,7 +239,7 @@
         [isLast]="last"
         (fileClicked)="openFile(file)">
       </app-optional-attachments-mobile-card>
-      <app-no-data *ngIf="otherFiles.length === 0" [showRequired]="showErrors"></app-no-data>
+      <app-no-data *ngIf="otherFiles.length === 0" [showRequired]="false"></app-no-data>
     </div>
     <div *ngIf="showEdit" class="edit-button">
       <button (click)="onNavigateToStep(6)" color="accent" mat-flat-button>Edit Section</button>


### PR DESCRIPTION
Fixed the bug that prevented applications and NOIs being submitted to ALCS if no optional document is attached on mobile view