### PR TITLE
2408 fix: Assignee Filter Bug

### DIFF
--- a/alcs-frontend/src/app/features/board/board.component.ts
+++ b/alcs-frontend/src/app/features/board/board.component.ts
@@ -247,6 +247,7 @@ export class BoardComponent implements OnInit, OnDestroy {
   private async setupBoard(board: BoardWithFavourite) {
     // clear cards to remove flickering
     this.cards = [];
+    this.selectedAssignees = [];
     this.titleService.setTitle(`${environment.siteName} | ${board.title} Board`);
     this.boardIsFavourite = board.isFavourite;
 


### PR DESCRIPTION
- cleared assignee filter when board loads, prevents filters from persisting from board 1 to board 2
- ty Tristan for the QA sanity check 🚀 