### PR TITLE
ALCS-2399 Order by label on retrieving codes

### DIFF
--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
@@ -609,7 +609,11 @@ export class ApplicationDecisionV2Service {
         },
       }),
       this.decisionComponentTypeRepository.find(),
-      this.decisionConditionTypeRepository.find(),
+      this.decisionConditionTypeRepository.find({
+        order: {
+          label: 'ASC',
+        },
+      }),
       this.naruNaruSubtypeRepository.find(),
     ]);
 

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
@@ -500,7 +500,11 @@ export class NoticeOfIntentDecisionV2Service {
     const values = await Promise.all([
       this.decisionOutcomeRepository.find(),
       this.decisionComponentTypeRepository.find(),
-      this.decisionConditionTypeRepository.find(),
+      this.decisionConditionTypeRepository.find({
+        order: {
+          label: 'ASC',
+        },
+      }),
     ]);
 
     return {


### PR DESCRIPTION
The drop down on add condition should be ordered by label. Previously it was ordered by edited date.

![image](https://github.com/user-attachments/assets/e83e8345-9834-49e4-aa4a-72e82659ead0)

![image](https://github.com/user-attachments/assets/71486664-1df2-47f5-8649-f23c1a91862f)
