### PR TITLE
Always show building plans w/ no data if empty in ALCS app info

### DIFF
--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/naru-details/naru-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/naru-details/naru-details.component.html
@@ -150,16 +150,15 @@
     </div>
   </div>
 
-  <ng-container *ngIf="buildingPlans.length !== 0">
-    <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
-    <div class="grid-double">
-      <div *ngFor="let file of buildingPlans">
-        <a (click)="openFile(file)">
-          {{ file.fileName }}
-        </a>
-      </div>
+  <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
+  <div class="grid-double">
+    <div *ngFor="let file of buildingPlans">
+      <a (click)="openFile(file)">
+        {{ file.fileName }}
+      </a>
     </div>
-  </ng-container>
+    <app-no-data *ngIf="buildingPlans.length === 0"></app-no-data>
+  </div>
 
   <ng-container *ngIf="_applicationSubmission.naruWillImportFill">
     <div class="subheading2 grid-1">Describe the type and amount of fill proposed to be placed.</div>


### PR DESCRIPTION
Previously, the building plans were hidden if not provided. Now, it shows"No Data".
