### PR TITLE
ALCS-2561 Fix re-enabling the fields

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -512,7 +512,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
       this.resolutionYearControl.disable();
       this.form.controls.resolutionNumber.setValue(number.toString());
       await this.onSubmit(true);
-    } catch {
+    } finally {
       this.resolutionYearControl.enable();
     }
   }

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -362,7 +362,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
       this.resolutionYearControl.disable();
       this.form.controls.resolutionNumber.setValue(number.toString());
       await this.onSubmit(true);
-    } catch {
+    } finally {
       this.resolutionYearControl.enable();
     }
   }


### PR DESCRIPTION
Once the field was changed, it was only enabled again in case of an error.
The desired behavior was to enable once the processing is over.