### PR TITLE
ALCS-2514: Fix dockerfile warnings

### DIFF
--- a/alcs-frontend/Dockerfile
+++ b/alcs-frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci
 # Copy the source code to the /app directory
 COPY . .
 
-ENV NODE_OPTIONS="--max-old-space-size=2048"
+ENV NODE_OPTIONS "--max-old-space-size=2048"
 
 # Build the application
 RUN npm run build --  --output-path=dist --output-hashing=all
@@ -47,10 +47,10 @@ COPY --from=build /app/dist /usr/share/nginx/html
 RUN chmod -R go+rwx /usr/share/nginx/html/assets
 
 # provide dynamic scp content-src
-ENV ENABLED_CONNECT_SRC=" 'self' http://localhost:* nrs.objectstore.gov.bc.ca"
+ENV ENABLED_CONNECT_SRC " 'self' http://localhost:* nrs.objectstore.gov.bc.ca"
 
 # set to true to enable maintenance mode
-ENV MAINTENANCE_MODE="false"
+ENV MAINTENANCE_MODE "false"
 
 # When the container starts, replace the settings.json with values from environment variables
 ENTRYPOINT [ "./init.sh" ]

--- a/portal-frontend/Dockerfile
+++ b/portal-frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci
 # Copy the source code to the /app directory
 COPY . .
 
-ENV NODE_OPTIONS="--max-old-space-size=2048"
+ENV NODE_OPTIONS "--max-old-space-size=2048"
 
 # Build the application
 RUN npm run build --  --output-path=dist --output-hashing=all
@@ -47,7 +47,7 @@ COPY --from=build /app/dist /usr/share/nginx/html
 RUN chmod -R go+rwx /usr/share/nginx/html/assets
 
 # provide dynamic scp content-src
-ENV ENABLED_CONNECT_SRC=" 'self' http://localhost:* nrs.objectstore.gov.bc.ca"
+ENV ENABLED_CONNECT_SRC " 'self' http://localhost:* nrs.objectstore.gov.bc.ca"
 
 # When the container starts, replace the settings.json with values from environment variables
 ENTRYPOINT [ "./init.sh" ]

--- a/services/Dockerfile
+++ b/services/Dockerfile
@@ -3,7 +3,7 @@
 # https://www.tomray.dev/nestjs-docker-production
 ###################
 
-FROM node:20-alpine As development
+FROM node:20-alpine AS development
 
 WORKDIR /opt/app-root/
 
@@ -19,7 +19,7 @@ USER node
 # BUILD FOR PRODUCTION
 ###################
 
-FROM node:20-alpine As build
+FROM node:20-alpine AS build
 ARG NEST_APP=alcs
 
 WORKDIR /opt/app-root/
@@ -40,7 +40,7 @@ USER node
 # PRODUCTION
 ###################
 
-FROM node:20-alpine As production
+FROM node:20-alpine AS production
 ARG NEST_APP=alcs
 
 # Init 

--- a/services/Dockerfile.local
+++ b/services/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:20-alpine As development
+FROM node:20-alpine AS development
 
 WORKDIR /opt/app-root/
 RUN chown node:node /opt/app-root/

--- a/services/Dockerfile.migrate
+++ b/services/Dockerfile.migrate
@@ -2,13 +2,13 @@
 # DATABASE MIGRATION 
 #####################
 
-FROM node:20-alpine As development
+FROM node:20-alpine AS development
 
 WORKDIR /opt/app-root/
 
 # OpenShift fixes
 RUN chmod og+rwx /opt/app-root/ /var/run
-ENV NPM_CONFIG_USERCONFIG=/opt/app-root/.npmrc
+ENV NPM_CONFIG_USERCONFIG /opt/app-root/.npmrc
 RUN npm config set cache $/opt/app-root/.npm
 
 COPY package*.json ./
@@ -20,7 +20,7 @@ ARG environment=production
 ENV NODE_ENV ${environment}
 
 ARG NEST_APP=alcs
-ENV NEST_APP=${NEST_APP}
+ENV NEST_APP ${NEST_APP}
 
 COPY . .
 


### PR DESCRIPTION
Address the warnings in [ALCS-2514](https://apps.nrs.gov.bc.ca/int/jira/browse/ALCS-2514):

```
344 - FromAsCasing: 'As' and 'FROM' keywords' casing do not match (line 6)
345 - FromAsCasing: 'As' and 'FROM' keywords' casing do not match (line 22)
346 - FromAsCasing: 'As' and 'FROM' keywords' casing do not match (line 43)
347 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 55) 
```