### PR TITLE
Fix Submission PDF Including "Other" Documents with Non-Applicant Source

### DIFF
--- a/services/apps/alcs/src/portal/pdf-generation/generate-noi-submission-document.service.ts
+++ b/services/apps/alcs/src/portal/pdf-generation/generate-noi-submission-document.service.ts
@@ -204,12 +204,13 @@ export class GenerateNoiSubmissionDocumentService {
 
     const otherDocuments = documents.filter(
       (e) =>
-        !e.typeCode ||
+        (!e.typeCode ||
         [
           DOCUMENT_TYPE.PHOTOGRAPH,
           DOCUMENT_TYPE.PROFESSIONAL_REPORT,
           DOCUMENT_TYPE.OTHER,
-        ].includes((e.typeCode ?? 'undefined') as DOCUMENT_TYPE),
+        ].includes((e.typeCode ?? 'undefined') as DOCUMENT_TYPE)) &&
+        e.document.source === DOCUMENT_SOURCE.APPLICANT,
     );
 
     const proposalMap = documents.filter(

--- a/services/apps/alcs/src/portal/pdf-generation/generate-submission-document.service.ts
+++ b/services/apps/alcs/src/portal/pdf-generation/generate-submission-document.service.ts
@@ -253,12 +253,13 @@ export class GenerateSubmissionDocumentService {
 
     const otherDocuments = documents.filter(
       (e) =>
-        !e.typeCode ||
+        (!e.typeCode ||
         [
           DOCUMENT_TYPE.PHOTOGRAPH,
           DOCUMENT_TYPE.PROFESSIONAL_REPORT,
           DOCUMENT_TYPE.OTHER,
-        ].includes((e.typeCode ?? 'undefined') as DOCUMENT_TYPE),
+        ].includes((e.typeCode ?? 'undefined') as DOCUMENT_TYPE)) &&
+        e.document.source === DOCUMENT_SOURCE.APPLICANT,
     );
 
     const proposalMap = documents.filter(


### PR DESCRIPTION
- Fixed Applicant Submission PDF (Portal download and {DATE}_APP_Submission.pdf on ALCS) including 'other' documents with non-applicant source for applications and NOIs
    - Documents added after submission by ALC or during L/FNG review.