### PR TITLE
Feature/alcs 2092 add due date to condition types

### DIFF
--- a/services/apps/alcs/src/providers/typeorm/migrations/1732821130867-add_due_date_to_conditions.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1732821130867-add_due_date_to_conditions.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDueDateToConditions1732821130867 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE "alcs"."application_decision_condition_type" SET "is_single_date_checked" = true, "single_date_label" = 'Due Date' WHERE "code" NOT IN ('SRPT', 'UEND')`);
+        await queryRunner.query(`UPDATE "alcs"."notice_of_intent_decision_condition_type" SET "is_single_date_checked" = true, "single_date_label" = 'Due Date' WHERE "code" NOT IN ('SRPT', 'UEND')`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1732821130867-add_due_date_to_conditions.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1732821130867-add_due_date_to_conditions.ts
@@ -8,6 +8,7 @@ export class AddDueDateToConditions1732821130867 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        // N/A
     }
 
 }


### PR DESCRIPTION
Update conditions types according to this description:

Use a migration to add optional single date field with label = Due Date to the Edit Decision UI of all conditions EXCEPT 'Use End Date' condition type or 'Status Report' condition type