### PR TITLE
ALCS-2468 Remove the individual date method

### DIFF
--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision-v2.service.ts
@@ -497,13 +497,6 @@ export class ApplicationDecisionV2Service {
       throw new ServiceNotFoundException(`Failed to find decision with uuid ${uuid}`);
     }
 
-    const dateIds: string[] = [];
-    applicationDecision.conditions.forEach((c) => {
-      c.dates.forEach((d) => {
-        dateIds.push(d.uuid);
-      });
-    });
-
     await this.decisionConditionService.remove(applicationDecision.conditions);
     applicationDecision.conditions = [];
 
@@ -527,9 +520,6 @@ export class ApplicationDecisionV2Service {
 
     await this.appDecisionRepository.softRemove([applicationDecision]);
     await this.updateApplicationDecisionDates(applicationDecision);
-    dateIds.forEach(async (id) => {
-      await this.dateService.delete(id, true);
-    });
   }
 
   async attachDocument(decisionUuid: string, file: MultipartFile, user: User) {

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-v2/notice-of-intent-decision-v2.service.ts
@@ -405,13 +405,6 @@ export class NoticeOfIntentDecisionV2Service {
       throw new ServiceNotFoundException(`Failed to find decision with uuid ${uuid}`);
     }
 
-    const dateIds: string[] = [];
-    noticeOfIntentDecision.conditions.forEach((c) => {
-      c.dates.forEach((d) => {
-        dateIds.push(d.uuid);
-      });
-    });
-
     await this.decisionConditionService.remove(noticeOfIntentDecision.conditions);
     noticeOfIntentDecision.conditions = [];
 
@@ -434,9 +427,6 @@ export class NoticeOfIntentDecisionV2Service {
 
     await this.noticeOfIntentDecisionRepository.softRemove([noticeOfIntentDecision]);
     await this.updateDecisionDates(noticeOfIntentDecision);
-    dateIds.forEach(async (id) => {
-      await this.dateService.delete(id, true);
-    });
   }
 
   async attachDocument(decisionUuid: string, file: MultipartFile, user: User) {


### PR DESCRIPTION
Since we are hard deleting the conditions making it an empty array, there's no need to handle the dates individually anymore. TypeORM is making the deletion when saving the decision entity.