### PR TITLE
2546: Pass submitted date to upstream submission methods

### DIFF
--- a/services/apps/alcs/src/alcs/notification/notification.controller.ts
+++ b/services/apps/alcs/src/alcs/notification/notification.controller.ts
@@ -117,18 +117,20 @@ export class NotificationController {
       user,
     );
 
+    const notification = await this.notificationService.getByFileNumber(submission.fileNumber);
+
     const documents = await this.notificationDocumentService.list(fileNumber);
     const document = documents.find(
       (document) => document.type?.code === DOCUMENT_TYPE.LTSA_LETTER,
     );
 
     if (document) {
-      const emailDidSend =
-        await this.notificationSubmissionService.sendAndRecordLTSAPackage(
-          submission,
-          document,
-          user,
-        );
+      const emailDidSend = await this.notificationSubmissionService.sendAndRecordLTSAPackage(
+        submission,
+        document,
+        user,
+        notification.dateSubmittedToAlc ?? undefined,
+      );
 
       if (!emailDidSend) {
         throw new BaseServiceException(

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.service.spec.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.service.spec.ts
@@ -243,24 +243,18 @@ describe('NotificationSubmissionService', () => {
     mockNotificationService.submit.mockRejectedValue(new Error());
 
     await expect(
-      service.submitToAlcs(
-        noticeOfIntentSubmission as ValidatedNotificationSubmission,
-      ),
-    ).rejects.toMatchObject(
-      new BaseServiceException(`Failed to submit notification: ${fileNumber}`),
-    );
+      service.submitToAlcs(noticeOfIntentSubmission as ValidatedNotificationSubmission, new Date()),
+    ).rejects.toMatchObject(new BaseServiceException(`Failed to submit notification: ${fileNumber}`));
   });
 
   it('should call out to service on submitToAlcs', async () => {
     const notification = new Notification({
       dateSubmittedToAlc: new Date(),
     });
-    mockStatusService.setStatusDate.mockResolvedValue(
-      new NotificationSubmissionToSubmissionStatus(),
-    );
+    mockStatusService.setStatusDate.mockResolvedValue(new NotificationSubmissionToSubmissionStatus());
 
     mockNotificationService.submit.mockResolvedValue(notification);
-    await service.submitToAlcs(mockSubmission);
+    await service.submitToAlcs(mockSubmission, new Date());
 
     expect(mockNotificationService.submit).toBeCalledTimes(1);
     expect(mockStatusService.setStatusDate).toHaveBeenCalledTimes(1);

--- a/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
+++ b/services/apps/alcs/src/portal/notification-submission/notification-submission.service.ts
@@ -366,14 +366,14 @@ export class NotificationSubmissionService {
     };
   }
 
-  async submitToAlcs(notificationSubmission: ValidatedNotificationSubmission) {
+  async submitToAlcs(notificationSubmission: ValidatedNotificationSubmission, dateSubmitted: Date) {
     try {
       const submittedNotification = await this.notificationService.submit({
         fileNumber: notificationSubmission.fileNumber,
         applicant: notificationSubmission.applicant,
         localGovernmentUuid: notificationSubmission.localGovernmentUuid,
         typeCode: notificationSubmission.typeCode,
-        dateSubmittedToAlc: new Date(),
+        dateSubmittedToAlc: dateSubmitted,
       });
 
       await this.notificationSubmissionStatusService.setStatusDate(
@@ -414,8 +414,9 @@ export class NotificationSubmissionService {
     submission: NotificationSubmission,
     document: NotificationDocument,
     user: User,
+    dateSubmitted?: Date,
   ): Promise<boolean> {
-    const templateData = await this.generateSrwEmailData(submission, document);
+    const templateData = await this.generateSrwEmailData(submission, document, dateSubmitted);
 
     const didSend = await this.emailService.sendEmail({
       to: [templateData.to],
@@ -458,6 +459,7 @@ export class NotificationSubmissionService {
   private async generateSrwEmailData(
     submission: NotificationSubmission,
     pdfDocument: NotificationDocument,
+    dateSubmitted?: Date,
   ) {
     const notification = await this.notificationService.getByFileNumber(
       submission.fileNumber,
@@ -468,9 +470,7 @@ export class NotificationSubmissionService {
       fileNumber: submission.fileNumber,
       contactName: `${submission.contactFirstName} ${submission.contactLastName}`,
       status: 'ALC Response Sent',
-      dateSubmitted: dayjs(notification.dateSubmittedToAlc).format(
-        'MMMM DD, YYYY',
-      ),
+      dateSubmitted: dayjs(dateSubmitted).format('MMMM DD, YYYY'),
       fileName: pdfDocument.document.fileName,
       submittersFileNumber: submission.submittersFileNumber!,
     });

--- a/services/apps/alcs/src/portal/pdf-generation/generate-srw-document.service.spec.ts
+++ b/services/apps/alcs/src/portal/pdf-generation/generate-srw-document.service.spec.ts
@@ -98,7 +98,7 @@ describe('GenerateSrwDocumentService', () => {
       name: 'Bruce Wayne',
     });
 
-    const res = await service.generate('fake', userEntity);
+    const res = await service.generate('fake', userEntity, new Date());
 
     expect(mockCdogsService.generateDocument).toBeCalledTimes(1);
     expect(mockLocalGovernmentService.getByUuid).toBeCalledTimes(1);


### PR DESCRIPTION
- This helps make sure notification, PDF, and email all have the same
  submitted date
- It also allows them to execute in any order
