### PR TITLE
Fix selected ETL missed review deletions

### DIFF
--- a/services/apps/alcs/src/providers/typeorm/migrations/1730144741773-fix_etl_missed_deleting_lfgn_reviews.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1730144741773-fix_etl_missed_deleting_lfgn_reviews.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixEtlMissedDeletingLfgnReviews1730144741773
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`
+        delete from alcs.application_submission_review asr
+        where       asr.application_file_number in ('61301', '67497')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
- When an app is returned from L/FNG, normally the review is deleted
- This was missed in ETL
- Any apps where a *second* L/FNG review was not yet started will be unable to start, since the old one already exists, creating a foreign key constraint validation
