### PR TITLE
ALCS-2476: Disable deploy concurrency

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,9 +12,15 @@ jobs:
     with:
       environment: test
     secrets: inherit
+    concurrency: 
+      group: deploy-test
+      cancel-in-progress: true
   deploy-prod:
     needs: deploy-test
     uses: ./.github/workflows/deploy.yml
     with:
       environment: prod
     secrets: inherit
+    concurrency: 
+      group: deploy-prod
+      cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,9 @@ env:
 
 jobs:
   deploy:
+    concurrency: 
+      group: deploy-${{ inputs.environment }}
+      cancel-in-progress: true
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
By adding the concurrency key in both the main CD workflow (cd.yml) and the deploy workflow (deploy.yml), we ensure that:

- A new deployment cancels any in-progress deployment for the same environment
- Only one deployment per environment (test, prod) runs at a time
- No outdated deployments remain stuck in a pending/waiting for approval state
- This prevents long-running or stuck (waiting for approval) deployments, which will eventually timeout