### PR TITLE
ALCS-2390: Remove "Use End Date" Field from Application and NOI Prep

### DIFF
--- a/alcs-frontend/src/app/features/application/proposal/naru/naru.component.html
+++ b/alcs-frontend/src/app/features/application/proposal/naru/naru.component.html
@@ -1,7 +1,1 @@
-<div>
-  <div class="subheading2">Use End Date</div>
-  <app-inline-datepicker
-    [value]="application?.proposalEndDate"
-    (save)="updateApplicationValue('proposalEndDate', $event)"
-  ></app-inline-datepicker>
-</div>
+<div></div>

--- a/alcs-frontend/src/app/features/application/proposal/nfu/nfu.component.html
+++ b/alcs-frontend/src/app/features/application/proposal/nfu/nfu.component.html
@@ -14,10 +14,3 @@
     (save)="updateApplicationValue('nfuUseSubType', $event)"
   ></app-inline-ng-select>
 </div>
-<div>
-  <div class="subheading2">Use End Date</div>
-  <app-inline-datepicker
-    [value]="application?.proposalEndDate"
-    (save)="updateApplicationValue('proposalEndDate', $event)"
-  ></app-inline-datepicker>
-</div>

--- a/alcs-frontend/src/app/features/application/proposal/soil/soil.component.html
+++ b/alcs-frontend/src/app/features/application/proposal/soil/soil.component.html
@@ -1,29 +1,3 @@
-<div *ngIf="submission?.typeCode !== 'PFRS'">
-  <div class="subheading2">Use End Date</div>
-  <app-inline-datepicker
-    [value]="application?.proposalEndDate"
-    (save)="updateApplicationValue('proposalEndDate', $event)"
-  ></app-inline-datepicker>
-</div>
-
-<div class="input-table">
-  <div *ngIf="submission?.typeCode === 'PFRS'">
-    <div class="subheading2">Use End Date (Placement of Fill)</div>
-    <app-inline-datepicker
-      [value]="application?.proposalEndDate2"
-      (save)="updateApplicationValue('proposalEndDate2', $event)"
-    ></app-inline-datepicker>
-  </div>
-
-  <div *ngIf="submission?.typeCode === 'PFRS'">
-    <div class="subheading2">Use End Date (Removal of Soil)</div>
-    <app-inline-datepicker
-      [value]="application?.proposalEndDate"
-      (save)="updateApplicationValue('proposalEndDate', $event)"
-    ></app-inline-datepicker>
-  </div>
-</div>
-
 <div *ngIf="submission?.soilFillTypeToPlace">
   <div class="subheading2 header">Type, origin and quality of fill proposed to be placed.</div>
   {{ submission?.soilFillTypeToPlace }}

--- a/alcs-frontend/src/app/features/notice-of-intent/proposal/soil/soil.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/proposal/soil/soil.component.html
@@ -1,29 +1,3 @@
-<div *ngIf="submission?.typeCode !== 'PFRS'">
-  <div class="subheading2">Use End Date</div>
-  <app-inline-datepicker
-    [value]="noticeOfIntent?.proposalEndDate"
-    (save)="updateValue('proposalEndDate', $event)"
-  ></app-inline-datepicker>
-</div>
-
-<div class="input-table">
-  <div *ngIf="submission?.typeCode === 'PFRS'">
-    <div class="subheading2">Use End Date (Placement of Fill)</div>
-    <app-inline-datepicker
-      [value]="noticeOfIntent?.proposalEndDate2"
-      (save)="updateValue('proposalEndDate2', $event)"
-    ></app-inline-datepicker>
-  </div>
-
-  <div *ngIf="submission?.typeCode === 'PFRS'">
-    <div class="subheading2">Use End Date (Removal of Soil)</div>
-    <app-inline-datepicker
-      [value]="noticeOfIntent?.proposalEndDate"
-      (save)="updateValue('proposalEndDate', $event)"
-    ></app-inline-datepicker>
-  </div>
-</div>
-
 <div *ngIf="submission?.soilFillTypeToPlace">
   <div class="subheading2 header">Type, origin and quality of fill proposed to be placed.</div>
   {{ submission?.soilFillTypeToPlace }}


### PR DESCRIPTION
- "Use End Date" from NARU, NFU, POFO, and ROSO applications
- "Use End Date" from POFO and ROSO NOIs
- "Use End Date (Placement of Fill/Removal of Soil)" from PFRS applications and NOIs