### PR TITLE
ALCS-2638: Sanitize fileName when uploading document

### DIFF
--- a/services/apps/alcs/src/alcs/application/application-document/application-document.controller.ts
+++ b/services/apps/alcs/src/alcs/application/application-document/application-document.controller.ts
@@ -293,9 +293,11 @@ export class ApplicationDocumentController {
   private async saveUploadedFile(req, fileNumber: string) {
     const documentType = req.body.documentType.value as DOCUMENT_TYPE;
     const file = req.body.file;
-    const fileName = req.body.fileName.value as string;
+    let fileName = req.body.fileName.value as string;
     const documentSource = req.body.source.value as DOCUMENT_SOURCE;
     const visibilityFlags = req.body.visibilityFlags.value.split(', ');
+
+    fileName = fileName.replace(/[–—]/g, '-'); // Replace en-dash, em-dash with hyphen
 
     //Set Default description to prevent issues when returning to Government
     let description: string | undefined;

--- a/services/apps/alcs/src/alcs/inquiry/inquiry-document/inquiry-document.controller.ts
+++ b/services/apps/alcs/src/alcs/inquiry/inquiry-document/inquiry-document.controller.ts
@@ -135,8 +135,10 @@ export class InquiryDocumentController {
   private async saveUploadedFile(req, fileNumber: string) {
     const documentType = req.body.documentType.value as DOCUMENT_TYPE;
     const file = req.body.file;
-    const fileName = req.body.fileName.value as string;
+    let fileName = req.body.fileName.value as string;
     const documentSource = req.body.source.value as DOCUMENT_SOURCE;
+
+    fileName = fileName.replace(/[–—]/g, '-'); // Replace en-dash, em-dash with hyphen
 
     return await this.inquiryDocumentService.attachDocument({
       fileNumber,

--- a/services/apps/alcs/src/alcs/notice-of-intent/notice-of-intent-document/notice-of-intent-document.controller.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent/notice-of-intent-document/notice-of-intent-document.controller.ts
@@ -281,9 +281,11 @@ export class NoticeOfIntentDocumentController {
   private async saveUploadedFile(req, fileNumber: string) {
     const documentType = req.body.documentType.value as DOCUMENT_TYPE;
     const file = req.body.file;
-    const fileName = req.body.fileName.value as string;
+    let fileName = req.body.fileName.value as string;
     const documentSource = req.body.source.value as DOCUMENT_SOURCE;
     const visibilityFlags = req.body.visibilityFlags.value.split(', ');
+
+    fileName = fileName.replace(/[–—]/g, '-'); // Replace en-dash, em-dash with hyphen
 
     return await this.noticeOfIntentDocumentService.attachDocument({
       fileNumber,

--- a/services/apps/alcs/src/alcs/notification/notification-document/notification-document.controller.ts
+++ b/services/apps/alcs/src/alcs/notification/notification-document/notification-document.controller.ts
@@ -176,9 +176,11 @@ export class NotificationDocumentController {
   private async saveUploadedFile(req, fileNumber: string) {
     const documentType = req.body.documentType.value as DOCUMENT_TYPE;
     const file = req.body.file;
-    const fileName = req.body.fileName.value as string;
+    let fileName = req.body.fileName.value as string;
     const documentSource = req.body.source.value as DOCUMENT_SOURCE;
     const visibilityFlags = req.body.visibilityFlags.value.split(', ');
+
+    fileName = fileName.replace(/[–—]/g, '-'); // Replace en-dash, em-dash with hyphen
 
     return await this.notificationDocumentService.attachDocument({
       fileNumber,

--- a/services/apps/alcs/src/alcs/planning-review/planning-review-document/planning-review-document.controller.ts
+++ b/services/apps/alcs/src/alcs/planning-review/planning-review-document/planning-review-document.controller.ts
@@ -188,9 +188,11 @@ export class PlanningReviewDocumentController {
   private async saveUploadedFile(req, fileNumber: string) {
     const documentType = req.body.documentType.value as DOCUMENT_TYPE;
     const file = req.body.file;
-    const fileName = req.body.fileName.value as string;
+    let fileName = req.body.fileName.value as string;
     const documentSource = req.body.source.value as DOCUMENT_SOURCE;
     const visibilityFlags = req.body.visibilityFlags.value.split(', ');
+
+    fileName = fileName.replace(/[–—]/g, '-'); // Replace en-dash, em-dash with hyphen
 
     return await this.planningReviewDocumentService.attachDocument({
       fileNumber,


### PR DESCRIPTION
- This pull request includes changes to the `saveUploadedFile` method in two different controllers to handle specific characters in file names. The main change is the replacement of en-dash and em-dash characters with hyphens in file names. 
- Applies to applications, NOIs, notifications, planning reviews, and inquiries on ALCS

