### PR TITLE
ALCS-2212: Improve advanced search name field

### DIFF
--- a/services/apps/alcs/src/alcs/search/inquiry/inquiry-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/inquiry/inquiry-advanced-search.service.ts
@@ -3,7 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as hash from 'object-hash';
 import { QueryRunner, Repository } from 'typeorm';
-import { formatStringToPostgresSearchStringArrayWithWildCard } from '../../../utils/search-helper';
+import { formatNameSearchString } from '../../../utils/search-helper';
 import { processSearchPromises } from '../../../utils/search/search-intersection';
 import { InquiryParcel } from '../../inquiry/inquiry-parcel/inquiry-parcel.entity';
 import { Inquiry } from '../../inquiry/inquiry.entity';
@@ -192,21 +192,21 @@ export class InquiryAdvancedSearchService {
   }
 
   private addNameResults(searchDto: SearchRequestDto, promises: Promise<{ fileNumber: string }[]>[]) {
-    const formattedSearchString = formatStringToPostgresSearchStringArrayWithWildCard(searchDto.name!);
+    const formattedSearchString = formatNameSearchString(searchDto.name!);
     const promise = this.inquiryRepository
       .createQueryBuilder('inquiry')
       .select('inquiry.fileNumber')
-      .where("LOWER(inquiry.inquirer_first_name || ' ' || inquiry.inquirer_last_name) LIKE ANY (:names)", {
-        names: formattedSearchString,
+      .where("LOWER(CONCAT_WS(' ', inquiry.inquirer_first_name, inquiry.inquirer_last_name)) LIKE :name", {
+        name: formattedSearchString,
       })
-      .orWhere('LOWER(inquiry.inquirer_first_name) LIKE ANY (:names)', {
-        names: formattedSearchString,
+      .orWhere('LOWER(inquiry.inquirer_first_name) LIKE :name', {
+        name: formattedSearchString,
       })
-      .orWhere('LOWER(inquiry.inquirer_last_name) LIKE ANY (:names)', {
-        names: formattedSearchString,
+      .orWhere('LOWER(inquiry.inquirer_last_name) LIKE :name', {
+        name: formattedSearchString,
       })
-      .orWhere('LOWER(inquiry.inquirer_organization) LIKE ANY (:names)', {
-        names: formattedSearchString,
+      .orWhere('LOWER(inquiry.inquirer_organization) LIKE :name', {
+        name: formattedSearchString,
       })
       .getMany();
     promises.push(promise);

--- a/services/apps/alcs/src/alcs/search/planning-review/planning-review-advanced-search.service.ts
+++ b/services/apps/alcs/src/alcs/search/planning-review/planning-review-advanced-search.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import * as hash from 'object-hash';
 import { QueryRunner, Repository } from 'typeorm';
 import { getNextDayToPacific, getStartOfDayToPacific } from '../../../utils/pacific-date-time-helper';
-import { formatStringToPostgresSearchStringArrayWithWildCard } from '../../../utils/search-helper';
+import { formatNameSearchString } from '../../../utils/search-helper';
 import { processSearchPromises } from '../../../utils/search/search-intersection';
 import { LocalGovernment } from '../../local-government/local-government.entity';
 import { PlanningReferral } from '../../planning-review/planning-referral/planning-referral.entity';
@@ -196,13 +196,13 @@ export class PlanningReviewAdvancedSearchService {
   }
 
   private addNameResults(searchDto: SearchRequestDto, promises: Promise<{ fileNumber: string }[]>[]) {
-    const formattedSearchString = formatStringToPostgresSearchStringArrayWithWildCard(searchDto.name!);
+    const formattedSearchString = formatNameSearchString(searchDto.name!);
 
     const promise = this.planningReviewRepository
       .createQueryBuilder('planningReview')
       .select('planningReview.fileNumber')
-      .where('LOWER(planningReview.document_name) LIKE ANY (:names)', {
-        names: formattedSearchString,
+      .where('LOWER(planningReview.document_name) LIKE :name', {
+        name: formattedSearchString,
       })
       .getMany();
     promises.push(promise);

--- a/services/apps/alcs/src/utils/search-helper.spec.ts
+++ b/services/apps/alcs/src/utils/search-helper.spec.ts
@@ -1,35 +1,44 @@
-import { formatStringToPostgresSearchStringArrayWithWildCard } from './search-helper';
+import { formatNameSearchString } from './search-helper';
 
 describe('formatStringToSearchStringWithWildCard', () => {
   test('should format string correctly when input contains single word', () => {
     const input = 'word';
-    const expectedOutput = '{%word%}';
-    const actualOutput =
-      formatStringToPostgresSearchStringArrayWithWildCard(input);
+    const expectedOutput = 'word';
+    const actualOutput = formatNameSearchString(input);
     expect(actualOutput).toBe(expectedOutput);
   });
 
   test('should format string correctly when input contains multiple words', () => {
     const input = 'multiple words';
-    const expectedOutput = '{%multiple%,%words%,%multiple words%}';
-    const actualOutput =
-      formatStringToPostgresSearchStringArrayWithWildCard(input);
+    const expectedOutput = 'multiple words';
+    const actualOutput = formatNameSearchString(input);
+    expect(actualOutput).toBe(expectedOutput);
+  });
+
+  test('should format string correctly when input contains ending wildcards', () => {
+    const input = 'multiple %words';
+    const expectedOutput = 'multiple %words';
+    const actualOutput = formatNameSearchString(input);
+    expect(actualOutput).toBe(expectedOutput);
+  });
+
+  test('should escape internal wildcards', () => {
+    const input = 'mult%iple %words';
+    const expectedOutput = 'mult\\%iple %words';
+    const actualOutput = formatNameSearchString(input);
     expect(actualOutput).toBe(expectedOutput);
   });
 
   test('should trim input and format string correctly', () => {
     const input = '   trimmed word  ';
-    const expectedOutput = '{%trimmed%,%word%,%trimmed word%}';
-    const actualOutput =
-      formatStringToPostgresSearchStringArrayWithWildCard(input);
+    const expectedOutput = 'trimmed word';
+    const actualOutput = formatNameSearchString(input);
     expect(actualOutput).toBe(expectedOutput);
   });
 
   it('should handle empty string correctly', () => {
     const input = '';
-    const expectedOutput = '{%%}';
-    expect(formatStringToPostgresSearchStringArrayWithWildCard(input)).toBe(
-      expectedOutput,
-    );
+    const expectedOutput = '';
+    expect(formatNameSearchString(input)).toBe(expectedOutput);
   });
 });

--- a/services/apps/alcs/src/utils/search-helper.ts
+++ b/services/apps/alcs/src/utils/search-helper.ts
@@ -1,18 +1,18 @@
-export const formatStringToPostgresSearchStringArrayWithWildCard = (
-  input: string,
-): string => {
-  input = input.trim();
-  const splitString = input.split(' ');
-  let output = '';
+export const formatNameSearchString = (input: string): string | null => {
+  return input
+    .split(/\s+/)
+    .filter((word) => word !== '')
+    .map((word) => {
+      const matches = word
+        .toLowerCase()
+        .match(/^(\%)?([^\s]+?)(\%)?$/)
+        ?.map((match) => match ?? '');
 
-  if (splitString.length === 1) {
-    output = splitString.map((word) => `%${word}%`.toLowerCase()).join(',');
-    return `{${output}}`;
-  }
+      if (!matches) {
+        return null;
+      }
 
-  output = splitString
-    .map((word) => `%${word}%`.trim().toLowerCase())
-    .join(',');
-  output += `,%${input}%`;
-  return `{${output}}`;
+      return matches[1] + matches[2].replace('%', `\\%`) + matches[3];
+    })
+    .join(' ');
 };

--- a/services/apps/alcs/src/utils/search/notice-of-intent-search-filters.ts
+++ b/services/apps/alcs/src/utils/search/notice-of-intent-search-filters.ts
@@ -6,7 +6,7 @@ import { NoticeOfIntentOwner } from '../../portal/notice-of-intent-submission/no
 import { NoticeOfIntentParcel } from '../../portal/notice-of-intent-submission/notice-of-intent-parcel/notice-of-intent-parcel.entity';
 import { NoticeOfIntentSubmission } from '../../portal/notice-of-intent-submission/notice-of-intent-submission.entity';
 import { SearchRequestDto } from '../../portal/public/search/public-search.dto';
-import { formatStringToPostgresSearchStringArrayWithWildCard } from '../search-helper';
+import { formatNameSearchString } from '../search-helper';
 
 export const NOI_SEARCH_FILTERS = {
   addFileNumberResults: (searchDto: SearchRequestDto | InboxRequestDto, noiRepository: Repository<NoticeOfIntent>) => {
@@ -81,7 +81,7 @@ export const NOI_SEARCH_FILTERS = {
     searchDto: SearchRequestDto | InboxRequestDto,
     noiSubmissionRepository: Repository<NoticeOfIntentSubmission>,
   ) => {
-    const formattedSearchString = formatStringToPostgresSearchStringArrayWithWildCard(searchDto.name!);
+    const formattedSearchString = formatNameSearchString(searchDto.name!);
     return noiSubmissionRepository
       .createQueryBuilder('noiSub')
       .select('noiSub.fileNumber')
@@ -94,19 +94,19 @@ export const NOI_SEARCH_FILTERS = {
         new Brackets((qb) =>
           qb
             .where(
-              "LOWER(notice_of_intent_owner.first_name || ' ' || notice_of_intent_owner.last_name) LIKE ANY (:names)",
+              "LOWER(CONCAT_WS(' ', notice_of_intent_owner.first_name, notice_of_intent_owner.last_name)) LIKE :name",
               {
-                names: formattedSearchString,
+                name: formattedSearchString,
               },
             )
-            .orWhere('LOWER(notice_of_intent_owner.first_name) LIKE ANY (:names)', {
-              names: formattedSearchString,
+            .orWhere('LOWER(notice_of_intent_owner.first_name) LIKE :name', {
+              name: formattedSearchString,
             })
-            .orWhere('LOWER(notice_of_intent_owner.last_name) LIKE ANY (:names)', {
-              names: formattedSearchString,
+            .orWhere('LOWER(notice_of_intent_owner.last_name) LIKE :name', {
+              name: formattedSearchString,
             })
-            .orWhere('LOWER(notice_of_intent_owner.organization_name) LIKE ANY (:names)', {
-              names: formattedSearchString,
+            .orWhere('LOWER(notice_of_intent_owner.organization_name) LIKE :name', {
+              name: formattedSearchString,
             }),
         ),
       )

--- a/services/apps/alcs/src/utils/search/notification-search-filters.ts
+++ b/services/apps/alcs/src/utils/search/notification-search-filters.ts
@@ -6,7 +6,7 @@ import { NotificationParcel } from '../../portal/notification-submission/notific
 import { NotificationSubmission } from '../../portal/notification-submission/notification-submission.entity';
 import { NotificationTransferee } from '../../portal/notification-submission/notification-transferee/notification-transferee.entity';
 import { SearchRequestDto } from '../../portal/public/search/public-search.dto';
-import { formatStringToPostgresSearchStringArrayWithWildCard } from '../search-helper';
+import { formatNameSearchString } from '../search-helper';
 
 export const NOTIFICATION_SEARCH_FILTERS = {
   addFileNumberResults: (
@@ -50,7 +50,7 @@ export const NOTIFICATION_SEARCH_FILTERS = {
     searchDto: SearchRequestDto | InboxRequestDto,
     notificationSubRepository: Repository<NotificationSubmission>,
   ) => {
-    const formattedSearchString = formatStringToPostgresSearchStringArrayWithWildCard(searchDto.name!);
+    const formattedSearchString = formatNameSearchString(searchDto.name!);
     return notificationSubRepository
       .createQueryBuilder('notiSub')
       .select('notiSub.fileNumber')
@@ -63,19 +63,19 @@ export const NOTIFICATION_SEARCH_FILTERS = {
         new Brackets((qb) =>
           qb
             .where(
-              "LOWER(notification_transferee.first_name || ' ' || notification_transferee.last_name) LIKE ANY (:names)",
+              "LOWER(CONCAT_WS(' ', notification_transferee.first_name, notification_transferee.last_name)) LIKE :name",
               {
-                names: formattedSearchString,
+                name: formattedSearchString,
               },
             )
-            .orWhere('LOWER(notification_transferee.first_name) LIKE ANY (:names)', {
-              names: formattedSearchString,
+            .orWhere('LOWER(notification_transferee.first_name) LIKE :name', {
+              name: formattedSearchString,
             })
-            .orWhere('LOWER(notification_transferee.last_name) LIKE ANY (:names)', {
-              names: formattedSearchString,
+            .orWhere('LOWER(notification_transferee.last_name) LIKE :name', {
+              name: formattedSearchString,
             })
-            .orWhere('LOWER(notification_transferee.organization_name) LIKE ANY (:names)', {
-              names: formattedSearchString,
+            .orWhere('LOWER(notification_transferee.organization_name) LIKE :name', {
+              name: formattedSearchString,
             }),
         ),
       )


### PR DESCRIPTION
- Change the way the search string is formatted
- It is now a single string and the full name, first name, and last name
  are compared against this string
- Use different concat method, so there is no space when first or last
  name are missing
