### PR TITLE
2349 fix: select outcom in reconsideration request

### DIFF
--- a/alcs-frontend/src/app/features/application/post-decision/post-decision.component.html
+++ b/alcs-frontend/src/app/features/application/post-decision/post-decision.component.html
@@ -107,7 +107,7 @@
         #{{ reconsideration.resultingDecision.resolutionNumber }}/{{ reconsideration.resultingDecision.resolutionYear }}
       </div>
 
-      <div *ngIf="reconsideration.decisionOutcome">
+      <div *ngIf="reconsideration.reviewOutcome?.code === 'PRC' || reconsideration.type.code === '33.1'">
         <div class="subheading2">
           Does the reconsideration confirm, reverse, or vary
           {{ reconsideration.reconsidersDecisionsNumbers.join(', ') }}?


### PR DESCRIPTION
- Changed the reconsideration outcome back to PRC
- Added type code 33.1 so the `Select Outcome` appears for both Affected Party and Chair Directed

### Affected Party:
![image](https://github.com/user-attachments/assets/f2448c54-1558-4144-9d9a-3a361f97f5d3)

### Chair Directed:
![image](https://github.com/user-attachments/assets/3befba58-c429-4b3a-92b3-b4e2903425fa)
