### PR TITLE
Fix ALCS Advanced Search "Date Range" Results Bugs

### DIFF
--- a/services/apps/alcs/src/alcs/search/application/application-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/application/application-advanced-search.service.ts
@@ -269,7 +269,7 @@ export class ApplicationAdvancedSearchService {
     }
 
     if (searchDto.dateSubmittedTo !== undefined) {
-      query.andWhere('app.date_submitted_to_alc <= :date_submitted_to', {
+      query.andWhere('app.date_submitted_to_alc < :date_submitted_to', {
         date_submitted_to: getNextDayToPacific(
           searchDto.dateSubmittedTo,
         ).toISOString(),
@@ -300,7 +300,7 @@ export class ApplicationAdvancedSearchService {
     }
 
     if (searchDto.dateDecidedTo) {
-      query.andWhere('decision.date <= :decision_date_to', {
+      query.andWhere('decision.date < :decision_date_to', {
         decision_date_to: getNextDayToPacific(
           searchDto.dateDecidedTo,
         ).toISOString(),

--- a/services/apps/alcs/src/alcs/search/inquiry/inquiry-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/inquiry/inquiry-advanced-search.service.ts
@@ -11,6 +11,7 @@ import { LocalGovernment } from '../../local-government/local-government.entity'
 import { SEARCH_CACHE_TIME } from '../search.config';
 import { AdvancedSearchResultDto, SearchRequestDto } from '../search.dto';
 import { InquirySearchView } from './inquiry-search-view.entity';
+import { getNextDayToPacific, getStartOfDayToPacific } from '../../../utils/pacific-date-time-helper';
 
 @Injectable()
 export class InquiryAdvancedSearchService {
@@ -284,16 +285,20 @@ export class InquiryAdvancedSearchService {
       query = query.andWhere(
         'inquiry.date_submitted_to_alc >= :date_submitted_from',
         {
-          date_submitted_from: new Date(searchDto.dateSubmittedFrom),
+          date_submitted_from: getStartOfDayToPacific(
+            searchDto.dateSubmittedFrom
+          ).toISOString(),
         },
       );
     }
 
     if (searchDto.dateSubmittedTo !== undefined) {
       query = query.andWhere(
-        'inquiry.date_submitted_to_alc <= :date_submitted_to',
+        'inquiry.date_submitted_to_alc < :date_submitted_to',
         {
-          date_submitted_to: new Date(searchDto.dateSubmittedTo),
+          date_submitted_to: getNextDayToPacific(
+            searchDto.dateSubmittedTo
+          ).toISOString(),
         },
       );
     }

--- a/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/notice-of-intent/notice-of-intent-advanced-search.service.ts
@@ -287,7 +287,7 @@ export class NoticeOfIntentAdvancedSearchService {
         {
           date_submitted_from: getStartOfDayToPacific(
             searchDto.dateSubmittedFrom,
-          ),
+          ).toISOString(),
         },
       );
     }
@@ -298,7 +298,7 @@ export class NoticeOfIntentAdvancedSearchService {
         {
           date_submitted_to: getNextDayToPacific(
             searchDto.dateSubmittedTo,
-          ),
+          ).toISOString(),
         },
       );
     }
@@ -327,7 +327,7 @@ export class NoticeOfIntentAdvancedSearchService {
     }
 
     if (searchDto.dateDecidedTo) {
-      query = query.andWhere('decision.date <= :decision_date_to', {
+      query = query.andWhere('decision.date < :decision_date_to', {
         decision_date_to: getNextDayToPacific(
           searchDto.dateDecidedTo,
         ).toISOString(),

--- a/services/apps/alcs/src/alcs/search/notification/notification-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/notification/notification-advanced-search.service.ts
@@ -11,6 +11,7 @@ import { Notification } from '../../notification/notification.entity';
 import { SEARCH_CACHE_TIME } from '../search.config';
 import { AdvancedSearchResultDto, SearchRequestDto } from '../search.dto';
 import { NotificationSubmissionSearchView } from './notification-search-view.entity';
+import { getNextDayToPacific, getStartOfDayToPacific } from '../../../utils/pacific-date-time-helper';
 
 @Injectable()
 export class NotificationAdvancedSearchService {
@@ -210,16 +211,20 @@ export class NotificationAdvancedSearchService {
       query = query.andWhere(
         'notification.date_submitted_to_alc >= :date_submitted_from',
         {
-          date_submitted_from: new Date(searchDto.dateSubmittedFrom),
+          date_submitted_from: getStartOfDayToPacific(
+            searchDto.dateSubmittedFrom
+          ).toISOString(),
         },
       );
     }
 
     if (searchDto.dateSubmittedTo !== undefined) {
       query = query.andWhere(
-        'notification.date_submitted_to_alc <= :date_submitted_to',
+        'notification.date_submitted_to_alc < :date_submitted_to',
         {
-          date_submitted_to: new Date(searchDto.dateSubmittedTo),
+          date_submitted_to: getNextDayToPacific(
+            searchDto.dateSubmittedTo
+          ).toISOString(),
         },
       );
     }

--- a/services/apps/alcs/src/alcs/search/planning-review/planning-review-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/planning-review/planning-review-advanced-search.service.ts
@@ -284,13 +284,17 @@ export class PlanningReviewAdvancedSearchService {
 
     if (searchDto.dateSubmittedFrom !== undefined) {
       query.andWhere('referral.submission_date >= :date_submitted_from', {
-        date_submitted_from: new Date(searchDto.dateSubmittedFrom),
+        date_submitted_from: getStartOfDayToPacific(
+          searchDto.dateSubmittedFrom
+        ).toISOString(),
       });
     }
 
     if (searchDto.dateSubmittedTo !== undefined) {
-      query.andWhere('referral.submission_date <= :date_submitted_to', {
-        date_submitted_to: new Date(searchDto.dateSubmittedTo),
+      query.andWhere('referral.submission_date < :date_submitted_to', {
+        date_submitted_to: getNextDayToPacific(
+          searchDto.dateSubmittedTo
+        ).toISOString(),
       });
     }
     promises.push(query.getMany());
@@ -318,7 +322,7 @@ export class PlanningReviewAdvancedSearchService {
     }
 
     if (searchDto.dateDecidedTo) {
-      query.andWhere('decision.date <= :decision_date_to', {
+      query.andWhere('decision.date < :decision_date_to', {
         decision_date_to: getNextDayToPacific(
           searchDto.dateDecidedTo,
         ).toISOString(),


### PR DESCRIPTION
ALCS Advanced Search:

- Fixed search results showing for the next day after "Submitted to ALC - End Date" and "Decision - End Date" fields. 
- Fixed pacific time conversion not being used. (Changed `new Date()` to `getNextDayToPacific()` and `getStartOfDayToPacific()`)
- Added toISOString for standardizing. 