### PR TITLE
Resend the response when an email is changed

### DIFF
--- a/alcs-frontend/src/app/features/notification/intake/intake.component.ts
+++ b/alcs-frontend/src/app/features/notification/intake/intake.component.ts
@@ -92,6 +92,7 @@ export class IntakeComponent implements OnInit, OnDestroy {
             if (update) {
               this.toastService.showSuccessToast('Notification updated');
               this.contactEmail = email;
+              this.resendResponse();
             }
           }
         }


### PR DESCRIPTION
When the email is changed, the resend method is called.
This method resent the notification to the new email, but also changes the status of the Notification:
await this.updateStatus(
        submission.uuid,
        NOTIFICATION_STATUS.ALC_RESPONSE_SENT,
      );

Which I believe will solve the sync issue displayed on the screen.