### PR TITLE
Fix "For Discussion" Column Showing the Furthest Date Instead of Closest

### DIFF
--- a/services/apps/alcs/src/alcs/application/application-decision-meeting/application-decision-meeting.service.ts
+++ b/services/apps/alcs/src/alcs/application/application-decision-meeting/application-decision-meeting.service.ts
@@ -131,7 +131,17 @@ export class ApplicationDecisionMeetingService {
   > {
     return await this.appDecisionMeetingRepository
       .createQueryBuilder('meeting')
-      .select('reconsideration.uuid, MAX(meeting.date) as next_meeting')
+      .select('reconsideration.uuid', 'uuid')
+      .addSelect(
+        `
+        CASE
+          WHEN MIN(CASE WHEN meeting.date >= (CURRENT_DATE) THEN meeting.date END) is NOT NULL
+          THEN MIN(CASE WHEN meeting.date >= (CURRENT_DATE) THEN meeting.date END)
+        ELSE MAX(CASE WHEN meeting.date < (CURRENT_DATE) THEN meeting.date END)
+        END
+        `,
+        'next_meeting',
+      )
       .innerJoin('meeting.application', 'application')
       .innerJoin('application.reconsiderations', 'reconsideration')
       .innerJoin('reconsideration.card', 'card')
@@ -145,7 +155,17 @@ export class ApplicationDecisionMeetingService {
   > {
     return await this.appDecisionMeetingRepository
       .createQueryBuilder('meeting')
-      .select('application.uuid, MAX(meeting.date) as next_meeting')
+      .select('application.uuid', 'uuid')
+      .addSelect(
+        `
+        CASE
+          WHEN MIN(CASE WHEN meeting.date >= (CURRENT_DATE) THEN meeting.date END) is NOT NULL
+          THEN MIN(CASE WHEN meeting.date >= (CURRENT_DATE) THEN meeting.date END)
+        ELSE MAX(CASE WHEN meeting.date < (CURRENT_DATE) THEN meeting.date END)
+        END
+        `,
+        'next_meeting',
+      )
       .innerJoin('meeting.application', 'application')
       .innerJoin('application.card', 'card')
       .where(`card.status_code != '${CARD_STATUS.DECISION_RELEASED}'`)

--- a/services/apps/alcs/src/alcs/planning-review/planning-review-meeting/planning-review-meeting.service.ts
+++ b/services/apps/alcs/src/alcs/planning-review/planning-review-meeting/planning-review-meeting.service.ts
@@ -102,7 +102,17 @@ export class PlanningReviewMeetingService {
   > {
     return await this.meetingRepository
       .createQueryBuilder('meeting')
-      .select('planningReview.uuid, MAX(meeting.date) as next_meeting')
+      .select('planningReview.uuid', 'uuid')
+      .addSelect(
+        `
+        CASE
+          WHEN MIN(CASE WHEN meeting.date >= (CURRENT_DATE) THEN meeting.date END) is NOT NULL
+          THEN MIN(CASE WHEN meeting.date >= (CURRENT_DATE) THEN meeting.date END)
+        ELSE MAX(CASE WHEN meeting.date < (CURRENT_DATE) THEN meeting.date END)
+        END
+        `,
+        'next_meeting',
+      )
       .innerJoin('meeting.planningReview', 'planningReview')
       .innerJoin('planningReview.referrals', 'referrals')
       .innerJoin('referrals.card', 'card')


### PR DESCRIPTION
- If file has only meetings in the past, show the latest one. 
- If file has meetings in the past and the future, show the closest future one. 
- If the file has only meetings in the future, show the closest future one. 