### PR TITLE
ALCS-1874 Refresh tags params correctly

### DIFF
--- a/alcs-frontend/src/app/features/search/notification-search-table/notification-search-table.component.ts
+++ b/alcs-frontend/src/app/features/search/notification-search-table/notification-search-table.component.ts
@@ -98,11 +98,11 @@ export class NotificationSearchTableComponent {
         board: e.boardCode,
         class: e.class,
         status: {
-          backgroundColor: status!.alcsBackgroundColor,
-          textColor: status!.alcsColor,
-          borderColor: status!.alcsBackgroundColor,
-          label: status!.label,
-          shortLabel: status!.label,
+          backgroundColor: status ? status!.alcsBackgroundColor : '',
+          textColor: status ? status!.alcsColor : '',
+          borderColor: status ? status!.alcsBackgroundColor : '',
+          label: status ? status!.label : '',
+          shortLabel: status ? status!.label : '',
         },
       };
     });

--- a/alcs-frontend/src/app/features/search/search.component.ts
+++ b/alcs-frontend/src/app/features/search/search.component.ts
@@ -336,7 +336,7 @@ export class SearchComponent implements OnInit, OnDestroy {
         : undefined,
       fileTypes: fileTypes,
       tagCategoryId: this.searchForm.controls.tagCategory.value ?? undefined,
-      tagIds: this.searchForm.controls.tag.value ?? undefined,
+      tagIds: this.tags.map((t) => t.uuid),
     };
   }
 


### PR DESCRIPTION
The search params were not being refresh correctly on subsequent searches.
Used array mapping to update.

Also found an unrelated bug that was firing some console errors, and fixed it.
![image](https://github.com/user-attachments/assets/a869a1a0-48b1-4423-8828-2a6b74ede6b7)
