### PR TITLE
Align revert button to right like edit button

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.html
@@ -104,6 +104,7 @@
         </ng-container>
 
         <div
+          class="revert-to-draft-button"
           *ngIf="!decision.isDraft"
           [matTooltip]="decision.disabledMessage"
           [matTooltipDisabled]="!isPaused && !isDraftExists && !decision.hasDuplicateComponents"

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.scss
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.scss
@@ -83,9 +83,14 @@ hr {
   }
 }
 
-.edit-decision-button {
+.edit-decision-button,
+.revert-to-draft-button {
   grid-row: 1/2;
   grid-column: 3/4;
+}
+
+.revert-to-draft-button {
+  text-align: right;
 }
 
 .loading-overlay {


### PR DESCRIPTION
Edit draft and revert to draft buttons are separate, so grid settings were only being applied to one. This just adds the same grid column setting to the revert button, and aligns it right, so the button is flush.