### PR TITLE
ALCS-2416 Added  preventDefault on dropdowns

### DIFF
--- a/alcs-frontend/src/app/features/search/search.component.html
+++ b/alcs-frontend/src/app/features/search/search.component.html
@@ -37,6 +37,7 @@
           [fileTypeData]="portalStatusDataService"
           (fileTypeChange)="onPortalStatusChange($event)"
           [preExpanded]="['With ALC']"
+          onclick="event.preventDefault()"
         />
       </div>
 
@@ -47,6 +48,7 @@
           #fileTypeDropDown
           [fileTypeData]="fileTypeService"
           (fileTypeChange)="onFileTypeChange($event)"
+          onclick="event.preventDefault()"
         />
       </div>
     </div>


### PR DESCRIPTION
I couldn't find a particular reason for the dropdown to open.
With some research I read that angular material have some issues with overlays, and these two being the same component could make use of the same overlay. (and it triggers the first dropdown no matter where it's on the screen ... I tested it ... :( )
But the event.preventDefault stops the overlay actions, and triggers only the desired functionality.
