### PR TITLE
ALCS-2579: Make shared upload dialog more robust and performant

### DIFF
--- a/alcs-frontend/src/app/features/inquiry/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/inquiry/documents/documents.component.ts
@@ -11,6 +11,7 @@ import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/c
 import { DOCUMENT_SYSTEM } from '../../../shared/document/document.dto';
 import { FILE_NAME_TRUNCATE_LENGTH } from '../../../shared/constants';
 import { DocumentUploadDialogComponent } from '../../../shared/document-upload-dialog/document-upload-dialog.component';
+import { DocumentUploadDialogData } from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
 
 @Component({
   selector: 'app-documents',
@@ -47,16 +48,18 @@ export class DocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
+    const data: DocumentUploadDialogData = {
+      allowsFileEdit: true,
+      fileId: this.fileId,
+      documentService: this.inquiryDocumentService,
+    };
+
     this.dialog
       .open(DocumentUploadDialogComponent, {
         minWidth: '600px',
         maxWidth: '800px',
         width: '70%',
-        data: {
-          fileId: this.fileId,
-          documentService: this.inquiryDocumentService,
-          allowsFileEdit: true,
-        },
+        data,
       })
       .afterClosed()
       .subscribe((isDirty) => {
@@ -89,17 +92,19 @@ export class DocumentsComponent implements OnInit {
   }
 
   onEditFile(element: PlanningReviewDocumentDto) {
+    const data: DocumentUploadDialogData = {
+      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+      fileId: this.fileId,
+      existingDocument: element,
+      documentService: this.inquiryDocumentService,
+    };
+
     this.dialog
       .open(DocumentUploadDialogComponent, {
         minWidth: '600px',
         maxWidth: '800px',
         width: '70%',
-        data: {
-          fileId: this.fileId,
-          existingDocument: element,
-          documentService: this.inquiryDocumentService,
-          allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
-        },
+        data,
       })
       .afterClosed()
       .subscribe((isDirty: boolean) => {

--- a/alcs-frontend/src/app/features/notification/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/notification/documents/documents.component.ts
@@ -12,6 +12,15 @@ import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/c
 import { DOCUMENT_SYSTEM } from '../../../shared/document/document.dto';
 import { FILE_NAME_TRUNCATE_LENGTH } from '../../../shared/constants';
 import { DocumentUploadDialogComponent } from '../../../shared/document-upload-dialog/document-upload-dialog.component';
+import {
+  DocumentUploadDialogData,
+  DocumentUploadDialogOptions,
+} from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
+
+const DOCUMENT_UPLOAD_DIALOG_OPTIONS: DocumentUploadDialogOptions = {
+  allowedVisibilityFlags: ['A', 'G', 'P'],
+  allowsFileEdit: true,
+};
 
 @Component({
   selector: 'app-notification-documents',
@@ -48,17 +57,17 @@ export class NotificationDocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
+    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
+      fileId: this.fileId,
+      documentService: this.notificationDocumentService,
+    });
+
     this.dialog
       .open(DocumentUploadDialogComponent, {
         minWidth: '600px',
         maxWidth: '800px',
         width: '70%',
-        data: {
-          fileId: this.fileId,
-          documentService: this.notificationDocumentService,
-          allowedVisibilityFlags: ['A', 'G', 'P'],
-          allowsFileEdit: true,
-        },
+        data,
       })
       .afterClosed()
       .subscribe((isDirty) => {
@@ -91,18 +100,19 @@ export class NotificationDocumentsComponent implements OnInit {
   }
 
   onEditFile(element: NoticeOfIntentDocumentDto) {
+    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
+      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+      fileId: this.fileId,
+      existingDocument: element,
+      documentService: this.notificationDocumentService,
+    });
+
     this.dialog
       .open(DocumentUploadDialogComponent, {
         minWidth: '600px',
         maxWidth: '800px',
         width: '70%',
-        data: {
-          fileId: this.fileId,
-          existingDocument: element,
-          documentService: this.notificationDocumentService,
-          allowedVisibilityFlags: ['A', 'G', 'P'],
-          allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
-        },
+        data,
       })
       .afterClosed()
       .subscribe((isDirty: boolean) => {

--- a/alcs-frontend/src/app/features/planning-review/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/planning-review/documents/documents.component.ts
@@ -10,6 +10,15 @@ import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/c
 import { DOCUMENT_SYSTEM } from '../../../shared/document/document.dto';
 import { FILE_NAME_TRUNCATE_LENGTH } from '../../../shared/constants';
 import { DocumentUploadDialogComponent } from '../../../shared/document-upload-dialog/document-upload-dialog.component';
+import {
+  DocumentUploadDialogData,
+  DocumentUploadDialogOptions,
+} from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
+
+const DOCUMENT_UPLOAD_DIALOG_OPTIONS: DocumentUploadDialogOptions = {
+  allowedVisibilityFlags: ['C'],
+  allowsFileEdit: true,
+};
 
 @Component({
   selector: 'app-documents',
@@ -48,17 +57,17 @@ export class DocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
+    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
+      fileId: this.fileId,
+      documentService: this.planningReviewDocumentService,
+    });
+
     this.dialog
       .open(DocumentUploadDialogComponent, {
         minWidth: '600px',
         maxWidth: '800px',
         width: '70%',
-        data: {
-          fileId: this.fileId,
-          documentService: this.planningReviewDocumentService,
-          allowedVisibilityFlags: ['C'],
-          allowsFileEdit: true,
-        },
+        data,
       })
       .afterClosed()
       .subscribe((isDirty) => {
@@ -91,18 +100,19 @@ export class DocumentsComponent implements OnInit {
   }
 
   onEditFile(element: PlanningReviewDocumentDto) {
+    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
+      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+      fileId: this.fileId,
+      existingDocument: element,
+      documentService: this.planningReviewDocumentService,
+    });
+
     this.dialog
       .open(DocumentUploadDialogComponent, {
         minWidth: '600px',
         maxWidth: '800px',
         width: '70%',
-        data: {
-          fileId: this.fileId,
-          existingDocument: element,
-          documentService: this.planningReviewDocumentService,
-          allowsFileEdit: true,
-          allowedVisibilityFlags: ['C'],
-        },
+        data,
       })
       .afterClosed()
       .subscribe((isDirty: boolean) => {

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.html
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.html
@@ -86,23 +86,23 @@
         </mat-select>
       </mat-form-field>
     </div>
-    <div *ngIf="data.selectableParcels && type.value === DOCUMENT_TYPE.CERTIFICATE_OF_TITLE">
+    <div *ngIf="selectableParcels && type.value === DOCUMENT_TYPE.CERTIFICATE_OF_TITLE">
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Associated Parcel</mat-label>
         <mat-select [formControl]="parcelId">
-          <mat-option *ngFor="let parcel of data.selectableParcels" [value]="parcel.uuid">
-            #{{ parcel.index + 1 }} PID:
+          <mat-option *ngFor="let parcel of selectableParcels; let i = index" [value]="parcel.uuid">
+            #{{ i + 1 }} PID:
             <span *ngIf="parcel.pid">{{ parcel.pid | mask: '000-000-000' }}</span>
             <span *ngIf="!parcel.pid">No Data</span></mat-option
           >
         </mat-select>
       </mat-form-field>
     </div>
-    <div *ngIf="data.selectableOwners && type.value === DOCUMENT_TYPE.CORPORATE_SUMMARY">
+    <div *ngIf="selectableOwners && type.value === DOCUMENT_TYPE.CORPORATE_SUMMARY">
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Associated Organization</mat-label>
         <mat-select [formControl]="ownerId">
-          <mat-option *ngFor="let owner of data.selectableOwners" [value]="owner.uuid">
+          <mat-option *ngFor="let owner of selectableOwners" [value]="owner.uuid">
             {{ owner.label }}
           </mat-option>
         </mat-select>

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.dto.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.dto.ts
@@ -1,4 +1,5 @@
 import { DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DOCUMENT_TYPE, DocumentTypeDto } from '../../shared/document/document.dto';
+import { BaseCodeDto } from '../dto/base.dto';
 
 export interface UpdateDocumentDto {
   file?: File;
@@ -32,13 +33,24 @@ export interface DocumentDto {
 
 export interface SelectableParcelDto {
   uuid: string;
-  pid: string;
-  certificateOfTitleUuid: string;
-  index: string;
+  pid?: string;
+  certificateOfTitleUuid?: string;
+}
+
+export interface OwnerDto {
+  uuid: string;
+  displayName: string;
+  organizationName?: string | null;
+  corporateSummaryUuid?: string;
+  type: BaseCodeDto;
 }
 
 export interface SelectableOwnerDto {
-  label: string;
   uuid: string;
-  corporateSummaryUuid: string;
+  corporateSummaryUuid?: string;
+  label: string;
+}
+
+export interface SubmissionOwnersDto {
+  owners: OwnerDto[];
 }

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.interface.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.interface.ts
@@ -1,5 +1,33 @@
-import { DocumentTypeDto } from '../document/document.dto';
-import { CreateDocumentDto, UpdateDocumentDto } from './document-upload-dialog.dto';
+import { DOCUMENT_TYPE, DocumentTypeDto } from '../document/document.dto';
+import { VisibilityGroup } from './document-upload-dialog.component';
+import {
+  CreateDocumentDto,
+  DocumentDto,
+  SelectableParcelDto,
+  SubmissionOwnersDto,
+  UpdateDocumentDto,
+} from './document-upload-dialog.dto';
+
+export interface DocumentTypeConfig {
+  visibilityGroups: VisibilityGroup[];
+  allowsFileEdit: boolean;
+}
+
+export interface DocumentUploadDialogOptions {
+  allowedVisibilityFlags?: ('A' | 'C' | 'G' | 'P')[];
+  allowsFileEdit?: boolean;
+  documentTypeOverrides?: Partial<Record<DOCUMENT_TYPE, DocumentTypeConfig>>;
+}
+
+export interface DocumentUploadDialogData extends DocumentUploadDialogOptions {
+  fileId: string;
+  decisionUuid?: string;
+  existingDocument?: DocumentDto;
+  decisionService?: DecisionService;
+  documentService?: DocumentService;
+  parcelService?: ParcelFetchingService;
+  submissionService?: SubmissionFetchingService;
+}
 
 export interface DecisionService {
   uploadFile(decisionUuid: string, file: File): Promise<Object | undefined>;
@@ -14,4 +42,12 @@ export interface DocumentService {
   download(uuid: string, fileName: string, isInline: boolean): Promise<void>;
   fetchTypes(): Promise<DocumentTypeDto[]>;
   delete(uuid: string): Promise<Object>;
+}
+
+export interface ParcelFetchingService {
+  fetchParcels(fileNumber: string): Promise<SelectableParcelDto[]>;
+}
+
+export interface SubmissionFetchingService {
+  fetchSubmission(fileNumber: string): Promise<SubmissionOwnersDto>;
 }


### PR DESCRIPTION
- Create interfaces for setting data to allow for
  better validation
- Create a global options consts that can be used
  for both add and edit to make sure they are
  consistent
- Pass in parcel/owner services to avoid long
  modal opening times
