### PR TITLE
Patch libxml2 in Dockerfiles for portal and ACLS frontends

### DIFF
--- a/alcs-frontend/Dockerfile
+++ b/alcs-frontend/Dockerfile
@@ -52,5 +52,8 @@ ENV ENABLED_CONNECT_SRC=" 'self' http://localhost:* nrs.objectstore.gov.bc.ca"
 # set to true to enable maintenance mode
 ENV MAINTENANCE_MODE="false"
 
+# Update libxml2 to patch the security vulnerabilities
+RUN apk add --no-cache libxml2
+
 # When the container starts, replace the settings.json with values from environment variables
 ENTRYPOINT [ "./init.sh" ]

--- a/portal-frontend/Dockerfile
+++ b/portal-frontend/Dockerfile
@@ -49,5 +49,8 @@ RUN chmod -R go+rwx /usr/share/nginx/html/assets
 # provide dynamic scp content-src
 ENV ENABLED_CONNECT_SRC=" 'self' http://localhost:* nrs.objectstore.gov.bc.ca"
 
+# Update libxml2 to patch the security vulnerabilities
+RUN apk add --no-cache libxml2
+
 # When the container starts, replace the settings.json with values from environment variables
 ENTRYPOINT [ "./init.sh" ]


### PR DESCRIPTION
libxml2 is not installed in base Docker image, but installing it should update the .so file in the `/usr/lib`.