### PR TITLE
Update gitops repo directly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,17 +41,44 @@ jobs:
           import alcs-migrate
           import alcs-portal-frontend
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
+      - name: Checkout Gitops repo
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITOPS_DEPLOY_KEY }}
-          repository: ${{ env.GITOPS_REPO }}
-          event-type: deploy-${{ inputs.environment }}
-          client-payload: |
-            {
-              "alcs-api": "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-api:${{ github.sha }}",
-              "alcs-frontend": "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-frontend:${{ github.sha }}",
-              "alcs-migrate": "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-migrate:${{ github.sha }}",
-              "alcs-portal-frontend": "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-portal-frontend:${{ github.sha }}",
-              "commitMessage": "${{ github.sha }}"
-            }
+          ssh-key: ${{ secrets.GITOPS_DEPLOY_KEY }}
+          repository: ${{ secrets.GITOPS_REPO }}
+
+      - name: "Configure git"
+        # From https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Update API Image
+        id: api-image-update
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq eval '.spec.template.spec.containers[0].image = "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-api:${{ github.sha }}"' -i namespaces/dev/images-api_patch.yaml
+
+      - name: Update Migrate Image
+        id: migrate-image-update
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq eval '.spec.template.spec.containers[0].image = "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-migrate:${{ github.sha }}"' -i namespaces/dev/images-migrate_patch.yaml
+
+      - name: Update ALCS Frontend Image
+        id: fe-image-update
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq eval '.spec.template.spec.containers[0].image = "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-frontend:${{ github.sha }}"' -i namespaces/dev/images-alcs_patch.yaml
+
+      - name: Update Portal Frontend Image
+        id: portal-fe-image-update
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq eval '.spec.template.spec.containers[0].image = "image-registry.apps.silver.devops.gov.bc.ca/a5cf88-tools/alcs-portal-frontend:${{ github.sha }}"' -i namespaces/dev/images-portal_patch.yaml
+
+      - name: Commit and push update
+        run: |
+          git commit -am "${{ github.sha }}"
+          git push origin


### PR DESCRIPTION
Update the gitops repo directly in the main repo's workflow.

This allows deploy keys to be used instead of a PAT.
