### PR TITLE
Feature/alcs 2262 evidentiary record table tweaks

### DIFF
--- a/alcs-frontend/src/app/shared/application-document/application-document.component.html
+++ b/alcs-frontend/src/app/shared/application-document/application-document.component.html
@@ -29,6 +29,11 @@
     <td *matCellDef="let element; let i = index" mat-cell>{{ i + 1 }}</td>
   </ng-container>
 
+  <ng-container matColumnDef="source">
+    <th *matHeaderCellDef mat-header-cell>Source</th>
+    <td *matCellDef="let element" mat-cell>{{ element.source }}</td>
+  </ng-container>
+
   <ng-container matColumnDef="type">
     <th *matHeaderCellDef mat-header-cell>Type</th>
     <td *matCellDef="let element" mat-cell>{{ element.type?.label }}</td>
@@ -44,11 +49,6 @@
         {{ element.fileName | truncate: fileNameTruncLen}}
       </a>
     </td>
-  </ng-container>
-
-  <ng-container matColumnDef="source">
-    <th *matHeaderCellDef mat-header-cell>Source</th>
-    <td *matCellDef="let element" mat-cell>{{ element.source }}</td>
   </ng-container>
 
   <ng-container matColumnDef="uploadedAt">

--- a/alcs-frontend/src/app/shared/application-document/application-document.component.scss
+++ b/alcs-frontend/src/app/shared/application-document/application-document.component.scss
@@ -50,7 +50,6 @@
 }
 
 a {
-  font-size: 14px !important;
   cursor: pointer;
 }
 
@@ -87,4 +86,51 @@ a {
 .cdk-drag-placeholder,
 .cdk-drag-preview {
   background-color: colors.$grey-light !important;
+}
+
+
+.mat-column-index {
+  width: 2%;
+}
+
+.mat-column-source {
+  word-wrap: break-word !important;
+  white-space: unset !important;
+  flex: 0 0 10% !important;
+  width: 10% !important;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.mat-column-type {
+  word-wrap: break-word !important;
+  white-space: unset !important;
+  flex: 0 0 21% !important;
+  width: 21% !important;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.mat-column-fileName {
+  word-wrap: break-word !important;
+  white-space: unset !important;
+  flex: 0 0 55% !important;
+  width: 55% !important;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.mat-column-uploadedAt {
+  width: 18%;
+}
+
+.mat-column-action {
+  width: 2%;
+}
+
+.mat-column-sorting {
+  width: 2%;
 }

--- a/alcs-frontend/src/app/shared/application-document/application-document.component.ts
+++ b/alcs-frontend/src/app/shared/application-document/application-document.component.ts
@@ -19,7 +19,7 @@ export class ApplicationDocumentComponent implements OnChanges {
 
   @ViewChild('orderMenu') orderMenu!: TemplateRef<any>;
 
-  displayedColumns: string[] = ['index', 'type', 'fileName', 'source', 'uploadedAt', 'action', 'sorting'];
+  displayedColumns: string[] = ['index', 'source', 'type', 'fileName', 'uploadedAt', 'action', 'sorting'];
   documents: ApplicationDocumentDto[] = [];
   dataSource = new MatTableDataSource<ApplicationDocumentDto>([]);
   overlayRef: OverlayRef | null = null;
@@ -36,7 +36,7 @@ export class ApplicationDocumentComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     this.loadDocuments();
     if (!this.sortable) {
-      this.displayedColumns = ['index', 'type', 'fileName', 'source', 'uploadedAt', 'action'];
+      this.displayedColumns = ['index', 'source', 'type', 'fileName', 'uploadedAt', 'action'];
     }
   }
 

--- a/services/apps/alcs/src/providers/typeorm/migrations/1728585388487-doc_code_rename.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1728585388487-doc_code_rename.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DocCodeRename1728585388487 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE "alcs"."document_code" SET 
+                "label" = 'Other File Info'
+             WHERE "code" = 'OTHR';`,
+          );
+          await queryRunner.query(
+            `UPDATE "alcs"."document_code" SET 
+                "label" = 'C&E Letter'
+            WHERE "code" = 'CAEL';`,
+          );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `UPDATE "alcs"."document_code" SET 
+                "label" = 'Other Correspondence or File Information'
+            WHERE "code" = 'OTHR';`,
+          );
+        await queryRunner.query(
+            `UPDATE "alcs"."document_code" SET 
+                "label" = 'Compliance and Enforcement Letter'
+            WHERE "code" = 'CAEL';`,
+          );
+        
+    }
+
+}


### PR DESCRIPTION
The file name column now occupies 55% of the whole table, and the other columns have their respective percentages.
The migration updates the labels of the two requested types.

![image](https://github.com/user-attachments/assets/e54cc7ec-d90d-4ec7-b229-cdefe05042a0)
Layout

![image](https://github.com/user-attachments/assets/3912fd87-1672-42ba-b853-3785d518a62e)
Two lines file name