### PR TITLE
ALCS-2603 QA #1: Replace condition that kept sane order numbers

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-condition-order-dialog/decision-condition-order-dialog.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-conditions/decision-condition-order-dialog/decision-condition-order-dialog.component.ts
@@ -90,7 +90,9 @@ export class DecisionConditionOrderDialogComponent implements OnInit {
 
   sendToBottom(record: ApplicationDecisionConditionDto) {
     this.conditionsToOrder.forEach((item) => {
-      item.order--;
+      if (item.order > record.order) {
+        item.order--;
+      }
     });
     record.order = this.conditionsToOrder.length - 1;
     this.dataSource.data = this.conditionsToOrder.sort((a, b) => a.order - b.order);
@@ -100,7 +102,9 @@ export class DecisionConditionOrderDialogComponent implements OnInit {
 
   sendToTop(record: ApplicationDecisionConditionDto) {
     this.conditionsToOrder.forEach((item) => {
-      item.order++;
+      if (item.order < record.order) {
+        item.order++;
+      }
     });
     record.order = 0;
     this.dataSource.data = this.conditionsToOrder.sort((a, b) => a.order - b.order);


### PR DESCRIPTION
- I had taken out a condition that I thought wasn't necessary, because it relied on the index which was causing the initial problem
- The condition prevented conditions that didn't move from having their orders updated
- I've put it back and it is now based on the record order, which should accomplish the same result
