### PR TITLE
ALCS-2579: QA #1: Don't overwrite options object

### DIFF
--- a/alcs-frontend/src/app/features/application/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/application/documents/documents.component.ts
@@ -82,12 +82,15 @@ export class DocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      fileId: this.fileId,
-      documentService: this.applicationDocumentService,
-      parcelService: this.applicationParcelService,
-      submissionService: this.applicationSubmissionService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        fileId: this.fileId,
+        documentService: this.applicationDocumentService,
+        parcelService: this.applicationParcelService,
+        submissionService: this.applicationSubmissionService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {
@@ -127,14 +130,17 @@ export class DocumentsComponent implements OnInit {
   }
 
   async onEditFile(element: ApplicationDocumentDto) {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
-      fileId: this.fileId,
-      existingDocument: element,
-      documentService: this.applicationDocumentService,
-      parcelService: this.applicationParcelService,
-      submissionService: this.applicationSubmissionService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+        fileId: this.fileId,
+        existingDocument: element,
+        documentService: this.applicationDocumentService,
+        parcelService: this.applicationParcelService,
+        submissionService: this.applicationSubmissionService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {

--- a/alcs-frontend/src/app/features/notice-of-intent/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/documents/documents.component.ts
@@ -86,12 +86,15 @@ export class NoiDocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      fileId: this.fileId,
-      documentService: this.noiDocumentService,
-      parcelService: this.noiParcelService,
-      submissionService: this.noiSubmissionService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        fileId: this.fileId,
+        documentService: this.noiDocumentService,
+        parcelService: this.noiParcelService,
+        submissionService: this.noiSubmissionService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {
@@ -117,14 +120,17 @@ export class NoiDocumentsComponent implements OnInit {
   }
 
   async onEditFile(element: NoticeOfIntentDocumentDto) {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
-      fileId: this.fileId,
-      existingDocument: element,
-      documentService: this.noiDocumentService,
-      parcelService: this.noiParcelService,
-      submissionService: this.noiSubmissionService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+        fileId: this.fileId,
+        existingDocument: element,
+        documentService: this.noiDocumentService,
+        parcelService: this.noiParcelService,
+        submissionService: this.noiSubmissionService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {

--- a/alcs-frontend/src/app/features/notification/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/notification/documents/documents.component.ts
@@ -57,10 +57,13 @@ export class NotificationDocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      fileId: this.fileId,
-      documentService: this.notificationDocumentService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        fileId: this.fileId,
+        documentService: this.notificationDocumentService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {
@@ -100,12 +103,15 @@ export class NotificationDocumentsComponent implements OnInit {
   }
 
   onEditFile(element: NoticeOfIntentDocumentDto) {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
-      fileId: this.fileId,
-      existingDocument: element,
-      documentService: this.notificationDocumentService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+        fileId: this.fileId,
+        existingDocument: element,
+        documentService: this.notificationDocumentService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {

--- a/alcs-frontend/src/app/features/planning-review/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/planning-review/documents/documents.component.ts
@@ -57,10 +57,13 @@ export class DocumentsComponent implements OnInit {
   }
 
   async onUploadFile() {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      fileId: this.fileId,
-      documentService: this.planningReviewDocumentService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        fileId: this.fileId,
+        documentService: this.planningReviewDocumentService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {
@@ -100,12 +103,15 @@ export class DocumentsComponent implements OnInit {
   }
 
   onEditFile(element: PlanningReviewDocumentDto) {
-    const data: DocumentUploadDialogData = Object.assign(DOCUMENT_UPLOAD_DIALOG_OPTIONS, {
-      allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
-      fileId: this.fileId,
-      existingDocument: element,
-      documentService: this.planningReviewDocumentService,
-    });
+    const data: DocumentUploadDialogData = {
+      ...DOCUMENT_UPLOAD_DIALOG_OPTIONS,
+      ...{
+        allowsFileEdit: element.system === DOCUMENT_SYSTEM.ALCS,
+        fileId: this.fileId,
+        existingDocument: element,
+        documentService: this.planningReviewDocumentService,
+      },
+    };
 
     this.dialog
       .open(DocumentUploadDialogComponent, {


### PR DESCRIPTION
- Silly mistake
- I forgot `Object.assign()` overwrites the target object
- Replaced with spread operators
