### PR TITLE
ALCS-2478 Allow to add a new date on conditions component

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/conditions/condition/condition.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/conditions/condition/condition.component.ts
@@ -295,12 +295,12 @@ export class ConditionComponent implements OnInit, AfterViewInit {
       this.dataSource = new MatTableDataSource<ApplicationDecisionConditionDateWithIndex>(
         this.addIndex(this.sortDates(this.dates)),
       );
-      const conditionNewStatus = await this.decisionService.getStatus(this.condition.uuid);
-      this.condition.status = conditionNewStatus.status;
-      this.setPillLabel(this.condition.status);
     } else {
-      console.error('Date with specified UUID not found');
+      await this.addNewDate();
     }
+    const conditionNewStatus = await this.decisionService.getStatus(this.condition.uuid);
+    this.condition.status = conditionNewStatus.status;
+    this.setPillLabel(this.condition.status);
   }
 
   async onDeleteDate(dateUuid: string) {


### PR DESCRIPTION
When a condition has a nullable single date, adding a date is only possible while adding the condition, or editing the draft.
This small fix enables the date to be added also at the conditions view component, also changing the statuses in real time.