### PR TITLE
Fix Portal Status and File Type Dropdown Bugs

### DIFF
--- a/alcs-frontend/src/app/features/search/file-type-filter-drop-down/file-type-filter-drop-down.component.html
+++ b/alcs-frontend/src/app/features/search/file-type-filter-drop-down/file-type-filter-drop-down.component.html
@@ -1,13 +1,8 @@
-<mat-form-field
-  [matTooltip]="tooltip"
-  [matTooltipDisabled]="!tooltip"
-  appearance="outline"
-  class="file-type-input"
->
+<mat-form-field [matTooltip]="tooltip" [matTooltipDisabled]="!tooltip" appearance="outline" class="file-type-input">
   <mat-label>{{ label }}</mat-label>
   <input
     value="{{ getSelectedItems() }}"
-    id="type"
+    [id]="id"
     type="text"
     matInput
     [matAutocomplete]="auto"

--- a/alcs-frontend/src/app/features/search/file-type-filter-drop-down/file-type-filter-drop-down.component.ts
+++ b/alcs-frontend/src/app/features/search/file-type-filter-drop-down/file-type-filter-drop-down.component.ts
@@ -8,6 +8,7 @@ import {
   FlatTreeNode,
   TreeNode,
 } from '../../../services/search/file-type/file-type-data-source.service';
+import { PortalStatusDataSourceService } from '../../../services/search/portal-status/portal-status-data-source.service';
 
 @Component({
   selector: 'app-file-type-filter-drop-down[fileTypeData]',
@@ -34,10 +35,11 @@ export class FileTypeFilterDropDownComponent implements OnInit {
   componentTypeControl = new FormControl<string[] | undefined>(undefined);
   @Output() fileTypeChange = new EventEmitter<string[]>();
 
-  @Input() fileTypeData!: FileTypeDataSourceService;
+  @Input() fileTypeData!: FileTypeDataSourceService | PortalStatusDataSourceService;
   @Input() label!: string;
   @Input() tooltip = '';
   @Input() preExpanded: string[] = [];
+  @Input() id!: string;
 
   constructor() {
     this.treeFlattener = new MatTreeFlattener(this.transformer, this.getLevel, this.isExpandable, this.getChildren);

--- a/alcs-frontend/src/app/features/search/search.component.html
+++ b/alcs-frontend/src/app/features/search/search.component.html
@@ -37,7 +37,7 @@
           [fileTypeData]="portalStatusDataService"
           (fileTypeChange)="onPortalStatusChange($event)"
           [preExpanded]="['With ALC']"
-          onclick="event.preventDefault()"
+          id="portal-status"
         />
       </div>
 
@@ -48,7 +48,7 @@
           #fileTypeDropDown
           [fileTypeData]="fileTypeService"
           (fileTypeChange)="onFileTypeChange($event)"
-          onclick="event.preventDefault()"
+          id="file-type"
         />
       </div>
     </div>


### PR DESCRIPTION
fix the advanced search bug that clicking on "File Type" text on dropdown would open the "Current Portal Status" dropdown