### PR TITLE
ALCS-2455: Don't show resolution number save error when re-editing

### DIFF
--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.html
@@ -56,6 +56,7 @@
           [disableThousandsSeparator]="true"
           [asyncValidators]="[resolutionNumberAsyncValidator()]"
           (save)="onSaveResolutionNumber($event)"
+          (cancel)="onCancelResolutionNumber()"
         />
         <div>&nbsp;/&nbsp;</div>
         {{ resolutionYearControl.value }}
@@ -83,13 +84,13 @@
                 (click)="onClickResolutionNumberSaveButton()"
                 [disabled]="resolutionNumberInput?.valueControl?.invalid"
                 [ngClass]="{
-                  'error-field-outlined': showErrors && resolutionNumberInput?.isEditing,
-                  'ng-invalid': showErrors && resolutionNumberInput?.isEditing,
+                  'error-field-outlined': showResolutionNumberSaveError,
+                  'ng-invalid': showResolutionNumberSaveError,
                 }"
               >
                 Save
               </button>
-              <mat-error *ngIf="showErrors && resolutionNumberInput?.isEditing"
+              <mat-error *ngIf="showResolutionNumberSaveError"
                 ><mat-icon>warning</mat-icon> This field is required</mat-error
               >
             </div>

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -74,6 +74,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
   conditionsValid = true;
   componentsValid = true;
   showErrors = false;
+  showResolutionNumberSaveError = false;
   index = 1;
 
   fileNumber: string = '';
@@ -540,6 +541,11 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
     if (resolutionNumber) {
       await this.setResolutionNumber(Number.parseInt(resolutionNumber));
     }
+    this.showResolutionNumberSaveError = false;
+  }
+
+  async onCancelResolutionNumber() {
+    this.showResolutionNumberSaveError = false;
   }
 
   private async setResolutionNumber(number: number) {
@@ -561,6 +567,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
   private runValidation() {
     this.form.markAllAsTouched();
     this.showErrors = true;
+    this.showResolutionNumberSaveError = true;
     const requiresConditions = this.showConditions;
     const requiresComponents = this.showComponents && this.requireComponents;
 

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.html
@@ -56,6 +56,7 @@
           [disableThousandsSeparator]="true"
           [asyncValidators]="[resolutionNumberAsyncValidator()]"
           (save)="onSaveResolutionNumber($event)"
+          (cancel)="onCancelResolutionNumber()"
         />
         <div>&nbsp;/&nbsp;</div>
         {{ resolutionYearControl.value }}
@@ -83,13 +84,13 @@
                 (click)="onClickResolutionNumberSaveButton()"
                 [disabled]="resolutionNumberInput?.valueControl?.invalid"
                 [ngClass]="{
-                  'error-field-outlined': showErrors && resolutionNumberInput?.isEditing,
-                  'ng-invalid': showErrors && resolutionNumberInput?.isEditing,
+                  'error-field-outlined': showResolutionNumberSaveError,
+                  'ng-invalid': showResolutionNumberSaveError,
                 }"
               >
                 Save
               </button>
-              <mat-error *ngIf="showErrors && resolutionNumberInput?.isEditing"
+              <mat-error *ngIf="showResolutionNumberSaveError"
                 ><mat-icon>warning</mat-icon> This field is required</mat-error
               >
             </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-input/decision-input-v2.component.ts
@@ -58,6 +58,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
   conditionsValid = true;
   componentsValid = true;
   showErrors = false;
+  showResolutionNumberSaveError = false;
   index = 1;
 
   fileNumber: string = '';
@@ -392,6 +393,11 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
     if (resolutionNumber) {
       await this.setResolutionNumber(Number.parseInt(resolutionNumber));
     }
+    this.showResolutionNumberSaveError = false;
+  }
+
+  async onCancelResolutionNumber() {
+    this.showResolutionNumberSaveError = false;
   }
 
   private async setResolutionNumber(number: number) {
@@ -413,6 +419,7 @@ export class DecisionInputV2Component implements OnInit, OnDestroy {
   private runValidation() {
     this.form.markAllAsTouched();
     this.showErrors = true;
+    this.showResolutionNumberSaveError = true;
     const requiresConditions = this.showConditions;
     const requiresComponents = this.showComponents && this.requireComponents;
 

--- a/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.ts
+++ b/alcs-frontend/src/app/shared/inline-editors/inline-number/inline-number.component.ts
@@ -24,6 +24,7 @@ export class InlineNumberComponent implements AfterContentChecked {
   @Input() disableThousandsSeparator = false;
   @Input() asyncValidators: AsyncValidatorFn[] = [];
   @Output() save = new EventEmitter<string | null>();
+  @Output() cancel = new EventEmitter<string | null>();
 
   @ViewChild('editInput') textInput!: ElementRef;
 
@@ -64,6 +65,7 @@ export class InlineNumberComponent implements AfterContentChecked {
   cancelEdit() {
     this.isEditing = false;
     this.valueControl.setValue(this._value);
+    this.cancel.emit();
   }
 
   preventKeydown(event: Event) {


### PR DESCRIPTION
- When the resolution number editor is open and a release is attempted, it shows an error
- Now, when we save or cancel the resolution editor, and then re-edit it, the error is gone
