### PR TITLE
ALCS-2414: Enhance email logging

### DIFF
--- a/services/apps/alcs/src/providers/email/email.service.ts
+++ b/services/apps/alcs/src/providers/email/email.service.ts
@@ -181,6 +181,14 @@ export class EmailService {
       let errorMessage = e.message;
       if (e.response) {
         errorMessage = e.response.data.detail;
+
+        // Add error details if they exist
+        if (e.response.data.errors) {
+          const errorDetails = e.response.data.errors
+            .map(error => error.message)
+            .join(', ');
+          errorMessage = `${errorMessage}: ${errorDetails}`;
+        }
       }
 
       this.repository.save(


### PR DESCRIPTION
Add error details to logs

- [API Documentation](https://ches.api.gov.bc.ca/api/v1/docs#tag/Email/operation/postEmail) indicates an `errors` list of objects containing `message` and `value` keys exists for only the `422` response. `400` and `401` responses don't have `errors`
- Should still work with the [Metabase dashboard](https://alcs-metabase-dev.apps.silver.devops.gov.bc.ca/question/31-email-status-dashboard?file_number=&recipients=&errors=)