### PR TITLE
ALCS-2327 Allow the changes on desktop version to reflect on mobile

### DIFF
--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/additional-information/additional-information.component.html
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/additional-information/additional-information.component.html
@@ -129,6 +129,7 @@
                   min="0.01"
                   placeholder="Type area"
                   [formControlName]="element.id + '-area'"
+                  (change)="onChangeArea(element.id, $event)"
                 />
                 <span matTextSuffix>m<sup>2</sup></span>
               </mat-form-field>

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/additional-information/additional-information.component.ts
@@ -353,6 +353,12 @@ export class AdditionalInformationComponent extends FilesStepComponent implement
     this.form.markAsDirty();
   }
 
+  private setStructureAreaInput(structure: FormProposedStructure, value: string) {
+    structure.area = value;
+    this.prepareStructureSpecificTextInputs();
+    this.form.markAsDirty();
+  }
+
   onChangeStructureType(id: string, value: STRUCTURE_TYPES) {
     const structure = this.proposedStructures.find((structure) => structure.id === id);
     if (!structure) {
@@ -381,6 +387,16 @@ export class AdditionalInformationComponent extends FilesStepComponent implement
         }
       });
     }
+  }
+
+  onChangeArea(id: string, event: Event) {
+    const input = event.target as HTMLInputElement;
+    const structure = this.proposedStructures.find((structure) => structure.id === id);
+    if (!structure) {
+      console.error('Failed to find structure');
+      return;
+    }
+    return this.setStructureAreaInput(structure, input.value);
   }
 
   onStructureRemove(id: string) {

--- a/portal-frontend/src/app/features/notice-of-intents/edit-submission/additional-information/additional-information.component.ts
+++ b/portal-frontend/src/app/features/notice-of-intents/edit-submission/additional-information/additional-information.component.ts
@@ -396,7 +396,7 @@ export class AdditionalInformationComponent extends FilesStepComponent implement
       console.error('Failed to find structure');
       return;
     }
-    return this.setStructureAreaInput(structure, input.value);
+    this.setStructureAreaInput(structure, input.value);
   }
 
   onStructureRemove(id: string) {


### PR DESCRIPTION
Every time the desktop version changes the structure type, it persists on the FormProposedStructure array, and this array is used to render the mobile component.
It doesn't exist when the area is changed, that's why it was not carried to the mobile view.
Added two methods to replicate the behavior to the Area fields, and carry the changes to the mobile view.