### PR TITLE
ALCS-2474 Fix single date updates

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-condition/decision-condition.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-condition/decision-condition.component.ts
@@ -120,6 +120,11 @@ export class DecisionConditionComponent implements OnInit, OnChanges {
       const singleDateDto: ApplicationDecisionConditionDateDto = {};
 
       if (this.singleDate.value) {
+        if (this.data.dates && this.data.dates.length > 0) {
+          singleDateDto.uuid = this.data.dates[0].uuid;
+          singleDateDto.completedDate = this.data.dates[0].completedDate;
+          singleDateDto.comment = this.data.dates[0].comment;
+        }
         singleDateDto.date = this.singleDate.value.toDate().getTime();
       }
 


### PR DESCRIPTION
While saving the whole condition, with already having updated the date in a single date condition, the date row was being updated only with the date portion but deleting the completedDate and the comment, since it was being send to the backend ONLY the date attribute, deleting the attributes added earlier, and changing the status in a wrong way.
The change checks if there's more data on that date and emits everything.