### PR TITLE
2448: Fix public doc sorting

### DIFF
--- a/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
+++ b/portal-frontend/src/app/features/public/application/alc-review/submission-documents/submission-documents.component.ts
@@ -7,6 +7,8 @@ import { PublicDocumentDto } from '../../../../../services/public/public.dto';
 import { PublicService } from '../../../../../services/public/public.service';
 import { openFileInline } from '../../../../../shared/utils/file';
 
+type PublicDocumentWithoutTypeDto = Omit<PublicDocumentDto, 'type'>;
+
 @Component({
   selector: 'app-submission-documents[applicationSubmission]',
   templateUrl: './submission-documents.component.html',
@@ -21,13 +23,27 @@ export class PublicSubmissionDocumentsComponent implements OnInit, OnDestroy {
   @Input() applicationDocuments!: PublicDocumentDto[];
   @Input() applicationSubmission!: PublicApplicationSubmissionDto;
 
-  @ViewChild(MatSort) sort!: MatSort;
   dataSource: MatTableDataSource<PublicDocumentDto> = new MatTableDataSource<PublicDocumentDto>();
+  @ViewChild(MatSort) sort!: MatSort;
 
   constructor(private publicService: PublicService) {}
 
   ngOnInit(): void {
-    this.dataSource = new MatTableDataSource(this.applicationDocuments);
+    this.dataSource.data = this.applicationDocuments;
+    this.dataSource.sortingDataAccessor = (
+      { type, ...rest }: PublicDocumentDto,
+      sortHeaderId: string,
+    ): string | number => {
+      if (sortHeaderId === 'type') {
+        return type?.label ?? '';
+      }
+
+      return (rest as PublicDocumentWithoutTypeDto)[sortHeaderId as keyof PublicDocumentWithoutTypeDto] ?? '';
+    };
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.sort = this.sort;
   }
 
   async openFile(file: PublicDocumentDto) {


### PR DESCRIPTION
3 things were needed:
- The table source data needed to be updated via the `data` property rather than replaced
- Sorting needed to be initialized after view init (at this point, all columns were sortable except for type)
- A custom sorting accessor was needed to make the type column work (since its value was a sub property)
