### PR TITLE
QA-2412: Disable Save on Enter Key When Paragraph is Allowed and Allow Paragraph on Proposal Summary 

### DIFF
--- a/alcs-frontend/src/app/features/application/overview/overview.component.html
+++ b/alcs-frontend/src/app/features/application/overview/overview.component.html
@@ -13,6 +13,7 @@
   <h5>Proposal Summary</h5>
   <app-inline-edit
     [value]="summary"
+    [allowParagraphs]="true"
     placeholder="Add Proposal Summary"
     (save)="onSaveSummary($event)"
   ></app-inline-edit>

--- a/alcs-frontend/src/app/features/notice-of-intent/overview/overview.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/overview/overview.component.html
@@ -13,6 +13,7 @@
   <h5>Proposal Summary</h5>
   <app-inline-edit
     [value]="summary"
+    [allowParagraphs]="true"
     placeholder="Add Proposal Summary"
     (save)="onSaveSummary($event)"
   ></app-inline-edit>

--- a/alcs-frontend/src/app/shared/inline-editors/inline-textarea-edit/inline-textarea-edit.component.html
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-textarea-edit/inline-textarea-edit.component.html
@@ -28,7 +28,7 @@
       [placeholder]="placeholder"
       #editInput
       [(ngModel)]="pendingValue"
-      (keydown.enter)="confirmEdit()"
+      (keydown.enter)="allowParagraphs ? null : confirmEdit()"
       (keydown.escape)="cancelEdit()"
     ></textarea>
     <div class="button-container">


### PR DESCRIPTION
This pull request includes changes to the `alcs-frontend` project to enhance the functionality of inline editing components by allowing paragraph breaks in text areas. The most important changes include updates to the `overview.component.html` files and modifications to the `inline-textarea-edit.component.html` file to support this new feature.

Enhancements to inline editing components:

* [`alcs-frontend/src/app/features/application/overview/overview.component.html`](diffhunk://#diff-db7ecd942f621d74383de52c431e7cb1b83339871ec49fc4a7347227f8b2ea52R16): Added the `allowParagraphs` attribute to the `<app-inline-edit>` component to enable paragraph breaks in the proposal summary.
* [`alcs-frontend/src/app/features/notice-of-intent/overview/overview.component.html`](diffhunk://#diff-1ce5fff1e238521a5eb9d72fa57f5cd6d2c9c21f6a86200f8f9fa1112f7fcebeR16): Added the `allowParagraphs` attribute to the `<app-inline-edit>` component to enable paragraph breaks in the proposal summary.
* [`alcs-frontend/src/app/shared/inline-editors/inline-textarea-edit/inline-textarea-edit.component.html`](diffhunk://#diff-06665dd0072fd2021393de669c16da4eec0a2765629e24cf7db288d585783eeeL31-R31): Modified the `keydown.enter` event to conditionally allow paragraph breaks based on the `allowParagraphs` attribute.