### PR TITLE
Fix Zero Optional Attachment Bug on Submission in Notifications

### DIFF
--- a/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.html
+++ b/portal-frontend/src/app/features/notifications/notification-details/notification-details.component.html
@@ -147,7 +147,7 @@
         [isLast]="last"
         (fileClicked)="openFile(file)">
       </app-optional-attachments-mobile-card>
-      <app-no-data *ngIf="otherFiles.length === 0" [showRequired]="showErrors"></app-no-data>
+      <app-no-data *ngIf="otherFiles.length === 0" [showRequired]="false"></app-no-data>
     </div>
 
     <div *ngIf="showEdit" class="edit-button">


### PR DESCRIPTION
Fixed the UI/UX bug that prevented users from submitting notifications when no optional attachment is attached on mobile view.