### PR TITLE
Fix Multiple Files Showing in One Line in Public Search View

### DIFF
--- a/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/pfrs-details/pfrs-details.component.html
@@ -180,7 +180,7 @@
   </div>
 
   <div class="subheading2 grid-1">Cross Sections</div>
-  <div class="grid-double">
+  <div class="grid-double multiple-documents">
     <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>
@@ -188,7 +188,7 @@
   </div>
 
   <div class="subheading2 grid-1">Reclamation Plan</div>
-  <div class="grid-double">
+  <div class="grid-double multiple-documents">
     <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>

--- a/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/pofo-details/pofo-details.component.html
@@ -122,7 +122,7 @@
   </div>
 
   <div class="subheading2 grid-1">Cross Sections</div>
-  <div class="grid-double">
+  <div class="grid-double multiple-documents">
     <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>

--- a/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.html
+++ b/portal-frontend/src/app/features/public/application/submission/roso-details/roso-details.component.html
@@ -114,7 +114,7 @@
   </div>
 
   <div class="subheading2 grid-1">Cross Sections</div>
-  <div class="grid-double">
+  <div class="grid-double multiple-documents">
     <a *ngFor="let file of crossSections" (click)="openFile(file)">
       {{ file.fileName }}
     </a>

--- a/portal-frontend/src/app/features/public/application/submission/submission-details.component.scss
+++ b/portal-frontend/src/app/features/public/application/submission/submission-details.component.scss
@@ -158,4 +158,10 @@
       }
     }
   }
+
+  .multiple-documents {
+    a {
+      display: block;
+    }
+  }
 }

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pfrs-details/pfrs-details.component.html
@@ -183,7 +183,7 @@
 
   <ng-container *ngIf="noiSubmission.soilIsExtractionOrMining || noiSubmission.soilIsAreaWideFilling">
     <div class="subheading2 grid-1">Cross Sections</div>
-    <div class="grid-double">
+    <div class="grid-double multiple-documents">
       <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/pofo-details/pofo-details.component.html
@@ -117,7 +117,7 @@
 
   <ng-container *ngIf="noiSubmission.soilIsAreaWideFilling">
     <div class="subheading2 grid-1">Cross Sections</div>
-    <div class="grid-double">
+    <div class="grid-double multiple-documents">
       <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.html
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/roso-details/roso-details.component.html
@@ -117,7 +117,7 @@
 
   <ng-container *ngIf="noiSubmission?.soilIsExtractionOrMining">
     <div class="subheading2 grid-1">Cross Sections</div>
-    <div class="grid-double">
+    <div class="grid-double multiple-documents">
       <a *ngFor="let file of crossSections" (click)="openFile(file)">
         {{ file.fileName }}
       </a>

--- a/portal-frontend/src/app/features/public/notice-of-intent/submission/submission-details.component.scss
+++ b/portal-frontend/src/app/features/public/notice-of-intent/submission/submission-details.component.scss
@@ -152,4 +152,10 @@
       }
     }
   }
+
+  .multiple-documents {
+    a {
+      display: block;
+    }
+  }
 }


### PR DESCRIPTION
Fix the bug for "Cross Sections" and "Reclamation Plan" fields showing multiple files in one line in public view. The issue was for applications and NOIs for the following file types:
- POFO
- ROSO
- PFRS