### PR TITLE
ALCS-2361 Leave total set on component

### DIFF
--- a/portal-frontend/src/app/features/home/inbox/inbox-list/inbox-list.component.ts
+++ b/portal-frontend/src/app/features/home/inbox/inbox-list/inbox-list.component.ts
@@ -18,7 +18,6 @@ export class InboxListComponent implements OnDestroy {
   @Input() set items(items: InboxResultDto[]) {
     this._items = items;
     this.visibleCount = items.length;
-    this.totalCount = items.length;
   }
 
   @Output() loadMore = new EventEmitter<void>();


### PR DESCRIPTION
Setting the total as the length was preventing the mobile view to paginate.
The total is set properly on component's input.
![image](https://github.com/user-attachments/assets/cd551fd6-0524-4664-bc56-ae075649a94b)
