### PR TITLE
Rename Financial Instrument Data Type Enums and Add Default to Status Column

### DIFF
--- a/services/apps/alcs/src/alcs/application-decision/application-decision-condition/application-decision-condition-financial-instrument/application-decision-condition-financial-instrument.entity.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-condition/application-decision-condition-financial-instrument/application-decision-condition-financial-instrument.entity.ts
@@ -39,7 +39,7 @@ export class ApplicationDecisionConditionFinancialInstrument extends Base {
   securityHolderPayee: string;
 
   @AutoMap()
-  @Column({ type: 'enum', enum: InstrumentType, nullable: false })
+  @Column({ type: 'enum', enum: InstrumentType, nullable: false, enumName: 'application_instrument_type' })
   type: InstrumentType;
 
   @AutoMap()
@@ -63,7 +63,7 @@ export class ApplicationDecisionConditionFinancialInstrument extends Base {
   instrumentNumber: string | null;
 
   @AutoMap()
-  @Column({ type: 'enum', enum: HeldBy, nullable: false })
+  @Column({ type: 'enum', enum: HeldBy, nullable: false, enumName: 'application_instrument_held_by' })
   heldBy: HeldBy;
 
   @AutoMap()
@@ -75,7 +75,13 @@ export class ApplicationDecisionConditionFinancialInstrument extends Base {
   notes: string | null;
 
   @AutoMap()
-  @Column({ type: 'enum', enum: InstrumentStatus, default: InstrumentStatus.RECEIVED, nullable: false })
+  @Column({
+    type: 'enum',
+    enum: InstrumentStatus,
+    default: InstrumentStatus.RECEIVED,
+    nullable: false,
+    enumName: 'application_instrument_status',
+  })
   status: InstrumentStatus;
 
   @AutoMap()

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-condition/notice-of-intent-decision-condition-financial-instrument/notice-of-intent-decision-condition-financial-instrument.entity.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision-condition/notice-of-intent-decision-condition-financial-instrument/notice-of-intent-decision-condition-financial-instrument.entity.ts
@@ -39,7 +39,7 @@ export class NoticeOfIntentDecisionConditionFinancialInstrument extends Base {
   securityHolderPayee: string;
 
   @AutoMap()
-  @Column({ type: 'enum', enum: InstrumentType, nullable: false })
+  @Column({ type: 'enum', enum: InstrumentType, nullable: false, enumName: 'noi_instrument_type' })
   type: InstrumentType;
 
   @AutoMap()
@@ -63,7 +63,7 @@ export class NoticeOfIntentDecisionConditionFinancialInstrument extends Base {
   instrumentNumber: string | null;
 
   @AutoMap()
-  @Column({ type: 'enum', enum: HeldBy, nullable: false })
+  @Column({ type: 'enum', enum: HeldBy, nullable: false, enumName: 'noi_instrument_held_by' })
   heldBy: HeldBy;
 
   @AutoMap()
@@ -75,7 +75,13 @@ export class NoticeOfIntentDecisionConditionFinancialInstrument extends Base {
   notes: string | null;
 
   @AutoMap()
-  @Column({ type: 'enum', enum: InstrumentStatus, default: InstrumentStatus.RECEIVED, nullable: false })
+  @Column({
+    type: 'enum',
+    enum: InstrumentStatus,
+    default: InstrumentStatus.RECEIVED,
+    nullable: false,
+    enumName: 'noi_instrument_status',
+  })
   status: InstrumentStatus;
 
   @AutoMap()

--- a/services/apps/alcs/src/providers/typeorm/migrations/1741287102799-rename_financial_instrument_enums.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1741287102799-rename_financial_instrument_enums.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameFinancialInstrumentEnums1741287102799 implements MigrationInterface {
+  name = 'RenameFinancialInstrumentEnums1741287102799';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Application instrument types - direct rename
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."application_decision_condition_financial_instrument_type_enum" RENAME TO "application_instrument_type"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."application_decision_condition_financial_instrument_held_by_enu" RENAME TO "application_instrument_held_by"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."application_decision_condition_financial_instrument_status_enum" RENAME TO "application_instrument_status"`,
+    );
+
+    // Notice of intent instrument types - direct rename
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."notice_of_intent_decision_condition_financial_instrument_type_e" RENAME TO "noi_instrument_type"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."notice_of_intent_decision_condition_financial_instrument_held_b" RENAME TO "noi_instrument_held_by"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."notice_of_intent_decision_condition_financial_instrument_status" RENAME TO "noi_instrument_status"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert notice of intent instrument types - direct rename
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."noi_instrument_status" RENAME TO "notice_of_intent_decision_condition_financial_instrument_status"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."noi_instrument_held_by" RENAME TO "notice_of_intent_decision_condition_financial_instrument_held_b"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."noi_instrument_type" RENAME TO "notice_of_intent_decision_condition_financial_instrument_type_e"`,
+    );
+
+    // Revert application instrument types - direct rename
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."application_instrument_status" RENAME TO "application_decision_condition_financial_instrument_status_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."application_instrument_held_by" RENAME TO "application_decision_condition_financial_instrument_held_by_enu"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "alcs"."application_instrument_type" RENAME TO "application_decision_condition_financial_instrument_type_enum"`,
+    );
+  }
+}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1741289414578-add_default_to_app_instrument_status.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1741289414578-add_default_to_app_instrument_status.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDefaultToAppInstrumentStatus1741289414578 implements MigrationInterface {
+    name = 'AddDefaultToAppInstrumentStatus1741289414578'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "alcs"."application_decision_condition_financial_instrument" ALTER COLUMN "status" SET DEFAULT 'Received'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "alcs"."application_decision_condition_financial_instrument" ALTER COLUMN "status" DROP DEFAULT`);
+    }
+
+}


### PR DESCRIPTION
- Fix financial instruments' enum data types' names being truncated due to PostgreSQL's 63-byte limit for names. Applies to both applications and NOIs.
- Add default value to application financial instrument's status column