### PR TITLE
Fix Error on Changing "Approx. Map Area" Field to Empty Value and Saving it

### DIFF
--- a/portal-frontend/src/app/services/application-parcel/application-parcel.service.ts
+++ b/portal-frontend/src/app/services/application-parcel/application-parcel.service.ts
@@ -54,7 +54,7 @@ export class ApplicationParcelService {
       this.overlayService.showSpinner();
       const formattedDtos = updateDtos.map((e) => ({
         ...e,
-        mapAreaHectares: e.mapAreaHectares ? parseFloat(e.mapAreaHectares) : e.mapAreaHectares,
+        mapAreaHectares: e.mapAreaHectares ? parseFloat(e.mapAreaHectares) : null,
       }));
 
       const result = await firstValueFrom(

--- a/portal-frontend/src/app/services/notice-of-intent-parcel/notice-of-intent-parcel.service.ts
+++ b/portal-frontend/src/app/services/notice-of-intent-parcel/notice-of-intent-parcel.service.ts
@@ -54,7 +54,7 @@ export class NoticeOfIntentParcelService {
       this.overlayService.showSpinner();
       const formattedDtos = updateDtos.map((e) => ({
         ...e,
-        mapAreaHectares: e.mapAreaHectares ? parseFloat(e.mapAreaHectares) : e.mapAreaHectares,
+        mapAreaHectares: e.mapAreaHectares ? parseFloat(e.mapAreaHectares) : null,
       }));
 
       const result = await firstValueFrom(

--- a/portal-frontend/src/app/services/notification-parcel/notification-parcel.service.ts
+++ b/portal-frontend/src/app/services/notification-parcel/notification-parcel.service.ts
@@ -51,7 +51,7 @@ export class NotificationParcelService {
       this.overlayService.showSpinner();
       const formattedDtos = updateDtos.map((e) => ({
         ...e,
-        mapAreaHectares: e.mapAreaHectares ? parseFloat(e.mapAreaHectares) : e.mapAreaHectares,
+        mapAreaHectares: e.mapAreaHectares ? parseFloat(e.mapAreaHectares) : null,
       }));
 
       const result = await firstValueFrom(


### PR DESCRIPTION
In parcel details step on portal submission, clearing "Approx. Map Area" field value and trying to save it after it has been saved before could cause 500 error on server side. This commit fixes the issue by sending null value instead of empty string to the server side.