### PR TITLE
ALCS-2542: Implement new inline document links and replace all ALCS links

### DIFF
--- a/alcs-frontend/src/app/app-routing.module.ts
+++ b/alcs-frontend/src/app/app-routing.module.ts
@@ -7,11 +7,20 @@ import { ProvisionComponent } from './features/provision/provision.component';
 import { AuthGuard } from './services/authentication/auth.guard';
 import { ALL_ROLES, ROLES } from './services/authentication/authentication.service';
 import { HasRolesGuard } from './services/authentication/hasRoles.guard';
+import { DocumentFileLoader } from './shared/document-file-loader/document-file-loader.component';
 
 export const ROLES_ALLOWED_APPLICATIONS = [ROLES.ADMIN, ROLES.LUP, ROLES.APP_SPECIALIST, ROLES.GIS, ROLES.SOIL_OFFICER];
 export const ROLES_ALLOWED_BOARDS = ROLES_ALLOWED_APPLICATIONS;
 
 const routes: Routes = [
+  {
+    path: 'document/:uuid',
+    canActivate: [HasRolesGuard],
+    data: {
+      roles: ROLES_ALLOWED_APPLICATIONS,
+    },
+    component: DocumentFileLoader,
+  },
   {
     path: 'board',
     canActivate: [HasRolesGuard],

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.component.html
@@ -84,7 +84,9 @@
       <div class="subheading2 grid-1">Authorization Letter(s)</div>
       <div class="grid-double">
         <div *ngFor="let file of authorizationLetters">
-          <a (click)="openFile(file)" data-testid="authorization-letter">{{ file.fileName }}</a>
+          <a routerLink="/document/{{ file.documentUuid }}" target="_blank" data-testid="authorization-letter">{{
+            file.fileName
+          }}</a>
         </div>
       </div>
     </ng-container>
@@ -229,7 +231,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div class="grid-1" data-testid="optional-document-file-name">
-          <a (click)="openFile(file)">{{ file.fileName }}</a>
+          <a routerLink="/document/{{ file.documentUuid }}" target="_blank">{{ file.fileName }}</a>
         </div>
         <div class="grid-2" data-testid="optional-document-type">
           {{ file.type?.label }}

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.module.ts
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/application-details.module.ts
@@ -13,6 +13,7 @@ import { RosoDetailsComponent } from './roso-details/roso-details.component';
 import { SubdDetailsComponent } from './subd-details/subd-details.component';
 import { TurDetailsComponent } from './tur-details/tur-details.component';
 import { ExclDetailsComponent } from './excl-details/excl-details.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [
@@ -29,7 +30,7 @@ import { ExclDetailsComponent } from './excl-details/excl-details.component';
     InclDetailsComponent,
     CoveDetailsComponent,
   ],
-  imports: [CommonModule, SharedModule],
+  imports: [CommonModule, SharedModule, RouterModule],
   exports: [ApplicationDetailsComponent],
 })
 export class ApplicationDetailsModule {}

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/cove-details/cove-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/cove-details/cove-details.component.html
@@ -45,7 +45,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
+    <a *ngFor="let map of proposalMap" routerLink="/document/{{ map.documentUuid }}" target="_blank">
       {{ map.fileName }}
     </a>
     <app-no-data *ngIf="proposalMap.length === 0"></app-no-data>
@@ -62,7 +62,7 @@
   <div class="subheading2 grid-1">Draft Covenant</div>
   <div class="grid-double">
     <div *ngFor="let file of srwTerms">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/excl-details/excl-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/excl-details/excl-details.component.html
@@ -28,7 +28,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -36,7 +36,7 @@
   <div class="subheading2 grid-1">Notice of Public Hearing (Advertisement)</div>
   <div class="grid-double">
     <div *ngFor="let file of noticeOfPublicHearing">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -45,7 +45,7 @@
   <div class="subheading2 grid-1">Proof of Signage</div>
   <div class="grid-double">
     <div *ngFor="let file of proofOfSignage">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -54,7 +54,7 @@
   <div class="subheading2 grid-1">Report of Public Hearing</div>
   <div class="grid-double">
     <div *ngFor="let file of reportOfPublicHearing">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/incl-details/incl-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/incl-details/incl-details.component.html
@@ -24,7 +24,7 @@
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
     <div *ngFor="let file of proposalMap">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -43,7 +43,7 @@
     <div class="subheading2 grid-1">Notice of Public Hearing (Advertisement)</div>
     <div class="grid-double">
       <div *ngFor="let file of noticeOfPublicHearing">
-        <a (click)="openFile(file)">
+        <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
           {{ file.fileName }}
         </a>
       </div>
@@ -52,7 +52,7 @@
     <div class="subheading2 grid-1">Proof of Signage</div>
     <div class="grid-double">
       <div *ngFor="let file of proofOfSignage">
-        <a (click)="openFile(file)">
+        <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
           {{ file.fileName }}
         </a>
       </div>
@@ -61,7 +61,7 @@
     <div class="subheading2 grid-1">Report of Public Hearing</div>
     <div class="grid-double">
       <div *ngFor="let file of reportOfPublicHearing">
-        <a (click)="openFile(file)">
+        <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
           {{ file.fileName }}
         </a>
       </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/naru-details/naru-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/naru-details/naru-details.component.html
@@ -169,7 +169,7 @@
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
     <div *ngFor="let file of proposalMap">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -178,7 +178,7 @@
   <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
   <div class="grid-double">
     <div *ngFor="let file of buildingPlans">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/nfu-details/nfu-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/nfu-details/nfu-details.component.html
@@ -18,7 +18,7 @@
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
     <div *ngFor="let file of proposalMap">
-      <a (click)="openFile(file)">
+      <a routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/parcel/parcel.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/parcel/parcel.component.html
@@ -65,7 +65,9 @@
       [attr.data-testid]="'parcel-' + (parcelInd + 1) + '-certificate-of-title'"
     >
       <div *ngIf="parcel.certificateOfTitle">
-        <a (click)="openFile(parcel.certificateOfTitle)">{{ parcel.certificateOfTitle.fileName }}</a>
+        <a routerLink="/document/{{ parcel.certificateOfTitle.documentUuid }}" target="_blank">{{
+          parcel.certificateOfTitle.fileName
+        }}</a>
       </div>
       <app-no-data *ngIf="!parcel.certificateOfTitle"></app-no-data>
     </div>
@@ -130,7 +132,11 @@
           {{ owner.email }}
         </div>
         <div [attr.data-testid]="'parcel-' + (parcelInd + 1) + '-owner-corporate-summary'">
-          <a *ngIf="owner.corporateSummary" (click)="openFile(owner.corporateSummary)">
+          <a
+            *ngIf="owner.corporateSummary"
+            routerLink="/document/{{ owner.corporateSummary.documentUuid }}"
+            target="_blank"
+          >
             {{ owner.corporateSummary.fileName }}
           </a>
           <div class="no-data" *ngIf="!owner.corporateSummary">

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/pfrs-details/pfrs-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/pfrs-details/pfrs-details.component.html
@@ -226,7 +226,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -235,7 +235,7 @@
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double multiple-documents">
       <div>
-        <a *ngFor="let file of crossSections" (click)="openFile(file)">
+        <a *ngFor="let file of crossSections" routerLink="/document/{{ file.documentUuid }}" target="_blank">
           {{ file.fileName }}
         </a>
       </div>
@@ -243,7 +243,7 @@
 
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
+      <a *ngFor="let file of reclamationPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -252,7 +252,7 @@
   <ng-container *ngIf="_applicationSubmission.soilIsNewStructure === true">
     <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of buildingPlans" (click)="openFile(file)">
+      <a *ngFor="let file of buildingPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="buildingPlans.length === 0"></app-no-data>
@@ -278,7 +278,7 @@
 
     <div *ngIf="_applicationSubmission.soilHasSubmittedNotice" class="subheading2 grid-1">Notice of Work</div>
     <div *ngIf="_applicationSubmission.soilHasSubmittedNotice" class="grid-double multiple-documents">
-      <a *ngFor="let file of noticeOfWork" (click)="openFile(file)">
+      <a *ngFor="let file of noticeOfWork" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/pofo-details/pofo-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/pofo-details/pofo-details.component.html
@@ -171,7 +171,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -179,14 +179,14 @@
   <ng-container *ngIf="_applicationSubmission.soilIsNewStructure === false">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of crossSections" (click)="openFile(file)">
+      <a *ngFor="let file of crossSections" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
 
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
+      <a *ngFor="let file of reclamationPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -195,7 +195,7 @@
   <ng-container *ngIf="_applicationSubmission.soilIsNewStructure === true">
     <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of buildingPlans" (click)="openFile(file)">
+      <a *ngFor="let file of buildingPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="buildingPlans.length === 0"></app-no-data>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/roso-details/roso-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/roso-details/roso-details.component.html
@@ -166,7 +166,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -174,14 +174,14 @@
   <ng-container *ngIf="_applicationSubmission.soilIsNewStructure === false">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of crossSections" (click)="openFile(file)">
+      <a *ngFor="let file of crossSections" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
 
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
+      <a *ngFor="let file of reclamationPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -190,7 +190,7 @@
   <ng-container *ngIf="_applicationSubmission.soilIsNewStructure === true">
     <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of buildingPlans" (click)="openFile(file)">
+      <a *ngFor="let file of buildingPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="buildingPlans.length === 0"></app-no-data>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/subd-details/subd-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/subd-details/subd-details.component.html
@@ -28,7 +28,7 @@
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double">
-    <a *ngFor="let notice of proposalMap" (click)="openFile(notice)">
+    <a *ngFor="let notice of proposalMap" routerLink="/document/{{ notice.documentUuid }}" target="_blank">
       {{ notice.fileName }}
     </a>
   </div>
@@ -40,7 +40,7 @@
     <div class="subheading2 grid-1">Proof of Homesite Severance Qualification</div>
     <div class="grid-double">
       <div *ngFor="let document of homesiteDocuments">
-        <a (click)="openFile(document)">
+        <a routerLink="/document/{{ document.documentUuid }}" target="_blank">
           {{ document.fileName }}
         </a>
       </div>

--- a/alcs-frontend/src/app/features/application/applicant-info/application-details/tur-details/tur-details.component.html
+++ b/alcs-frontend/src/app/features/application/applicant-info/application-details/tur-details/tur-details.component.html
@@ -26,13 +26,13 @@
   </div>
   <div class="subheading2 grid-1">Proof of Serving Notice</div>
   <div class="grid-double" data-testid="tur-proof-of-serving-notice">
-    <a *ngFor="let notice of servingNotice" (click)="openFile(notice)">
+    <a *ngFor="let notice of servingNotice" routerLink="/document/{{ notice.documentUuid }}" target="_blank">
       {{ notice.fileName }}
     </a>
   </div>
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double" data-testid="tur-proposal-map">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-documents/decision-documents.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-documents/decision-documents.component.html
@@ -25,10 +25,12 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
-        {{ element.fileName | truncate: fileNameTruncLen}}
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
+        {{ element.fileName | truncate: fileNameTruncLen }}
       </a>
     </td>
   </ng-container>

--- a/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.html
+++ b/alcs-frontend/src/app/features/application/decision/decision-v2/decision-v2.component.html
@@ -193,7 +193,7 @@
         <div class="full-width">
           <div class="document split" *ngFor="let document of decision.documents">
             <div>
-              <a (click)="openFile(decision.uuid, document.uuid, document.fileName)">{{ document.fileName }}</a>
+              <a routerLink="/document/{{ document.documentUuid }}" target="_blank">{{ document.fileName }}</a>
               &nbsp;({{ document.fileSize ? (document.fileSize | filesize) : '' }})
             </div>
             <button class="center" mat-button (click)="openFile(decision.uuid, document.uuid, document.fileName)">

--- a/alcs-frontend/src/app/features/application/documents/documents.component.html
+++ b/alcs-frontend/src/app/features/application/documents/documents.component.html
@@ -14,9 +14,11 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
         {{ element.fileName }}
       </a>
     </td>

--- a/alcs-frontend/src/app/features/commissioner/application/commissioner-decisions/commissioner-decisions.component.html
+++ b/alcs-frontend/src/app/features/commissioner/application/commissioner-decisions/commissioner-decisions.component.html
@@ -20,21 +20,21 @@
       <div class="subheading2">Decision Document</div>
       <div class="document split" *ngFor="let document of decision.documents">
         <div>
-          <a (click)="openFile(decision, document)">{{ document.fileName }}</a>
+          <a routerLink="/document/{{ document.documentUuid }}" target="_blank">{{ document.fileName }}</a>
           &nbsp;({{ document.fileSize! | filesize }})
         </div>
-        <button class="center" mat-button (click)="openFile(decision, document)">
+        <button class="center" mat-button routerLink="/document/{{ document.documentUuid }}" target="_blank">
           <mat-icon>file_download</mat-icon>
           Download
         </button>
       </div>
       <div class="document responsive left" *ngFor="let document of decision.documents">
         <div class="document-name">
-          <a (click)="openFile(decision, document)">{{ document.fileName }}</a>
+          <a routerLink="/document/{{ document.documentUuid }}" target="_blank">{{ document.fileName }}</a>
         </div>
         <div class="split">
           <div>{{ document.fileSize! | filesize }}</div>
-          <button class="center" mat-button (click)="openFile(decision, document)">
+          <button class="center" mat-button routerLink="/document/{{ document.documentUuid }}" target="_blank">
             <mat-icon>file_download</mat-icon>
             Download
           </button>

--- a/alcs-frontend/src/app/features/inquiry/documents/documents.component.html
+++ b/alcs-frontend/src/app/features/inquiry/documents/documents.component.html
@@ -14,9 +14,11 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
         {{ element.fileName }}
       </a>
     </td>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/additional-information/additional-information.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/additional-information/additional-information.component.html
@@ -87,7 +87,7 @@
 
     <div class="subheading2 grid-1">Detailed Building Plan(s)</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of buildingPlans" (click)="openFile(file)">
+      <a *ngFor="let file of buildingPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
       <app-no-data *ngIf="buildingPlans.length === 0"></app-no-data>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.component.html
@@ -54,7 +54,7 @@
       <div class="subheading2 grid-1">Authorization Letter(s)</div>
       <div class="grid-double">
         <div *ngFor="let file of authorizationLetters">
-          <a (click)="openFile(file)">{{ file.fileName }}</a>
+          <a routerLink="/document/{{ file.documentUuid }}" target="_blank">{{ file.fileName }}</a>
         </div>
       </div>
     </ng-container>
@@ -181,7 +181,7 @@
           {{ file.description }}
         </div>
         <div class="grid-3">
-          <a (click)="openFile(file)">{{ file.fileName }}</a>
+          <a routerLink="/document/{{ file.documentUuid }}" target="_blank">{{ file.fileName }}</a>
         </div>
       </ng-container>
       <div *ngIf="otherFiles.length === 0" class="full-width">No optional attachments</div>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.module.ts
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/notice-of-intent-details.module.ts
@@ -9,6 +9,7 @@ import { ParcelComponent } from './parcel/parcel.component';
 import { PfrsDetailsComponent } from './pfrs-details/pfrs-details.component';
 import { PofoDetailsComponent } from './pofo-details/pofo-details.component';
 import { RosoDetailsComponent } from './roso-details/roso-details.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [
@@ -19,7 +20,7 @@ import { RosoDetailsComponent } from './roso-details/roso-details.component';
     NoticeOfIntentDetailsComponent,
     AdditionalInformationComponent,
   ],
-  imports: [CommonModule, SharedModule, NgxMaskPipe, MatProgressSpinnerModule, NgIf],
+  imports: [CommonModule, SharedModule, NgxMaskPipe, MatProgressSpinnerModule, NgIf, RouterModule],
   exports: [NoticeOfIntentDetailsComponent],
 })
 export class NoticeOfIntentDetailsModule {}

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/parcel/parcel.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/parcel/parcel.component.html
@@ -59,7 +59,9 @@
     <div class="subheading2 grid-1">Certificate Of Title</div>
     <div class="grid-double">
       <div *ngIf="parcel.certificateOfTitle">
-        <a (click)="onOpenFile(parcel.certificateOfTitle)">{{ parcel.certificateOfTitle.fileName }}</a>
+        <a routerLink="/document/{{ parcel.certificateOfTitle.documentUuid }}" target="_blank">{{
+          parcel.certificateOfTitle.fileName
+        }}</a>
       </div>
       <app-no-data *ngIf="!parcel.certificateOfTitle"></app-no-data>
     </div>
@@ -118,9 +120,12 @@
         <div>{{ owner.phoneNumber }}</div>
         <div>{{ owner.email }}</div>
         <div>
-          <a *ngIf="owner.corporateSummary" (click)="onOpenFile(owner.corporateSummary)">{{
-              owner.corporateSummary.fileName
-            }}</a>
+          <a
+            *ngIf="owner.corporateSummary"
+            routerLink="/document/{{ owner.corporateSummary.documentUuid }}"
+            target="_blank"
+            >{{ owner.corporateSummary.fileName }}</a
+          >
           <div class="no-data" *ngIf="!owner.corporateSummary">
             <div *ngIf="owner.type.code === 'INDV'" class="no-data-text">Not Applicable</div>
             <div *ngIf="owner.type.code !== 'INDV'" class="no-data-text">No Data</div>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/pfrs-details/pfrs-details.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/pfrs-details/pfrs-details.component.html
@@ -134,7 +134,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -157,14 +157,14 @@
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double multiple-documents">
     <div>
-      <a *ngFor="let file of crossSections" (click)="openFile(file)">
+      <a *ngFor="let file of crossSections" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
   </div>
   <div class="subheading2 grid-1">Reclamation Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
+    <a *ngFor="let file of reclamationPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -180,7 +180,7 @@
 
   <div *ngIf="_noiSubmission.soilHasSubmittedNotice" class="subheading2 grid-1">Notice of Work</div>
   <div *ngIf="_noiSubmission.soilHasSubmittedNotice" class="grid-double multiple-documents">
-    <a *ngFor="let file of noticeOfWork" (click)="openFile(file)">
+    <a *ngFor="let file of noticeOfWork" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/pofo-details/pofo-details.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/pofo-details/pofo-details.component.html
@@ -76,7 +76,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of proposalMap" (click)="openFile(file)">
+    <a *ngFor="let file of proposalMap" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
@@ -91,13 +91,13 @@
 
   <div class="subheading2 grid-1">Cross Sections</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of crossSections" (click)="openFile(file)">
+    <a *ngFor="let file of crossSections" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>
   <div class="subheading2 grid-1">Reclamation Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
+    <a *ngFor="let file of reclamationPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
       {{ file.fileName }}
     </a>
   </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/roso-details/roso-details.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/applicant-info/notice-of-intent-details/roso-details/roso-details.component.html
@@ -85,7 +85,7 @@
 
   <div class="subheading2 grid-1">Proposal Map / Site Plan</div>
   <div class="grid-double multiple-documents">
-    <a *ngFor="let map of proposalMap" (click)="openFile(map)">
+    <a *ngFor="let map of proposalMap" routerLink="/document/{{ map.uuid }}" target="_blank">
       {{ map.fileName }}
     </a>
   </div>
@@ -100,14 +100,14 @@
   <ng-container *ngIf="_noiSubmission?.soilIsExtractionOrMining">
     <div class="subheading2 grid-1">Cross Sections</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of crossSections" (click)="openFile(file)">
+      <a *ngFor="let file of crossSections" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
 
     <div class="subheading2 grid-1">Reclamation Plan</div>
     <div class="grid-double multiple-documents">
-      <a *ngFor="let file of reclamationPlans" (click)="openFile(file)">
+      <a *ngFor="let file of reclamationPlans" routerLink="/document/{{ file.documentUuid }}" target="_blank">
         {{ file.fileName }}
       </a>
     </div>
@@ -124,7 +124,7 @@
     <ng-container *ngIf="_noiSubmission.soilHasSubmittedNotice">
       <div class="subheading2 grid-1">Notice of Work</div>
       <div class="grid-double multiple-documents">
-        <a *ngFor="let file of noticeOfWorks" (click)="openFile(file)">
+        <a *ngFor="let file of noticeOfWorks" routerLink="/document/{{ file.documentUuid }}" target="_blank">
           {{ file.fileName }}
         </a>
       </div>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-documents/decision-documents.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-documents/decision-documents.component.html
@@ -26,10 +26,12 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
-        {{ element.fileName | truncate: fileNameTruncLen}}
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
+        {{ element.fileName | truncate: fileNameTruncLen }}
       </a>
     </td>
   </ng-container>

--- a/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-v2.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/decision/decision-v2/decision-v2.component.html
@@ -177,7 +177,7 @@
         <div class="full-width">
           <div class="document split" *ngFor="let document of decision.documents">
             <div>
-              <a (click)="openFile(decision.uuid, document.uuid, document.fileName)">{{ document.fileName }}</a>
+              <a routerLink="/document/{{ document.documentUuid }}" target="_blank">{{ document.fileName }}</a>
               &nbsp;({{ document.fileSize ? (document.fileSize | filesize) : '' }})
             </div>
             <button class="center" mat-button (click)="openFile(decision.uuid, document.uuid, document.fileName)">

--- a/alcs-frontend/src/app/features/notice-of-intent/documents/documents.component.html
+++ b/alcs-frontend/src/app/features/notice-of-intent/documents/documents.component.html
@@ -14,9 +14,11 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
         {{ element.fileName }}
       </a>
     </td>

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.html
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.component.html
@@ -80,7 +80,7 @@
     <div class="subheading2 grid-1">Upload Terms of the SRW</div>
     <div class="grid-double">
       <div *ngFor="let document of srwTerms">
-        <a (click)="openFile(document)">
+        <a routerLink="/document/{{ document.documentUuid }}" target="_blank">
           {{ document.fileName }}
         </a>
       </div>
@@ -95,7 +95,7 @@
       <div class="subheading2">Control Number</div>
       <ng-container *ngFor="let document of surveyPlans">
         <div>
-          <a (click)="openFile(document)">
+          <a routerLink="/document/{{ document.documentUuid }}" target="_blank">
             {{ document.fileName }}
           </a>
         </div>
@@ -119,7 +119,7 @@
 
       <ng-container *ngFor="let file of otherFiles">
         <div>
-          <a (click)="openFile(file)">{{ file.fileName }}</a>
+          <a routerLink="/document/{{ file.documentUuid }}" target="_blank">{{ file.fileName }}</a>
         </div>
         <div>
           {{ file.type?.label }}

--- a/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.module.ts
+++ b/alcs-frontend/src/app/features/notification/applicant-info/notification-details/notification-details.module.ts
@@ -4,10 +4,11 @@ import { NgxMaskPipe } from 'ngx-mask';
 import { SharedModule } from '../../../../shared/shared.module';
 import { NotificationDetailsComponent } from './notification-details.component';
 import { ParcelComponent } from './parcel/parcel.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [ParcelComponent, NotificationDetailsComponent],
-  imports: [CommonModule, SharedModule, NgxMaskPipe, NgxMaskPipe],
+  imports: [CommonModule, SharedModule, NgxMaskPipe, NgxMaskPipe, RouterModule],
   exports: [NotificationDetailsComponent],
 })
 export class NotificationDetailsModule {}

--- a/alcs-frontend/src/app/features/notification/documents/documents.component.html
+++ b/alcs-frontend/src/app/features/notification/documents/documents.component.html
@@ -14,9 +14,11 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
         {{ element.fileName }}
       </a>
     </td>

--- a/alcs-frontend/src/app/features/planning-review/decision/decision-documents/decision-documents.component.html
+++ b/alcs-frontend/src/app/features/planning-review/decision/decision-documents/decision-documents.component.html
@@ -25,10 +25,12 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
-        {{ element.fileName | truncate: fileNameTruncLen}}
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
+        {{ element.fileName | truncate: fileNameTruncLen }}
       </a>
     </td>
   </ng-container>

--- a/alcs-frontend/src/app/features/planning-review/documents/documents.component.html
+++ b/alcs-frontend/src/app/features/planning-review/documents/documents.component.html
@@ -14,9 +14,11 @@
     <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
     <td mat-cell *matCellDef="let element">
       <a
-        (click)="openFile(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
         {{ element.fileName }}
       </a>
     </td>

--- a/alcs-frontend/src/app/features/planning-review/review/evidentiary-record/evidentiary-record.component.html
+++ b/alcs-frontend/src/app/features/planning-review/review/evidentiary-record/evidentiary-record.component.html
@@ -38,10 +38,12 @@
     <th *matHeaderCellDef mat-header-cell>File Name</th>
     <td *matCellDef="let element" mat-cell>
       <a
-        (click)="onOpen(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
-        {{ element.fileName | truncate: fileNameTruncLen}}
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
+        {{ element.fileName | truncate: fileNameTruncLen }}
       </a>
     </td>
   </ng-container>

--- a/alcs-frontend/src/app/services/application/decision/application-decision-v2/application-decision-v2.dto.ts
+++ b/alcs-frontend/src/app/services/application/decision/application-decision-v2/application-decision-v2.dto.ts
@@ -137,6 +137,7 @@ export interface ApplicationDecisionWithLinkedResolutionDto extends ApplicationD
 
 export interface ApplicationDecisionDocumentDto {
   uuid: string;
+  documentUuid: string;
   fileName: string;
   mimeType: string;
   uploadedBy: string;

--- a/alcs-frontend/src/app/services/application/decision/application-decision-v2/application-decision.dto.ts
+++ b/alcs-frontend/src/app/services/application/decision/application-decision-v2/application-decision.dto.ts
@@ -64,6 +64,7 @@ export interface LinkedResolutionDto {
 
 export interface ApplicationDecisionDocumentDto {
   uuid: string;
+  documentUuid: string;
   fileName: string;
   mimeType: string;
   uploadedBy: string;

--- a/alcs-frontend/src/app/services/common/document/document.service.spec.ts
+++ b/alcs-frontend/src/app/services/common/document/document.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { DocumentService } from './document.service';
+
+describe('DocumentService', () => {
+  let service: DocumentService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DocumentService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/alcs-frontend/src/app/services/common/document/document.service.spec.ts
+++ b/alcs-frontend/src/app/services/common/document/document.service.spec.ts
@@ -1,11 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 import { DocumentService } from './document.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('DocumentService', () => {
   let service: DocumentService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(DocumentService);
   });
 

--- a/alcs-frontend/src/app/services/common/document/document.service.ts
+++ b/alcs-frontend/src/app/services/common/document/document.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DocumentService {
+  baseUrl = `${environment.apiUrl}/document`;
+
+  constructor(private http: HttpClient) {}
+
+  async getDownloadUrlAndFileName(uuid: string, isInline = true): Promise<{ url: string; fileName: string }> {
+    const url =
+      `${this.baseUrl}/getDownloadUrlAndFileName/${uuid}` + (isInline ? `?isInline=${isInline.toString()}` : '');
+
+    return await firstValueFrom(this.http.get<{ url: string; fileName: string }>(url));
+  }
+}

--- a/alcs-frontend/src/app/services/notice-of-intent/decision-v2/notice-of-intent-decision.dto.ts
+++ b/alcs-frontend/src/app/services/notice-of-intent/decision-v2/notice-of-intent-decision.dto.ts
@@ -109,6 +109,7 @@ export interface NoticeOfIntentDecisionDto {
 
 export interface NoticeOfIntentDecisionDocumentDto {
   uuid: string;
+  documentUuid: string;
   fileName: string;
   mimeType: string;
   uploadedBy: string;

--- a/alcs-frontend/src/app/shared/application-document/application-document.component.html
+++ b/alcs-frontend/src/app/shared/application-document/application-document.component.html
@@ -43,9 +43,11 @@
     <th *matHeaderCellDef mat-header-cell>File Name</th>
     <td *matCellDef="let element" mat-cell>
       <a
-        (click)="onOpen(element.uuid, element.fileName)" 
+        routerLink="/document/{{ element.documentUuid }}"
+        target="_blank"
         [matTooltip]="element.fileName"
-        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen">
+        [matTooltipDisabled]="element.fileName.length <= fileNameTruncLen"
+      >
         {{ element.fileName }}
       </a>
     </td>

--- a/alcs-frontend/src/app/shared/document-file-loader/document-file-loader.component.html
+++ b/alcs-frontend/src/app/shared/document-file-loader/document-file-loader.component.html
@@ -1,0 +1,5 @@
+<div class="container">
+  <mat-spinner class="spinner"></mat-spinner>
+
+  <div>Loading document...</div>
+</div>

--- a/alcs-frontend/src/app/shared/document-file-loader/document-file-loader.component.scss
+++ b/alcs-frontend/src/app/shared/document-file-loader/document-file-loader.component.scss
@@ -1,0 +1,20 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.spinner {
+  --spinner-size: 75px;
+
+  width: var(--spinner-size) !important;
+  height: var(--spinner-size) !important;
+}

--- a/alcs-frontend/src/app/shared/document-file-loader/document-file-loader.component.ts
+++ b/alcs-frontend/src/app/shared/document-file-loader/document-file-loader.component.ts
@@ -1,0 +1,39 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { DocumentService } from '../../services/common/document/document.service';
+
+@Component({
+  selector: 'app-temp',
+  templateUrl: './document-file-loader.component.html',
+  styleUrl: './document-file-loader.component.scss',
+})
+export class DocumentFileLoader {
+  uuid: string | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private documentService: DocumentService,
+  ) {
+    this.uuid = this.route.snapshot.paramMap.get('uuid');
+  }
+
+  ngAfterViewInit() {
+    if (this.uuid !== null) {
+      this.open(this.uuid);
+    }
+  }
+
+  async open(uuid: string) {
+    const { url, fileName } = await this.documentService.getDownloadUrlAndFileName(uuid);
+    const object = window.document.createElement('object');
+
+    object.data = url;
+
+    object.style.borderWidth = '0';
+    object.style.width = '100%';
+    object.style.height = '100%';
+
+    window.document.documentElement.replaceChild(object, document.body);
+    window.document.title = fileName;
+  }
+}

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.html
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.html
@@ -37,9 +37,11 @@
           Remove
         </button>
       </div>
-      <div *ngIf="existingFile" class="file">
+      <div *ngIf="existingFile && data.existingDocument" class="file">
         <div>
-          <a (click)="openExistingFile()">{{ existingFile.name }}</a>
+          <a routerLink="/document/{{ data.existingDocument?.documentUuid }}" target="_blank">{{
+            existingFile.name
+          }}</a>
         </div>
         <button (click)="onRemoveFile()" [disabled]="!allowsFileEdit" mat-button>
           <mat-icon>close</mat-icon>

--- a/alcs-frontend/src/app/shared/shared.module.ts
+++ b/alcs-frontend/src/app/shared/shared.module.ts
@@ -84,6 +84,7 @@ import { FlagDialogComponent } from './flag-dialog/flag-dialog.component';
 import { UnFlagDialogComponent } from './unflag-dialog/unflag-dialog.component';
 import { DecisionConditionFinancialInstrumentComponent } from './decision-condition-financial-instrument/decision-condition-financial-instrument.component';
 import { DecisionConditionFinancialInstrumentDialogComponent } from './decision-condition-financial-instrument/decision-condition-financial-instrument-dialog/decision-condition-financial-instrument-dialog.component';
+import { DocumentFileLoader } from './document-file-loader/document-file-loader.component';
 
 @NgModule({
   declarations: [
@@ -133,6 +134,7 @@ import { DecisionConditionFinancialInstrumentDialogComponent } from './decision-
     UnFlagDialogComponent,
     DecisionConditionFinancialInstrumentComponent,
     DecisionConditionFinancialInstrumentDialogComponent,
+    DocumentFileLoader,
   ],
   imports: [
     CommonModule,

--- a/services/apps/alcs/src/alcs/alcs.module.ts
+++ b/services/apps/alcs/src/alcs/alcs.module.ts
@@ -30,6 +30,7 @@ import { SearchModule } from './search/search.module';
 import { StaffJournalModule } from './staff-journal/staff-journal.module';
 import { IncomingFileModule } from './incoming-files/incoming-file.module';
 import { TagModule } from './tag/tag.module';
+import { AlcsDocumentModule } from '../alcs/document/document.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { TagModule } from './tag/tag.module';
     MaintenanceModule,
     IncomingFileModule,
     TagModule,
+    AlcsDocumentModule,
     RouterModule.register([
       { path: 'alcs', module: ApplicationModule },
       { path: 'alcs', module: CommentModule },
@@ -91,6 +93,7 @@ import { TagModule } from './tag/tag.module';
       { path: 'alcs', module: TagModule },
       { path: 'alcs', module: MaintenanceModule },
       { path: 'alcs', module: IncomingFileModule },
+      { path: 'alcs', module: AlcsDocumentModule },
     ]),
   ],
   controllers: [],

--- a/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision.dto.ts
+++ b/services/apps/alcs/src/alcs/application-decision/application-decision-v2/application-decision/application-decision.dto.ts
@@ -284,6 +284,9 @@ export class DecisionDocumentDto {
   uuid: string;
 
   @AutoMap()
+  documentUuid: string;
+
+  @AutoMap()
   fileName: string;
 
   @AutoMap()

--- a/services/apps/alcs/src/alcs/document/document.controller.spec.ts
+++ b/services/apps/alcs/src/alcs/document/document.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DocumentController } from './document.controller';
+
+describe('DocumentController', () => {
+  let controller: DocumentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DocumentController],
+    }).compile();
+
+    controller = module.get<DocumentController>(DocumentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/services/apps/alcs/src/alcs/document/document.controller.spec.ts
+++ b/services/apps/alcs/src/alcs/document/document.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DocumentController } from './document.controller';
+import { DocumentService } from '../../document/document.service';
 
 describe('DocumentController', () => {
   let controller: DocumentController;
@@ -7,6 +8,12 @@ describe('DocumentController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DocumentController],
+      providers: [
+        {
+          provide: DocumentService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<DocumentController>(DocumentController);

--- a/services/apps/alcs/src/alcs/document/document.controller.ts
+++ b/services/apps/alcs/src/alcs/document/document.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { DocumentService } from '../../document/document.service';
+
+@Controller('document')
+export class DocumentController {
+  constructor(private documentService: DocumentService) {}
+
+  @Get('/getDownloadUrlAndFileName/:uuid')
+  async getDownloadUrlAndFileName(
+    @Param('uuid') uuid: string,
+    @Query('isInline') isInline: boolean = false,
+  ): Promise<{ url: string; fileName: string }> {
+    return await this.documentService.getDownloadUrlAndFileNameByUuid(uuid, isInline);
+  }
+}

--- a/services/apps/alcs/src/alcs/document/document.module.ts
+++ b/services/apps/alcs/src/alcs/document/document.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DocumentModule } from '../../document/document.module';
+import { DocumentController } from './document.controller';
+
+@Module({
+  imports: [DocumentModule],
+  controllers: [DocumentController],
+  providers: [],
+  exports: [],
+})
+export class AlcsDocumentModule {}

--- a/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision.dto.ts
+++ b/services/apps/alcs/src/alcs/notice-of-intent-decision/notice-of-intent-decision.dto.ts
@@ -210,6 +210,9 @@ export class NoticeOfIntentDecisionDocumentDto {
   @AutoMap()
   uuid: string;
 
+  @AutoMap()
+  documentUuid: string;
+
   fileName: string;
   fileSize: number;
   mimeType: string;

--- a/services/apps/alcs/src/common/automapper/application-decision-v2.automapper.profile.ts
+++ b/services/apps/alcs/src/common/automapper/application-decision-v2.automapper.profile.ts
@@ -238,6 +238,10 @@ export class ApplicationDecisionProfile extends AutomapperProfile {
           (a) => a.uploadedAt,
           mapFrom((ad) => ad.document.uploadedAt.getTime()),
         ),
+        forMember(
+          (a) => a.documentUuid,
+          mapFrom((ad) => ad.document.uuid),
+        ),
       );
 
       createMap(

--- a/services/apps/alcs/src/common/automapper/notice-of-intent-decision.automapper.profile.ts
+++ b/services/apps/alcs/src/common/automapper/notice-of-intent-decision.automapper.profile.ts
@@ -295,6 +295,10 @@ export class NoticeOfIntentDecisionProfile extends AutomapperProfile {
           (a) => a.uploadedAt,
           mapFrom((ad) => ad.document.uploadedAt.getTime()),
         ),
+        forMember(
+          (a) => a.documentUuid,
+          mapFrom((ad) => ad.document.uuid),
+        ),
       );
 
       createMap(mapper, NoticeOfIntentModificationOutcomeType, NoticeOfIntentModificationOutcomeCodeDto);

--- a/services/apps/alcs/src/document/document.service.ts
+++ b/services/apps/alcs/src/document/document.service.ts
@@ -150,6 +150,12 @@ export class DocumentService {
     });
   }
 
+  async getDownloadUrlAndFileNameByUuid(uuid: string, openInline = false): Promise<{ url: string; fileName: string }> {
+    const document = await this.getDocument(uuid);
+
+    return { url: await this.getDownloadUrl(document, openInline), fileName: document.fileName };
+  }
+
   async createDocumentRecord(data: CreateDocumentDto) {
     const command = new GetObjectCommand({
       Bucket: this.config.get('STORAGE.BUCKET'),


### PR DESCRIPTION
- Implement new document open system
   - Add a new Angular route
   - Add a new component as target for the route
      - The component view is initially a loading spinner with "Loading document..."
      - The component grabs the document UUID, fetches the S3 URL, and loads it into an object
   - Controllers, DTO's, and services needed to be updated to make sure that <file>-documents had a documentUuid, and that there was a shared endpoint for retreiving the S3 URL
- Replace all existing click handlers with router links to the new route
