### PR TITLE
ALCS-2453 Handle unique descriptions on condition types

### DIFF
--- a/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types-dialog/decision-condition-types-dialog.component.html
+++ b/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types-dialog/decision-condition-types-dialog.component.html
@@ -25,6 +25,9 @@
         <mat-label>Description</mat-label>
         <input required matInput id="description" formControlName="description" name="description" />
       </mat-form-field>
+      <div *ngIf="conditionTypeForm.get('description')?.hasError('descriptionExists')">
+        <app-error-message message="Description already in use or deteled, pick a different description."></app-error-message>
+      </div>
     </div>
 
     <div class="dialog-field full-width">

--- a/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types-dialog/decision-condition-types-dialog.component.ts
+++ b/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types-dialog/decision-condition-types-dialog.component.ts
@@ -17,7 +17,7 @@ import {
 import { ApplicationDecisionConditionService } from '../../../../services/application/decision/application-decision-v2/application-decision-condition/application-decision-condition.service';
 import { NoticeOfIntentDecisionConditionService } from '../../../../services/notice-of-intent/decision-v2/notice-of-intent-decision-condition/notice-of-intent-decision-condition.service';
 import { catchError, debounceTime, map, Observable, of, switchMap } from 'rxjs';
-import { codeExistsValidator } from '../../../../shared/validators/code-exists-validator';
+import { codeExistsValidator, descriptionExistsValidator } from '../../../../shared/validators/code-exists-validator';
 
 enum ValidationFields {
   Dates,
@@ -54,6 +54,7 @@ export class DecisionConditionTypesDialogComponent {
     this.conditionTypeForm = new FormGroup({
       description: new FormControl(this.data?.content?.description ? this.data.content.description : '', [
         Validators.required,
+        descriptionExistsValidator(this.data?.existingDescriptions ? this.data.existingDescriptions : []),
       ]),
       label: new FormControl(this.data?.content?.label ? this.data.content.label : '', [Validators.required]),
       code: new FormControl(this.data?.content?.code ? this.data.content.code : '', [

--- a/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types.component.ts
+++ b/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types.component.ts
@@ -30,6 +30,7 @@ export class DecisionConditionTypesComponent implements OnInit {
 
   decisionConditionTypeDtos: ApplicationDecisionConditionTypeDto[] | NoticeOfIntentDecisionConditionTypeDto[] = [];
   decisionConditionTypeCodeDtos: string[] = [];
+  decisionConditionTypeDescriptionDtos: string[] = [];
   displayedColumns: string[] = ['label', 'description', 'code', 'isActive', 'actions'];
 
   constructor(
@@ -45,6 +46,7 @@ export class DecisionConditionTypesComponent implements OnInit {
     if (!this.service) return;
     this.decisionConditionTypeDtos = await this.service.fetch();
     this.decisionConditionTypeCodeDtos = await this.service.fetchCodesWithDeleted();
+    this.decisionConditionTypeDescriptionDtos = this.decisionConditionTypeDtos.map((d) => d.description);
   }
 
   async onCreate() {
@@ -57,6 +59,7 @@ export class DecisionConditionTypesComponent implements OnInit {
         service: this.service,
         conditionService: this.conditionService,
         existingCodes: this.decisionConditionTypeCodeDtos,
+        existingDescriptions: this.decisionConditionTypeDescriptionDtos,
       },
     });
     dialog.beforeClosed().subscribe(async (result) => {
@@ -77,6 +80,7 @@ export class DecisionConditionTypesComponent implements OnInit {
         conditionService: this.conditionService,
         content: dto,
         existingCodes: this.decisionConditionTypeCodeDtos,
+        existingDescriptions: this.decisionConditionTypeDescriptionDtos,
       },
     });
     dialog.beforeClosed().subscribe(async (result) => {

--- a/alcs-frontend/src/app/features/admin/decision-condition-types/decision-dialog-data.interface.ts
+++ b/alcs-frontend/src/app/features/admin/decision-condition-types/decision-dialog-data.interface.ts
@@ -9,4 +9,5 @@ export interface DecisionDialogDataInterface {
   conditionService: ApplicationDecisionConditionService | NoticeOfIntentDecisionConditionService;
   content: ApplicationDecisionConditionTypeDto;
   existingCodes: string[];
+  existingDescriptions: string[];
 }

--- a/alcs-frontend/src/app/shared/validators/code-exists-validator.ts
+++ b/alcs-frontend/src/app/shared/validators/code-exists-validator.ts
@@ -12,6 +12,17 @@ export function codeExistsValidator(existingCodes: string[]): ValidatorFn {
   };
 }
 
+export function descriptionExistsValidator(existingDescriptions: string[]): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value) return null;
+    const inputValue = control.value.toLowerCase();
+    if (existingDescriptions.some((description) => description.toLowerCase() === inputValue)) {
+      return { descriptionExists: true };
+    }
+    return null;
+  };
+}
+
 export function codeExistsDirectiveValidator(model: NgModel, existingCodes: string[], code: string) {
   const existingErrors = model.control.errors || {};
   const isExisting = existingCodes.includes(code.toLowerCase());


### PR DESCRIPTION
We have a constraint that all the CODE based entities should have an unique description.

What was done:

Check the existence of a description and display a clear message to the user about the uniqueness of the description.

![image](https://github.com/user-attachments/assets/9bbebdda-be8e-4457-ab96-59a3836dc19e)
