### PR TITLE
ALCS-2260: QA #2: Fix complete filter and update status properly

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/conditions/condition/condition.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/conditions/condition/condition.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import moment from 'moment';
 import { ApplicationDecisionComponentToConditionLotService } from '../../../../../services/application/decision/application-decision-v2/application-decision-component-to-condition-lot/application-decision-component-to-condition-lot.service';
 import { ApplicationDecisionConditionService } from '../../../../../services/application/decision/application-decision-v2/application-decision-condition/application-decision-condition.service';
@@ -48,6 +48,8 @@ export class ConditionComponent implements OnInit, AfterViewInit {
   @Input() isDraftDecision!: boolean;
   @Input() fileNumber!: string;
   @Input() index!: number;
+
+  @Output() statusChange: EventEmitter<string> = new EventEmitter();
 
   DateType = DateType;
 
@@ -308,6 +310,7 @@ export class ConditionComponent implements OnInit, AfterViewInit {
     }
     const conditionNewStatus = await this.decisionService.getStatus(this.condition.uuid);
     this.condition.status = conditionNewStatus.status;
+    this.statusChange.emit(this.condition.status);
     this.setPillLabel(this.condition.status);
   }
 
@@ -323,6 +326,7 @@ export class ConditionComponent implements OnInit, AfterViewInit {
         );
         const conditionNewStatus = await this.decisionService.getStatus(this.condition.uuid);
         this.condition.status = conditionNewStatus.status;
+        this.statusChange.emit(this.condition.status);
         this.setPillLabel(this.condition.status);
       }
     }

--- a/alcs-frontend/src/app/features/application/decision/conditions/conditions.component.html
+++ b/alcs-frontend/src/app/features/application/decision/conditions/conditions.component.html
@@ -51,6 +51,7 @@
           [isDraftDecision]="decision.isDraft"
           [fileNumber]="fileNumber"
           [index]="j + 1"
+          (statusChange)="onStatusChange(condition, $event)"
         ></app-condition>
       </div>
     </div>

--- a/alcs-frontend/src/app/features/application/decision/conditions/conditions.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/conditions/conditions.component.ts
@@ -40,7 +40,7 @@ export type ApplicationDecisionWithConditionComponentLabels = ApplicationDecisio
 };
 
 export const CONDITION_STATUS = {
-  COMPLETE: 'COMPLETE',
+  COMPLETED: 'COMPLETED',
   ONGOING: 'ONGOING',
   PENDING: 'PENDING',
   PASTDUE: 'PASTDUE',
@@ -54,7 +54,7 @@ export const CONDITION_STATUS = {
 })
 export class ConditionsComponent implements OnInit {
   conditionLabelsByStatus: Record<keyof typeof CONDITION_STATUS, string> = {
-    COMPLETE: 'Complete',
+    COMPLETED: 'Complete',
     ONGOING: 'Ongoing',
     PENDING: 'Pending',
     PASTDUE: 'Past Due',
@@ -155,7 +155,7 @@ export class ConditionsComponent implements OnInit {
     decision.conditions = conditions.sort((a, b) => {
       const order = [
         CONDITION_STATUS.ONGOING,
-        CONDITION_STATUS.COMPLETE,
+        CONDITION_STATUS.COMPLETED,
         CONDITION_STATUS.PASTDUE,
         CONDITION_STATUS.EXPIRED,
       ];

--- a/alcs-frontend/src/app/features/application/decision/conditions/conditions.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/conditions/conditions.component.ts
@@ -243,4 +243,8 @@ export class ConditionsComponent implements OnInit {
 
     return conditions.filter((condition) => this.conditionFilters.includes(condition.status));
   }
+
+  onStatusChange(condition: ApplicationDecisionConditionWithStatus, newStatus: string) {
+    condition.status = newStatus;
+  }
 }

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/condition/condition.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/condition/condition.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import moment from 'moment';
 import { NoticeOfIntentDecisionConditionService } from '../../../../../services/notice-of-intent/decision-v2/notice-of-intent-decision-condition/notice-of-intent-decision-condition.service';
 import {
@@ -39,6 +39,8 @@ export class ConditionComponent implements OnInit, AfterViewInit {
   @Input() isDraftDecision!: boolean;
   @Input() fileNumber!: string;
   @Input() index!: number;
+
+  @Output() statusChange: EventEmitter<string> = new EventEmitter();
 
   DateType = DateType;
 
@@ -219,6 +221,7 @@ export class ConditionComponent implements OnInit, AfterViewInit {
 
       const conditionNewStatus = await this.decisionService.getStatus(this.condition.uuid);
       this.condition.status = conditionNewStatus.status;
+      this.statusChange.emit(this.condition.status);
       this.setPillLabel(this.condition.status);
     } else {
       console.error('Date with specified UUID not found');
@@ -238,6 +241,7 @@ export class ConditionComponent implements OnInit, AfterViewInit {
 
         const conditionNewStatus = await this.decisionService.getStatus(this.condition.uuid);
         this.condition.status = conditionNewStatus.status;
+        this.statusChange.emit(this.condition.status);
         this.setPillLabel(this.condition.status);
       }
     }

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.html
@@ -46,6 +46,7 @@
           [isDraftDecision]="decision.isDraft"
           [fileNumber]="fileNumber"
           [index]="j + 1"
+          (statusChange)="onStatusChange(condition, $event)"
         ></app-condition>
       </div>
     </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.ts
@@ -239,4 +239,8 @@ export class ConditionsComponent implements OnInit {
 
     return conditions.filter((condition) => this.conditionFilters.includes(condition.status));
   }
+
+  onStatusChange(condition: DecisionConditionWithStatus, newStatus: string) {
+    condition.status = newStatus;
+  }
 }

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/conditions/conditions.component.ts
@@ -38,7 +38,7 @@ export type DecisionWithConditionComponentLabels = NoticeOfIntentDecisionWithLin
 };
 
 export const CONDITION_STATUS = {
-  COMPLETE: 'complete',
+  COMPLETED: 'completed',
   ONGOING: 'ongoing',
   PENDING: 'pending',
   PASTDUE: 'pastdue',
@@ -52,7 +52,7 @@ export const CONDITION_STATUS = {
 })
 export class ConditionsComponent implements OnInit {
   conditionLabelsByStatus: Record<keyof typeof CONDITION_STATUS, string> = {
-    COMPLETE: 'Complete',
+    COMPLETED: 'Complete',
     ONGOING: 'Ongoing',
     PENDING: 'Pending',
     PASTDUE: 'Past Due',
@@ -151,7 +151,7 @@ export class ConditionsComponent implements OnInit {
     decision.conditions = conditions.sort((a, b) => {
       const order = [
         CONDITION_STATUS.ONGOING,
-        CONDITION_STATUS.COMPLETE,
+        CONDITION_STATUS.COMPLETED,
         CONDITION_STATUS.PASTDUE,
         CONDITION_STATUS.EXPIRED,
       ];


### PR DESCRIPTION
- There was a typo making complete filter fail
- When the status was updated in the single condition component, the change was not being propogated to the list condition component's data, so when the list redrew the single components, it used its old data
   - Added an event emitted to update the list status when updating the single status
