### PR TITLE
ALCS-2254 DTO and map change

### DIFF
--- a/services/apps/alcs/src/alcs/incoming-files/incoming-file.controller.ts
+++ b/services/apps/alcs/src/alcs/incoming-files/incoming-file.controller.ts
@@ -57,7 +57,9 @@ export class IncomingFileController {
         applicant: incomingFile.applicant,
         boardCode: incomingFile.code,
         type: CARD_TYPE.APP,
-        assignee: this.mapper.map(user, User, UserDto),
+        assignee: incomingFile.name
+          ? this.mapper.map(user, User, UserDto)
+          : null,
         highPriority: incomingFile.high_priority,
         activeDays: incomingFile.active_days,
       };
@@ -77,7 +79,9 @@ export class IncomingFileController {
         applicant: incomingFile.applicant,
         boardCode: incomingFile.code,
         type: CARD_TYPE.APP,
-        assignee: this.mapper.map(user, User, UserDto),
+        assignee: incomingFile.name
+          ? this.mapper.map(user, User, UserDto)
+          : null,
         highPriority: incomingFile.high_priority,
         activeDays: incomingFile.active_days,
       };
@@ -97,7 +101,9 @@ export class IncomingFileController {
         applicant: incomingFile.applicant,
         boardCode: incomingFile.code,
         type: CARD_TYPE.PLAN,
-        assignee: this.mapper.map(user, User, UserDto),
+        assignee: incomingFile.name
+          ? this.mapper.map(user, User, UserDto)
+          : null,
         highPriority: incomingFile.high_priority,
         activeDays: incomingFile.active_days,
       };

--- a/services/apps/alcs/src/alcs/incoming-files/incoming-file.dto.ts
+++ b/services/apps/alcs/src/alcs/incoming-files/incoming-file.dto.ts
@@ -5,7 +5,7 @@ export type IncomingFileDto = {
   applicant: string;
   boardCode: string;
   type: string;
-  assignee: UserDto;
+  assignee: UserDto | null;
   highPriority: boolean;
   activeDays: number;
 };


### PR DESCRIPTION
Since the assigned user in the incoming files comes from a LEFT JOIN query, the mapping doesn't check if the assigned is null always returning an user to the DTO (showing the unwanted NA).
If the incoming file can be unassigned, makes sense to make the DTO nullable, and check on map method the query output, if the assignee is null or not, and populate it properly.

With this api change, the frontend check doesn't need to be changed, and it's ngIf check:
<app-avatar-circle
          *ngIf="incomingFile.assignee"
          [initials]="incomingFile.assignee.initials"
          [name]="incomingFile.assignee.prettyName"
        ></app-avatar-circle>

Will reflect the reality.