### PR TITLE
ALCS-2451 Allow to remove check box if the value is zero

### DIFF
--- a/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types-dialog/decision-condition-types-dialog.component.ts
+++ b/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types-dialog/decision-condition-types-dialog.component.ts
@@ -202,12 +202,12 @@ export class DecisionConditionTypesDialogComponent {
   hasAdminFee(
     conditions: Partial<ApplicationDecisionConditionDto>[] | Partial<NoticeOfIntentDecisionConditionDto>[],
   ): boolean {
-    return conditions.map((c) => c.administrativeFee).filter((f) => f !== null).length > 0;
+    return conditions.map((c) => c.administrativeFee).filter((f) => f !== null && f !== undefined && f > 0).length > 0;
   }
 
   hasSecurityAmount(
     conditions: Partial<ApplicationDecisionConditionDto>[] | Partial<NoticeOfIntentDecisionConditionDto>[],
   ): boolean {
-    return conditions.map((c) => c.securityAmount).filter((f) => f !== null).length > 0;
+    return conditions.map((c) => c.securityAmount).filter((f) => f !== null && f !== undefined && f > 0).length > 0;
   }
 }

--- a/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types.component.ts
+++ b/alcs-frontend/src/app/features/admin/decision-condition-types/decision-condition-types.component.ts
@@ -80,7 +80,7 @@ export class DecisionConditionTypesComponent implements OnInit {
         conditionService: this.conditionService,
         content: dto,
         existingCodes: this.decisionConditionTypeCodeDtos,
-        existingDescriptions: this.decisionConditionTypeDescriptionDtos,
+        existingDescriptions: this.decisionConditionTypeDescriptionDtos.filter((d) => d !== dto.description),
       },
     });
     dialog.beforeClosed().subscribe(async (result) => {


### PR DESCRIPTION
Allow the checkboxes to be disabled if the stored value is zero.

There's also a minor fix on the edit dialog, to prevent the validation from unique description on the actual value.