### PR TITLE
Add submission doc to C&E draft

### DIFF
--- a/alcs-frontend/src/app/features/compliance-and-enforcement/compliance-and-enforcement.module.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/compliance-and-enforcement.module.ts
@@ -6,6 +6,7 @@ import { MatMomentDateModule } from '@angular/material-moment-adapter';
 import { DraftComponent } from './draft/draft.component';
 import { SubmitterComponent } from './submitter/submitter.component';
 import { PropertyComponent } from './property/property.component';
+import { ComplianceAndEnforcementDocumentsComponent } from './documents/documents.component';
 
 const routes: Routes = [
   {
@@ -15,7 +16,13 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  declarations: [DraftComponent, OverviewComponent, SubmitterComponent, PropertyComponent],
+  declarations: [
+    DraftComponent,
+    OverviewComponent,
+    SubmitterComponent,
+    PropertyComponent,
+    ComplianceAndEnforcementDocumentsComponent,
+  ],
   imports: [SharedModule.forRoot(), RouterModule.forChild(routes), MatMomentDateModule],
 })
 export class ComplianceAndEnforcementModule {}

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.html
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.html
@@ -1,0 +1,55 @@
+<div class="header">
+  <h3>{{ title }}</h3>
+  <button (click)="openUploadDialog()" mat-flat-button color="primary">+ Add Document</button>
+</div>
+
+<table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z3 documents full-width">
+  <ng-container matColumnDef="source">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by source">Source</th>
+    <td mat-cell *matCellDef="let document">{{ document.source }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="type">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by type">Type</th>
+    <td mat-cell *matCellDef="let document" [matTooltip]="document.type.label">
+      {{ document.type.oatsCode }}
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="fileName">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by name">Document Name</th>
+    <td mat-cell *matCellDef="let document">
+      <a
+        routerLink="/document/{{ document.documentUuid }}"
+        target="_blank"
+        [matTooltip]="document.fileName"
+        [matTooltipDisabled]="document.fileName.length <= fileNameTruncLen"
+      >
+        {{ document.fileName }}
+      </a>
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="uploadedAt">
+    <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by date">Upload Date</th>
+    <td mat-cell *matCellDef="let document">{{ document.uploadedAt | date }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef class="actions-column">Actions</th>
+    <td mat-cell *matCellDef="let document">
+      <button class="action-button" mat-icon-button (click)="openEditDialog(document)">
+        <mat-icon>edit</mat-icon>
+      </button>
+      <button class="action-button" mat-icon-button (click)="deleteFile(document)">
+        <mat-icon color="warn">delete</mat-icon>
+      </button>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  <tr class="mat-row" *matNoDataRow>
+    <td class="text-center" colspan="6">No Complaint/Referral</td>
+  </tr>
+</table>

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.scss
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.scss
@@ -1,0 +1,15 @@
+@use '../../../../styles/colors.scss' as colors;
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.documents {
+  box-shadow: none;
+}
+
+.text-center {
+  padding-top: 10px;
+}

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
 import { DocumentUploadDialogComponent } from '../../../shared/document-upload-dialog/document-upload-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
-import { ComplianceAndEnforcementDocumentService } from '../../../services/compliance-and-enforcement/documents/document.service';
+import {
+  ComplianceAndEnforcementDocumentService,
+  Section,
+} from '../../../services/compliance-and-enforcement/documents/document.service';
 import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/confirmation-dialog.service';
 import { ToastService } from '../../../services/toast/toast.service';
 
@@ -29,6 +32,7 @@ export class ComplianceAndEnforcementDocumentsComponent implements OnInit, OnDes
   @Input() title?: string;
   @Input() fileNumber?: string;
   @Input() options?: DocumentUploadDialogOptions;
+  @Input() section?: Section;
 
   displayedColumns: string[] = ['source', 'type', 'fileName', 'uploadedAt', 'actions'];
 
@@ -62,6 +66,7 @@ export class ComplianceAndEnforcementDocumentsComponent implements OnInit, OnDes
         fileId: this.fileNumber,
         existingDocument: document,
         documentService: this.documentService,
+        section: this.section,
       },
     };
 
@@ -104,9 +109,10 @@ export class ComplianceAndEnforcementDocumentsComponent implements OnInit, OnDes
 
     const data: DocumentUploadDialogData = {
       ...this.options,
-      documentService: this.documentService,
       ...{
+        documentService: this.documentService,
         fileId: this.fileNumber,
+        section: this.section,
       },
     };
 
@@ -127,7 +133,7 @@ export class ComplianceAndEnforcementDocumentsComponent implements OnInit, OnDes
 
   async loadDocuments() {
     if (this.fileNumber) {
-      const documents = await this.documentService.list(this.fileNumber, this.options?.allowedDocumentTypes ?? []);
+      const documents = await this.documentService.list(this.fileNumber, this.section);
       this.dataSource.data = documents;
     }
   }

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/documents/documents.component.ts
@@ -1,0 +1,139 @@
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Subject } from 'rxjs';
+import { ComplianceAndEnforcementDocumentDto } from '../../../services/compliance-and-enforcement/documents/document.dto';
+import { MatSort } from '@angular/material/sort';
+import { MatTableDataSource } from '@angular/material/table';
+import { FILE_NAME_TRUNCATE_LENGTH } from '../../../shared/constants';
+import { DOCUMENT_SYSTEM } from '../../../shared/document/document.dto';
+import {
+  DocumentUploadDialogData,
+  DocumentUploadDialogOptions,
+} from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
+import { DocumentUploadDialogComponent } from '../../../shared/document-upload-dialog/document-upload-dialog.component';
+import { MatDialog } from '@angular/material/dialog';
+import { ComplianceAndEnforcementDocumentService } from '../../../services/compliance-and-enforcement/documents/document.service';
+import { ConfirmationDialogService } from '../../../shared/confirmation-dialog/confirmation-dialog.service';
+import { ToastService } from '../../../services/toast/toast.service';
+
+@Component({
+  selector: 'app-compliance-and-enforcement-documents',
+  templateUrl: './documents.component.html',
+  styleUrls: ['./documents.component.scss'],
+})
+export class ComplianceAndEnforcementDocumentsComponent implements OnInit, OnDestroy {
+  $destroy = new Subject<void>();
+
+  isPatching = false;
+  isSubscribed = false;
+
+  @Input() title?: string;
+  @Input() fileNumber?: string;
+  @Input() options?: DocumentUploadDialogOptions;
+
+  displayedColumns: string[] = ['source', 'type', 'fileName', 'uploadedAt', 'actions'];
+
+  @ViewChild(MatSort) sort!: MatSort;
+  dataSource: MatTableDataSource<ComplianceAndEnforcementDocumentDto> =
+    new MatTableDataSource<ComplianceAndEnforcementDocumentDto>();
+
+  readonly fileNameTruncLen = FILE_NAME_TRUNCATE_LENGTH;
+  readonly documentSystem = DOCUMENT_SYSTEM;
+
+  constructor(
+    public dialog: MatDialog,
+    private readonly documentService: ComplianceAndEnforcementDocumentService,
+    private confirmationDialogService: ConfirmationDialogService,
+    private toastService: ToastService,
+  ) {}
+
+  ngOnInit() {
+    this.loadDocuments();
+  }
+
+  openEditDialog(document: ComplianceAndEnforcementDocumentDto) {
+    if (!this.fileNumber) {
+      console.error('File number is required to open the upload dialog.');
+      return;
+    }
+
+    const data: DocumentUploadDialogData = {
+      ...this.options,
+      ...{
+        fileId: this.fileNumber,
+        existingDocument: document,
+        documentService: this.documentService,
+      },
+    };
+
+    this.dialog
+      .open(DocumentUploadDialogComponent, {
+        minWidth: '600px',
+        maxWidth: '800px',
+        width: '70%',
+        data,
+      })
+      .afterClosed()
+      .subscribe((isDirty) => {
+        if (isDirty) {
+          this.loadDocuments();
+        }
+      });
+  }
+
+  deleteFile(document: ComplianceAndEnforcementDocumentDto) {
+    this.confirmationDialogService
+      .openDialog({
+        body: `Are you sure you want to delete ${document.fileName}?`,
+      })
+      .subscribe(async (accepted) => {
+        if (accepted) {
+          await this.documentService.delete(document.uuid);
+
+          this.toastService.showSuccessToast('Document deleted');
+
+          this.loadDocuments();
+        }
+      });
+  }
+
+  openUploadDialog() {
+    if (!this.fileNumber) {
+      console.error('File number is required to open the upload dialog.');
+      return;
+    }
+
+    const data: DocumentUploadDialogData = {
+      ...this.options,
+      documentService: this.documentService,
+      ...{
+        fileId: this.fileNumber,
+      },
+    };
+
+    this.dialog
+      .open(DocumentUploadDialogComponent, {
+        minWidth: '600px',
+        maxWidth: '800px',
+        width: '70%',
+        data,
+      })
+      .afterClosed()
+      .subscribe((isDirty) => {
+        if (isDirty) {
+          this.loadDocuments();
+        }
+      });
+  }
+
+  async loadDocuments() {
+    if (this.fileNumber) {
+      const documents = await this.documentService.list(this.fileNumber, this.options?.allowedDocumentTypes ?? []);
+      this.dataSource.data = documents;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.$destroy.next();
+    this.$destroy.complete();
+  }
+}

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.html
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.html
@@ -16,6 +16,7 @@
         [title]="'Complaint/Referral Submission'"
         [fileNumber]="fileNumber"
         [options]="submissionDocumentOptions"
+        [section]="Section.SUBMISSION"
       />
     </section>
 

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.html
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.html
@@ -10,14 +10,17 @@
         [submitter]="submitter"
         [initialSubmissionType]="initialSubmissionType"
       />
+
+      <app-compliance-and-enforcement-documents
+        #submissionDocumentsComponent
+        [title]="'Complaint/Referral Submission'"
+        [fileNumber]="fileNumber"
+        [options]="submissionDocumentOptions"
+      />
     </section>
 
     <section class="form-section">
-      <app-compliance-and-enforcement-property
-        #propertyComponent
-        [parentForm]="form"
-        [property]="property"
-      />
+      <app-compliance-and-enforcement-property #propertyComponent [parentForm]="form" [property]="property" />
     </section>
 
     <div class="button-container">

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.ts
@@ -13,8 +13,10 @@ import { SubmitterComponent } from '../submitter/submitter.component';
 import { ComplianceAndEnforcementSubmitterDto } from '../../../services/compliance-and-enforcement/submitter/submitter.dto';
 import { ComplianceAndEnforcementSubmitterService } from '../../../services/compliance-and-enforcement/submitter/submitter.service';
 import { PropertyComponent, cleanPropertyUpdate } from '../property/property.component';
-import { ComplianceAndEnforcementPropertyDto, UpdateComplianceAndEnforcementPropertyDto } from '../../../services/compliance-and-enforcement/property/property.dto';
+import { ComplianceAndEnforcementPropertyDto } from '../../../services/compliance-and-enforcement/property/property.dto';
 import { ComplianceAndEnforcementPropertyService } from '../../../services/compliance-and-enforcement/property/property.service';
+import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/document/document.dto';
+import { DocumentUploadDialogOptions } from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
 
 @Component({
   selector: 'app-compliance-and-enforcement-draft',
@@ -22,6 +24,13 @@ import { ComplianceAndEnforcementPropertyService } from '../../../services/compl
   styleUrls: ['./draft.component.scss'],
 })
 export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
+  submissionDocumentOptions: DocumentUploadDialogOptions = {
+    allowedVisibilityFlags: [],
+    allowsFileEdit: true,
+    allowedDocumentSources: [DOCUMENT_SOURCE.COMPLAINANT],
+    allowedDocumentTypes: [DOCUMENT_TYPE.COMPLAINT],
+  };
+
   $destroy = new Subject<void>();
 
   fileNumber?: string;
@@ -112,8 +121,8 @@ export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
         debounceTime(1000),
         switchMap((property) => {
           // Only auto-save if there are meaningful changes (non-empty fields)
-          const hasActualData = Object.values(cleanPropertyUpdate(property)).some(value => 
-            value !== null && value !== undefined && value !== '' && value !== 0
+          const hasActualData = Object.values(cleanPropertyUpdate(property)).some(
+            (value) => value !== null && value !== undefined && value !== '' && value !== 0,
           );
 
           if (!hasActualData) {
@@ -123,9 +132,9 @@ export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
           if (this.property?.uuid) {
             return this.complianceAndEnforcementPropertyService.update(this.property.uuid, property);
           } else if (this.file?.uuid) {
-            return this.complianceAndEnforcementPropertyService.create({ 
+            return this.complianceAndEnforcementPropertyService.create({
               fileUuid: this.file.uuid,
-              ...cleanPropertyUpdate(property)
+              ...cleanPropertyUpdate(property),
             });
           } else {
             return EMPTY;
@@ -153,7 +162,7 @@ export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
       this.file = await this.complianceAndEnforcementService.fetchByFileNumber(fileNumber, true);
       this.submitter = this.file.submitters[0];
       this.initialSubmissionType = this.file.initialSubmissionType ?? undefined;
-      
+
       // Load property data
       if (this.file.uuid) {
         try {
@@ -187,7 +196,7 @@ export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
 
     try {
       await firstValueFrom(this.complianceAndEnforcementService.update(this.file.uuid, overviewUpdate));
-      
+
       if (this.submitter?.uuid) {
         await firstValueFrom(
           this.complianceAndEnforcementSubmitterService.update(this.submitter.uuid, submitterUpdate),
@@ -197,14 +206,12 @@ export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
       }
 
       if (this.property?.uuid) {
-        await firstValueFrom(
-          this.complianceAndEnforcementPropertyService.update(this.property.uuid, propertyUpdate),
-        );
+        await firstValueFrom(this.complianceAndEnforcementPropertyService.update(this.property.uuid, propertyUpdate));
       } else {
         this.property = await firstValueFrom(
           this.complianceAndEnforcementPropertyService.create({
             fileUuid: this.file.uuid,
-            ...cleanPropertyUpdate(propertyUpdate)
+            ...cleanPropertyUpdate(propertyUpdate),
           }),
         );
       }

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.ts
@@ -27,8 +27,15 @@ export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
   submissionDocumentOptions: DocumentUploadDialogOptions = {
     allowedVisibilityFlags: [],
     allowsFileEdit: true,
-    allowedDocumentSources: [DOCUMENT_SOURCE.COMPLAINANT],
-    allowedDocumentTypes: [DOCUMENT_TYPE.COMPLAINT],
+    allowedDocumentSources: [
+      DOCUMENT_SOURCE.COMPLAINANT,
+      DOCUMENT_SOURCE.PUBLIC,
+      DOCUMENT_SOURCE.LFNG,
+      DOCUMENT_SOURCE.BC_GOVERNMENT,
+      DOCUMENT_SOURCE.OTHER_AGENCY,
+      DOCUMENT_SOURCE.ALC,
+    ],
+    allowedDocumentTypes: [DOCUMENT_TYPE.COMPLAINT, DOCUMENT_TYPE.REFERRAL],
   };
 
   $destroy = new Subject<void>();

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/draft/draft.component.ts
@@ -17,6 +17,7 @@ import { ComplianceAndEnforcementPropertyDto } from '../../../services/complianc
 import { ComplianceAndEnforcementPropertyService } from '../../../services/compliance-and-enforcement/property/property.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE } from '../../../shared/document/document.dto';
 import { DocumentUploadDialogOptions } from '../../../shared/document-upload-dialog/document-upload-dialog.interface';
+import { Section } from '../../../services/compliance-and-enforcement/documents/document.service';
 
 @Component({
   selector: 'app-compliance-and-enforcement-draft',
@@ -24,6 +25,8 @@ import { DocumentUploadDialogOptions } from '../../../shared/document-upload-dia
   styleUrls: ['./draft.component.scss'],
 })
 export class DraftComponent implements OnInit, AfterViewInit, OnDestroy {
+  Section = Section;
+
   submissionDocumentOptions: DocumentUploadDialogOptions = {
     allowedVisibilityFlags: [],
     allowsFileEdit: true,

--- a/alcs-frontend/src/app/services/compliance-and-enforcement/documents/document.dto.ts
+++ b/alcs-frontend/src/app/services/compliance-and-enforcement/documents/document.dto.ts
@@ -1,4 +1,5 @@
 import { DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DocumentTypeDto } from '../../../shared/document/document.dto';
+import { Section } from './document.service';
 
 export interface ComplianceAndEnforcementDocumentDto {
   uuid: string;
@@ -13,19 +14,14 @@ export interface ComplianceAndEnforcementDocumentDto {
   fileSize?: number;
 }
 
-export interface CreateComplianceAndEnforcementDocumentDto {
-  typeCode: string;
-
-  source: DOCUMENT_SOURCE;
-  fileName: string;
-  file: File;
-}
-
 export interface UpdateComplianceAndEnforcementDocumentDto {
   typeCode?: string;
 
   source?: DOCUMENT_SOURCE;
   fileName?: string;
-  file?: File;
-  visibilityFlags?: ('A' | 'C' | 'G' | 'P')[];
+  section?: Section;
+}
+
+export interface CreateComplianceAndEnforcementDocumentDto extends UpdateComplianceAndEnforcementDocumentDto {
+  file: File;
 }

--- a/alcs-frontend/src/app/services/compliance-and-enforcement/documents/document.dto.ts
+++ b/alcs-frontend/src/app/services/compliance-and-enforcement/documents/document.dto.ts
@@ -1,0 +1,31 @@
+import { DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DocumentTypeDto } from '../../../shared/document/document.dto';
+
+export interface ComplianceAndEnforcementDocumentDto {
+  uuid: string;
+  type: DocumentTypeDto;
+
+  documentUuid: string;
+  source: DOCUMENT_SOURCE;
+  system: DOCUMENT_SYSTEM;
+  fileName: string;
+  mimeType: string;
+  uploadedAt: number;
+  fileSize?: number;
+}
+
+export interface CreateComplianceAndEnforcementDocumentDto {
+  typeCode: string;
+
+  source: DOCUMENT_SOURCE;
+  fileName: string;
+  file: File;
+}
+
+export interface UpdateComplianceAndEnforcementDocumentDto {
+  typeCode?: string;
+
+  source?: DOCUMENT_SOURCE;
+  fileName?: string;
+  file?: File;
+  visibilityFlags?: ('A' | 'C' | 'G' | 'P')[];
+}

--- a/alcs-frontend/src/app/services/compliance-and-enforcement/documents/document.service.ts
+++ b/alcs-frontend/src/app/services/compliance-and-enforcement/documents/document.service.ts
@@ -1,0 +1,88 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { ComplianceAndEnforcementDocumentDto, UpdateComplianceAndEnforcementDocumentDto } from './document.dto';
+import { DOCUMENT_TYPE, DocumentTypeDto } from '../../../shared/document/document.dto';
+import { downloadFileFromUrl, openFileInline } from '../../../shared/utils/file';
+import { CreateDocumentDto, UpdateDocumentDto } from '../../application/application-document/application-document.dto';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ComplianceAndEnforcementDocumentService {
+  private readonly url = `${environment.apiUrl}/compliance-and-enforcement/document`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  list(fileNumber?: string, typeCodes: string[] = []): Promise<ComplianceAndEnforcementDocumentDto[]> {
+    let params = new HttpParams();
+
+    if (fileNumber) {
+      params = params.set('fileNumber', fileNumber);
+    }
+    for (const typeCode of typeCodes) {
+      params = params.append('typeCodes', typeCode);
+    }
+
+    return firstValueFrom(this.http.get<ComplianceAndEnforcementDocumentDto[]>(this.url, { params }));
+  }
+
+  async update(
+    uuid: string,
+    updateDto: UpdateComplianceAndEnforcementDocumentDto,
+  ): Promise<ComplianceAndEnforcementDocumentDto> {
+    return firstValueFrom(this.http.patch<ComplianceAndEnforcementDocumentDto>(`${this.url}/${uuid}`, updateDto));
+  }
+
+  async upload(fileNumber: string, createDto: CreateDocumentDto): Promise<ComplianceAndEnforcementDocumentDto> {
+    let formData = this.convertDtoToFormData(createDto);
+
+    return firstValueFrom(this.http.post<ComplianceAndEnforcementDocumentDto>(`${this.url}/${fileNumber}`, formData));
+  }
+
+  async download(uuid: string, fileName: string, isInline: boolean) {
+    const url = isInline ? `${this.url}/${uuid}/open` : `${this.url}/${uuid}/download`;
+    const data = await firstValueFrom(this.http.get<{ url: string }>(url));
+
+    if (isInline) {
+      openFileInline(data.url, fileName);
+    } else {
+      downloadFileFromUrl(data.url, fileName);
+    }
+  }
+
+  async fetchTypes(allowedCodes: DOCUMENT_TYPE[] = []): Promise<DocumentTypeDto[]> {
+    let params = new HttpParams();
+
+    for (const typeCode of allowedCodes) {
+      params = params.append('allowedCodes', typeCode);
+    }
+
+    return firstValueFrom(this.http.get<DocumentTypeDto[]>(`${this.url}/types`, { params }));
+  }
+
+  async delete(uuid: string): Promise<ComplianceAndEnforcementDocumentDto> {
+    return firstValueFrom(this.http.delete<ComplianceAndEnforcementDocumentDto>(`${this.url}/${uuid}`));
+  }
+
+  private convertDtoToFormData(dto: UpdateDocumentDto | CreateDocumentDto): FormData {
+    let formData: FormData = new FormData();
+
+    formData.append('documentType', dto.typeCode);
+    formData.append('source', dto.source);
+    formData.append('visibilityFlags', dto.visibilityFlags.join(', '));
+    formData.append('fileName', dto.fileName);
+    if (dto.file) {
+      formData.append('file', dto.file, dto.file.name);
+    }
+    if (dto.parcelUuid) {
+      formData.append('parcelUuid', dto.parcelUuid);
+    }
+    if (dto.ownerUuid) {
+      formData.append('ownerUuid', dto.ownerUuid);
+    }
+
+    return formData;
+  }
+}

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.html
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.html
@@ -110,7 +110,7 @@
         </mat-select>
       </mat-form-field>
     </div>
-    <div *ngIf="data.allowedVisibilityFlags" class="double">
+    <div *ngIf="data.allowedVisibilityFlags && data.allowedVisibilityFlags.length > 0" class="double">
       <mat-label>Visible To:</mat-label>
       <div
         *ngIf="

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.ts
@@ -84,6 +84,9 @@ export class DocumentUploadDialogComponent implements OnInit, OnDestroy {
     this.internalVisibilityLabel = this.buildInternalVisibilityLabel();
 
     this.documentSources = this.data.allowedDocumentSources ?? DEFAULT_DOCUMENT_SOURCES;
+    if (this.documentSources.length === 1) {
+      this.source.setValue(this.documentSources[0]);
+    }
 
     if (this.data.existingDocument) {
       const document = this.data.existingDocument;
@@ -406,9 +409,13 @@ export class DocumentUploadDialogComponent implements OnInit, OnDestroy {
 
   private async loadDocumentTypes() {
     if (this.data.documentService) {
-      const docTypes = await this.data.documentService.fetchTypes();
+      const docTypes = await this.data.documentService.fetchTypes(this.data.allowedDocumentTypes);
       docTypes.sort((a, b) => (a.label > b.label ? 1 : -1));
       this.documentTypes = docTypes.filter((type) => type.code !== DOCUMENT_TYPE.ORIGINAL_APPLICATION);
+
+      if (this.documentTypes.length === 1) {
+        this.type.setValue(this.documentTypes[0].code);
+      }
     } else if (this.data.decisionService) {
       this.documentTypes = [
         {

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.component.ts
@@ -205,6 +205,7 @@ export class DocumentUploadDialogComponent implements OnInit, OnDestroy {
       visibilityFlags,
       parcelUuid: this.parcelId.value ?? undefined,
       ownerUuid: this.ownerId.value ?? undefined,
+      section: this.data.section ?? undefined,
     };
 
     if (file) {

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.dto.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.dto.ts
@@ -1,3 +1,4 @@
+import { Section } from '../../services/compliance-and-enforcement/documents/document.service';
 import { DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DOCUMENT_TYPE, DocumentTypeDto } from '../../shared/document/document.dto';
 import { BaseCodeDto } from '../dto/base.dto';
 
@@ -9,6 +10,7 @@ export interface UpdateDocumentDto {
   source?: DOCUMENT_SOURCE;
   visibilityFlags?: ('A' | 'C' | 'G' | 'P')[];
   file?: File;
+  section?: Section;
 }
 
 export interface CreateDocumentDto extends UpdateDocumentDto {

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.dto.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.dto.ts
@@ -2,13 +2,13 @@ import { DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DOCUMENT_TYPE, DocumentTypeDto } from
 import { BaseCodeDto } from '../dto/base.dto';
 
 export interface UpdateDocumentDto {
-  file?: File;
   parcelUuid?: string;
   ownerUuid?: string;
-  fileName: string;
-  typeCode: DOCUMENT_TYPE;
-  source: DOCUMENT_SOURCE;
+  fileName?: string;
+  typeCode?: DOCUMENT_TYPE;
+  source?: DOCUMENT_SOURCE;
   visibilityFlags?: ('A' | 'C' | 'G' | 'P')[];
+  file?: File;
 }
 
 export interface CreateDocumentDto extends UpdateDocumentDto {
@@ -25,7 +25,6 @@ export interface DocumentDto {
   system: DOCUMENT_SYSTEM;
   fileName: string;
   mimeType: string;
-  uploadedBy: string;
   uploadedAt: number;
   evidentiaryRecordSorting?: number;
   fileSize?: number;

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.interface.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.interface.ts
@@ -1,3 +1,4 @@
+import { Section } from '../../services/compliance-and-enforcement/documents/document.service';
 import { DOCUMENT_SOURCE, DOCUMENT_TYPE, DocumentTypeDto } from '../document/document.dto';
 import { VisibilityGroup } from './document-upload-dialog.component';
 import {
@@ -19,6 +20,7 @@ export interface DocumentUploadDialogOptions {
   documentTypeOverrides?: Partial<Record<DOCUMENT_TYPE, DocumentTypeConfig>>;
   allowedDocumentSources?: DOCUMENT_SOURCE[];
   allowedDocumentTypes?: DOCUMENT_TYPE[];
+  section?: Section;
 }
 
 export interface DocumentUploadDialogData extends DocumentUploadDialogOptions {

--- a/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.interface.ts
+++ b/alcs-frontend/src/app/shared/document-upload-dialog/document-upload-dialog.interface.ts
@@ -18,6 +18,7 @@ export interface DocumentUploadDialogOptions {
   allowsFileEdit?: boolean;
   documentTypeOverrides?: Partial<Record<DOCUMENT_TYPE, DocumentTypeConfig>>;
   allowedDocumentSources?: DOCUMENT_SOURCE[];
+  allowedDocumentTypes?: DOCUMENT_TYPE[];
 }
 
 export interface DocumentUploadDialogData extends DocumentUploadDialogOptions {
@@ -41,7 +42,7 @@ export interface DocumentService {
   update(uuid: string, updateDto: UpdateDocumentDto): Promise<Object>;
   upload(fileNumber: string, createDto: CreateDocumentDto): Promise<Object | undefined>;
   download(uuid: string, fileName: string, isInline: boolean): Promise<void>;
-  fetchTypes(): Promise<DocumentTypeDto[]>;
+  fetchTypes(allowedCodes?: DOCUMENT_TYPE[]): Promise<DocumentTypeDto[]>;
   delete(uuid: string): Promise<Object>;
 }
 

--- a/alcs-frontend/src/app/shared/document/document.dto.ts
+++ b/alcs-frontend/src/app/shared/document/document.dto.ts
@@ -5,6 +5,7 @@ export enum DOCUMENT_TYPE {
   DECISION_DOCUMENT = 'DPAC',
   OTHER = 'OTHR',
   ORIGINAL_APPLICATION = 'ORIG',
+  REFERRAL = 'REFR',
 
   //Government Review
   RESOLUTION_DOCUMENT = 'RESO',

--- a/alcs-frontend/src/app/shared/document/document.dto.ts
+++ b/alcs-frontend/src/app/shared/document/document.dto.ts
@@ -34,6 +34,10 @@ export enum DOCUMENT_TYPE {
   //SRW
   SRW_TERMS = 'SRTD',
   SURVEY_PLAN = 'SURV',
+
+  // C&E
+  COMPLAINT = 'CMPL',
+  BC_ASSESSMENT_REPORT = 'BCAR',
 }
 
 export enum DOCUMENT_SOURCE {

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.module.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.module.ts
@@ -12,25 +12,49 @@ import { ComplianceAndEnforcementPropertyController } from './property/property.
 import { ComplianceAndEnforcementPropertyProfile } from './property/property.automapper.profile';
 import { ComplianceAndEnforcementPropertyService } from './property/property.service';
 import { ComplianceAndEnforcementProperty } from './property/property.entity';
+import { ComplianceAndEnforcementDocumentController } from './document/document.controller';
+import { ComplianceAndEnforcementDocumentService } from './document/document.service';
+import { ComplianceAndEnforcementDocumentProfile } from './document/document.automapper.profile';
+import { ComplianceAndEnforcementDocument } from './document/document.entity';
+import { DocumentCode } from '../../document/document-code.entity';
+import { DocumentModule } from '../../document/document.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ComplianceAndEnforcement, ComplianceAndEnforcementSubmitter, ComplianceAndEnforcementProperty])],
-  controllers: [ComplianceAndEnforcementController, ComplianceAndEnforcementSubmitterController, ComplianceAndEnforcementPropertyController],
+  imports: [
+    TypeOrmModule.forFeature([
+      ComplianceAndEnforcement,
+      ComplianceAndEnforcementSubmitter,
+      ComplianceAndEnforcementProperty,
+      ComplianceAndEnforcementDocument,
+      DocumentCode,
+    ]),
+    DocumentModule,
+  ],
+  controllers: [
+    ComplianceAndEnforcementController,
+    ComplianceAndEnforcementSubmitterController,
+    ComplianceAndEnforcementPropertyController,
+    ComplianceAndEnforcementDocumentController,
+  ],
   providers: [
     ComplianceAndEnforcementService,
     ComplianceAndEnforcementSubmitterService,
     ComplianceAndEnforcementPropertyService,
+    ComplianceAndEnforcementDocumentService,
     ComplianceAndEnforcementProfile,
     ComplianceAndEnforcementSubmitterProfile,
     ComplianceAndEnforcementPropertyProfile,
+    ComplianceAndEnforcementDocumentProfile,
   ],
   exports: [
     ComplianceAndEnforcementService,
     ComplianceAndEnforcementSubmitterService,
     ComplianceAndEnforcementPropertyService,
+    ComplianceAndEnforcementDocumentService,
     ComplianceAndEnforcementProfile,
     ComplianceAndEnforcementSubmitterProfile,
     ComplianceAndEnforcementPropertyProfile,
+    ComplianceAndEnforcementDocumentProfile,
   ],
 })
 export class ComplianceAndEnforcementModule {}

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.automapper.profile.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.automapper.profile.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { createMap, forMember, mapFrom, Mapper } from 'automapper-core';
+import { AutomapperProfile, InjectMapper } from 'automapper-nestjs';
+import { ComplianceAndEnforcementDocument } from './document.entity';
+import { ComplianceAndEnforcementDocumentDto, UpdateComplianceAndEnforcementDocumentDto } from './document.dto';
+
+@Injectable()
+export class ComplianceAndEnforcementDocumentProfile extends AutomapperProfile {
+  constructor(@InjectMapper() mapper: Mapper) {
+    super(mapper);
+  }
+
+  override get profile() {
+    return (mapper) => {
+      createMap(
+        mapper,
+        ComplianceAndEnforcementDocument,
+        ComplianceAndEnforcementDocumentDto,
+        forMember(
+          (dto) => dto.documentUuid,
+          mapFrom((entity) => entity.document.uuid),
+        ),
+        forMember(
+          (dto) => dto.source,
+          mapFrom((entity) => entity.document.source),
+        ),
+        forMember(
+          (dto) => dto.system,
+          mapFrom((entity) => entity.document.system),
+        ),
+        forMember(
+          (dto) => dto.fileName,
+          mapFrom((entity) => entity.document.fileName),
+        ),
+        forMember(
+          (dto) => dto.mimeType,
+          mapFrom((entity) => entity.document.mimeType),
+        ),
+        forMember(
+          (dto) => dto.uploadedAt,
+          mapFrom((entity) => entity.document.uploadedAt.getTime()),
+        ),
+      );
+
+      createMap(mapper, UpdateComplianceAndEnforcementDocumentDto, ComplianceAndEnforcementDocument);
+    };
+  }
+}

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.controller.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.controller.ts
@@ -22,6 +22,7 @@ import { DeleteResult } from 'typeorm';
 import { CreateDocumentDto, DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DocumentTypeDto } from '../../../document/document.dto';
 import { User } from '../../../user/user.entity';
 import { v4 } from 'uuid';
+import { Section } from './document.entity';
 
 @Controller('compliance-and-enforcement/document')
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
@@ -33,9 +34,9 @@ export class ComplianceAndEnforcementDocumentController {
   @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
   async list(
     @Query('fileNumber') fileNumber?: string,
-    @Query('typeCodes') typeCodes?: string[],
+    @Query('section') section?: Section,
   ): Promise<ComplianceAndEnforcementDocumentDto[]> {
-    return await this.service.list(fileNumber, typeCodes);
+    return await this.service.list(fileNumber, section);
   }
 
   @Post('/:fileNumber')
@@ -52,6 +53,7 @@ export class ComplianceAndEnforcementDocumentController {
       fileKey: `compliance-and-enforcement/${fileNumber}/${v4()}`,
       source: req.body.source.value as DOCUMENT_SOURCE,
       system: DOCUMENT_SYSTEM.ALCS,
+      section: req.body.section.value as Section,
     };
 
     return await this.service.create(fileNumber, req.user.entity as User, req.body.file, dto);

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.controller.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.controller.ts
@@ -1,0 +1,84 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOAuth2 } from '@nestjs/swagger';
+import * as config from 'config';
+import { RolesGuard } from '../../../common/authorization/roles-guard.service';
+import { UserRoles } from '../../../common/authorization/roles.decorator';
+import { AUTH_ROLE } from '../../../common/authorization/roles';
+import { ComplianceAndEnforcementDocumentService } from './document.service';
+import { ComplianceAndEnforcementDocumentDto, UpdateComplianceAndEnforcementDocumentDto } from './document.dto';
+import { DeleteResult } from 'typeorm';
+import { CreateDocumentDto, DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DocumentTypeDto } from '../../../document/document.dto';
+import { User } from '../../../user/user.entity';
+import { v4 } from 'uuid';
+
+@Controller('compliance-and-enforcement/document')
+@ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
+@UseGuards(RolesGuard)
+export class ComplianceAndEnforcementDocumentController {
+  constructor(private service: ComplianceAndEnforcementDocumentService) {}
+
+  @Get('')
+  @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
+  async list(
+    @Query('fileNumber') fileNumber?: string,
+    @Query('typeCodes') typeCodes?: string[],
+  ): Promise<ComplianceAndEnforcementDocumentDto[]> {
+    return await this.service.list(fileNumber, typeCodes);
+  }
+
+  @Post('/:fileNumber')
+  @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
+  async create(@Param('fileNumber') fileNumber: string, @Req() req): Promise<ComplianceAndEnforcementDocumentDto> {
+    if (!req.isMultipart()) {
+      throw new BadRequestException('Request is not multipart');
+    }
+
+    const dto: CreateDocumentDto = {
+      typeCode: req.body.documentType.value,
+      mimeType: req.body.file.mimeType,
+      fileName: req.body.fileName.value,
+      fileKey: `compliance-and-enforcement/${fileNumber}/${v4()}`,
+      source: req.body.source.value as DOCUMENT_SOURCE,
+      system: DOCUMENT_SYSTEM.ALCS,
+    };
+
+    return await this.service.create(fileNumber, req.user.entity as User, req.body.file, dto);
+  }
+
+  @Patch('/:uuid')
+  @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
+  async update(
+    @Param('uuid') uuid: string,
+    @Body() updateDto: UpdateComplianceAndEnforcementDocumentDto,
+  ): Promise<ComplianceAndEnforcementDocumentDto> {
+    return await this.service.update(uuid, updateDto);
+  }
+
+  @Delete('/:uuid')
+  @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
+  async delete(@Param('uuid') uuid: string): Promise<DeleteResult> {
+    return await this.service.delete(uuid);
+  }
+
+  @Get('/types')
+  @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
+  async getDocumentTypes(@Query('allowedCodes') allowedCodes?: string[]): Promise<DocumentTypeDto[]> {
+    if (allowedCodes && !Array.isArray(allowedCodes)) {
+      allowedCodes = [allowedCodes];
+    }
+
+    return await this.service.fetchTypes(allowedCodes);
+  }
+}

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.dto.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.dto.ts
@@ -1,0 +1,54 @@
+import { AutoMap } from 'automapper-classes';
+import { IsString } from 'class-validator';
+import { ComplianceAndEnforcementDto } from '../compliance-and-enforcement.dto';
+import { DOCUMENT_SOURCE, DOCUMENT_SYSTEM, DocumentTypeDto } from '../../../document/document.dto';
+import { DocumentDto } from '../../../document/document.dto';
+
+export class ComplianceAndEnforcementDocumentDto {
+  @AutoMap()
+  uuid: string;
+
+  @AutoMap()
+  type: DocumentTypeDto;
+
+  @AutoMap()
+  file: ComplianceAndEnforcementDto;
+
+  @AutoMap()
+  document: DocumentDto;
+
+  @AutoMap()
+  documentUuid: string;
+
+  @AutoMap()
+  source: DOCUMENT_SOURCE;
+
+  @AutoMap()
+  system: DOCUMENT_SYSTEM;
+
+  @AutoMap()
+  fileName: string;
+
+  @AutoMap()
+  mimeType: string;
+
+  @AutoMap()
+  uploadedAt: number;
+
+  @AutoMap()
+  fileSize?: number;
+}
+
+export class UpdateComplianceAndEnforcementDocumentDto {
+  @IsString()
+  @AutoMap()
+  typeCode?: string;
+
+  @IsString()
+  @AutoMap()
+  fileName?: string;
+
+  @IsString()
+  @AutoMap()
+  source?: DOCUMENT_SOURCE;
+}

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.entity.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.entity.ts
@@ -1,0 +1,31 @@
+import { AutoMap } from 'automapper-classes';
+import { BaseEntity, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { DocumentCode } from '../../../document/document-code.entity';
+import { Document } from '../../../document/document.entity';
+import { ComplianceAndEnforcement } from '../compliance-and-enforcement.entity';
+
+@Entity({
+  comment: "Links complaint/referral documents with the complaint/referral they're saved to and logs other attributes",
+})
+export class ComplianceAndEnforcementDocument extends BaseEntity {
+  constructor(data?: Partial<ComplianceAndEnforcementDocument>) {
+    super();
+    if (data) {
+      Object.assign(this, data);
+    }
+  }
+
+  @AutoMap()
+  @PrimaryGeneratedColumn('uuid')
+  uuid: string;
+
+  @ManyToOne(() => DocumentCode, { cascade: true })
+  type?: DocumentCode;
+
+  @ManyToOne(() => ComplianceAndEnforcement, { nullable: false })
+  file: ComplianceAndEnforcement;
+
+  @OneToOne(() => Document, { cascade: true })
+  @JoinColumn()
+  document: Document;
+}

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.entity.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.entity.ts
@@ -4,7 +4,7 @@ import { DocumentCode } from '../../../document/document-code.entity';
 import { Document } from '../../../document/document.entity';
 import { ComplianceAndEnforcement } from '../compliance-and-enforcement.entity';
 
-enum Section {
+export enum Section {
   SUBMISSION = 'Submission',
 }
 

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.entity.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.entity.ts
@@ -1,8 +1,12 @@
 import { AutoMap } from 'automapper-classes';
-import { BaseEntity, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { DocumentCode } from '../../../document/document-code.entity';
 import { Document } from '../../../document/document.entity';
 import { ComplianceAndEnforcement } from '../compliance-and-enforcement.entity';
+
+enum Section {
+  SUBMISSION = 'Submission',
+}
 
 @Entity({
   comment: "Links complaint/referral documents with the complaint/referral they're saved to and logs other attributes",
@@ -28,4 +32,8 @@ export class ComplianceAndEnforcementDocument extends BaseEntity {
   @OneToOne(() => Document, { cascade: true })
   @JoinColumn()
   document: Document;
+
+  @AutoMap()
+  @Column({ type: 'enum', enum: Section })
+  section: Section;
 }

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.service.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DeleteResult, In, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ComplianceAndEnforcementDocument } from './document.entity';
+import { ComplianceAndEnforcementDocument, Section } from './document.entity';
 import { ComplianceAndEnforcementDocumentDto, UpdateComplianceAndEnforcementDocumentDto } from './document.dto';
 import { InjectMapper } from 'automapper-nestjs';
 import { Mapper } from 'automapper-core';
@@ -29,13 +29,13 @@ export class ComplianceAndEnforcementDocumentService {
     @InjectMapper() private mapper: Mapper,
   ) {}
 
-  async list(fileNumber?: string, types: string[] = []): Promise<ComplianceAndEnforcementDocumentDto[]> {
+  async list(fileNumber?: string, section?: Section): Promise<ComplianceAndEnforcementDocumentDto[]> {
     const entities = await this.repository.find({
       where: {
         file: {
           fileNumber: fileNumber,
         },
-        type: types.length > 0 ? In(types) : undefined,
+        section,
       },
       relations: ['type', 'document'],
       order: {
@@ -84,6 +84,7 @@ export class ComplianceAndEnforcementDocumentService {
       file,
       document,
       type,
+      section: createDto.section,
     });
 
     const savedEntity = await this.repository.save(entity);

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.service.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/document/document.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { DeleteResult, In, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ComplianceAndEnforcementDocument } from './document.entity';
+import { ComplianceAndEnforcementDocumentDto, UpdateComplianceAndEnforcementDocumentDto } from './document.dto';
+import { InjectMapper } from 'automapper-nestjs';
+import { Mapper } from 'automapper-core';
+import {
+  ServiceConflictException,
+  ServiceNotFoundException,
+} from '../../../../../../libs/common/src/exceptions/base.exception';
+import { DocumentService } from '../../../document/document.service';
+import { User } from '../../../user/user.entity';
+import { DocumentCode } from '../../../document/document-code.entity';
+import { CreateDocumentDto } from '../../../document/document.dto';
+import { MultipartFile } from '@fastify/multipart';
+import { ComplianceAndEnforcement } from '../compliance-and-enforcement.entity';
+
+@Injectable()
+export class ComplianceAndEnforcementDocumentService {
+  constructor(
+    private documentService: DocumentService,
+    @InjectRepository(ComplianceAndEnforcementDocument)
+    private repository: Repository<ComplianceAndEnforcementDocument>,
+    @InjectRepository(ComplianceAndEnforcement)
+    private complianceAndEnforcementRepository: Repository<ComplianceAndEnforcement>,
+    @InjectRepository(DocumentCode)
+    private documentCodeRepository: Repository<DocumentCode>,
+    @InjectMapper() private mapper: Mapper,
+  ) {}
+
+  async list(fileNumber?: string, types: string[] = []): Promise<ComplianceAndEnforcementDocumentDto[]> {
+    const entities = await this.repository.find({
+      where: {
+        file: {
+          fileNumber: fileNumber,
+        },
+        type: types.length > 0 ? In(types) : undefined,
+      },
+      relations: ['type', 'document'],
+      order: {
+        document: {
+          uploadedAt: 'DESC',
+        },
+      },
+    });
+
+    if (entities === null) {
+      throw new ServiceNotFoundException('A C&E file with this file number does not exist.');
+    }
+
+    return this.mapper.mapArray(entities, ComplianceAndEnforcementDocument, ComplianceAndEnforcementDocumentDto);
+  }
+
+  async create(
+    fileNumber: string,
+    user: User,
+    uploadData: MultipartFile,
+    createDto: CreateDocumentDto,
+  ): Promise<ComplianceAndEnforcementDocumentDto> {
+    const document = await this.documentService.create(
+      `compliance-and-enforcement/${fileNumber}`,
+      createDto.fileName,
+      uploadData,
+      user,
+      createDto.source,
+      createDto.system,
+      ['86000-20'],
+    );
+
+    const file = await this.complianceAndEnforcementRepository.findOneBy({ fileNumber });
+
+    if (!file) {
+      throw new ServiceNotFoundException('Compliance and Enforcement file not found.');
+    }
+
+    const type = await this.documentCodeRepository.findOneBy({ code: createDto.typeCode });
+
+    if (!type) {
+      throw new ServiceNotFoundException(`Document type with code ${createDto.typeCode} not found.`);
+    }
+
+    const entity = new ComplianceAndEnforcementDocument({
+      file,
+      document,
+      type,
+    });
+
+    const savedEntity = await this.repository.save(entity);
+
+    return this.mapper.map(savedEntity, ComplianceAndEnforcementDocument, ComplianceAndEnforcementDocumentDto);
+  }
+
+  async update(
+    uuid: string,
+    updateDto: UpdateComplianceAndEnforcementDocumentDto,
+  ): Promise<ComplianceAndEnforcementDocumentDto> {
+    const entity = await this.repository.findOne({ where: { uuid }, relations: ['document', 'file', 'type'] });
+    if (entity === null) {
+      throw new ServiceConflictException('A C&E file with this UUID does not exist. Unable to update.');
+    }
+
+    if (updateDto.fileName) {
+      entity.document.fileName = updateDto.fileName;
+    }
+    if (updateDto.source) {
+      entity.document.source = updateDto.source;
+    }
+
+    if (updateDto.typeCode) {
+      const type = await this.documentCodeRepository.findOneBy({ code: updateDto.typeCode });
+      if (!type) {
+        throw new ServiceNotFoundException(`Document type with code ${updateDto.typeCode} not found.`);
+      }
+
+      entity.type = type;
+    }
+
+    const savedEntity = await this.repository.save(entity);
+
+    return this.mapper.map(savedEntity, ComplianceAndEnforcementDocument, ComplianceAndEnforcementDocumentDto);
+  }
+
+  async delete(uuid: string): Promise<DeleteResult> {
+    const entity = await this.repository.findOneBy({ uuid });
+    if (entity === null) {
+      throw new ServiceNotFoundException('A C&E file with this UUID does not exist. Unable to delete.');
+    }
+
+    return await this.repository.delete(uuid);
+  }
+
+  async fetchTypes(allowedCodes: string[] = []): Promise<DocumentCode[]> {
+    return await this.documentCodeRepository.find({
+      where: {
+        code: allowedCodes.length > 0 ? In(allowedCodes) : undefined,
+      },
+    });
+  }
+}

--- a/services/apps/alcs/src/document/document-code.entity.ts
+++ b/services/apps/alcs/src/document/document-code.entity.ts
@@ -6,6 +6,7 @@ export enum DOCUMENT_TYPE {
   //ALCS
   DECISION_DOCUMENT = 'DPAC',
   OTHER = 'OTHR',
+  REFERRAL = 'REFR',
 
   //Government Review
   RESOLUTION_DOCUMENT = 'RESO',

--- a/services/apps/alcs/src/document/document.automapper.profile.ts
+++ b/services/apps/alcs/src/document/document.automapper.profile.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { createMap, Mapper } from 'automapper-core';
+import { AutomapperProfile, InjectMapper } from 'automapper-nestjs';
+import { Document } from './document.entity';
+import { DocumentDto } from './document.dto';
+
+@Injectable()
+export class DocumentProfile extends AutomapperProfile {
+  constructor(@InjectMapper() mapper: Mapper) {
+    super(mapper);
+  }
+
+  override get profile() {
+    return (mapper) => {
+      createMap(mapper, Document, DocumentDto);
+    };
+  }
+}

--- a/services/apps/alcs/src/document/document.dto.ts
+++ b/services/apps/alcs/src/document/document.dto.ts
@@ -2,6 +2,7 @@ import { AutoMap } from 'automapper-classes';
 import { BaseCodeDto } from '../common/dtos/base.dto';
 import { User } from '../user/user.entity';
 import { UserDto } from '../user/user.dto';
+import { Section } from '../alcs/compliance-and-enforcement/document/document.entity';
 
 export enum DOCUMENT_SOURCE {
   // All types
@@ -83,4 +84,5 @@ export class CreateDocumentDto {
   source: DOCUMENT_SOURCE;
   system: DOCUMENT_SYSTEM;
   tags?: string[];
+  section?: Section;
 }

--- a/services/apps/alcs/src/document/document.dto.ts
+++ b/services/apps/alcs/src/document/document.dto.ts
@@ -1,6 +1,7 @@
 import { AutoMap } from 'automapper-classes';
 import { BaseCodeDto } from '../common/dtos/base.dto';
 import { User } from '../user/user.entity';
+import { UserDto } from '../user/user.dto';
 
 export enum DOCUMENT_SOURCE {
   // All types
@@ -26,18 +27,60 @@ export enum DOCUMENT_SYSTEM {
   PORTAL = 'Portal',
 }
 
+export class DocumentTypeDto extends BaseCodeDto {
+  @AutoMap()
+  oatsCode: string;
+}
+
+export class DocumentDto {
+  @AutoMap()
+  uuid: string;
+
+  @AutoMap()
+  documentUuid: string;
+
+  @AutoMap()
+  type?: DocumentTypeDto;
+
+  @AutoMap()
+  description?: string;
+
+  @AutoMap()
+  visibilityFlags?: string[];
+
+  @AutoMap()
+  source: DOCUMENT_SOURCE;
+
+  @AutoMap()
+  system: DOCUMENT_SYSTEM;
+
+  @AutoMap()
+  fileName: string;
+
+  @AutoMap()
+  mimeType: string;
+
+  @AutoMap()
+  uploadedBy: UserDto;
+
+  @AutoMap()
+  uploadedAt: number;
+
+  @AutoMap()
+  evidentiaryRecordSorting?: number;
+
+  @AutoMap()
+  fileSize?: number;
+}
+
 export class CreateDocumentDto {
+  typeCode?: string;
   mimeType: string;
   fileKey: string;
   fileName: string;
-  fileSize: number;
+  fileSize?: number;
   uploadedBy?: User | null;
   source: DOCUMENT_SOURCE;
   system: DOCUMENT_SYSTEM;
   tags?: string[];
-}
-
-export class DocumentTypeDto extends BaseCodeDto {
-  @AutoMap()
-  oatsCode: string;
 }

--- a/services/apps/alcs/src/document/document.module.ts
+++ b/services/apps/alcs/src/document/document.module.ts
@@ -4,13 +4,11 @@ import { ClamAntivirusModule } from '../clamav/clam-antivirus.module';
 import { DocumentCode } from './document-code.entity';
 import { Document } from './document.entity';
 import { DocumentService } from './document.service';
+import { DocumentProfile } from './document.automapper.profile';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Document, DocumentCode]),
-    ClamAntivirusModule,
-  ],
-  providers: [DocumentService],
+  imports: [TypeOrmModule.forFeature([Document, DocumentCode]), ClamAntivirusModule],
+  providers: [DocumentService, DocumentProfile],
   exports: [DocumentService],
 })
 export class DocumentModule {}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1752168876435-add_complaint_doc_type.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1752168876435-add_complaint_doc_type.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddComplaintDocType1752168876435 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO alcs.document_code (audit_created_by, label, code, description, oats_code)
+      VALUES ('migration_seed', 'Complaint', 'CMPL', 'Complaint or referral submission document', 'CMPL')
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1752183361775-add_c_and_e_docs_table.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1752183361775-add_c_and_e_docs_table.ts
@@ -1,0 +1,108 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCAndEDocsTable1752183361775 implements MigrationInterface {
+  name = 'AddCAndEDocsTable1752183361775';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+      CREATE TABLE
+        "alcs"."compliance_and_enforcement_document" (
+            "uuid" uuid NOT NULL DEFAULT gen_random_uuid(),
+            "type_code" text,
+            "file_uuid" uuid NOT NULL,
+            "document_uuid" uuid,
+            CONSTRAINT "REL_8f67dae9787b42bef912292716" UNIQUE ("document_uuid"),
+            CONSTRAINT "PK_74f7873502cb0bce8ceeb8cd23a" PRIMARY KEY ("uuid")
+        )
+      `,
+    );
+    await queryRunner.query(
+      `
+      COMMENT ON TABLE
+        "alcs"."compliance_and_enforcement_document"
+      IS
+        'Links complaint/referral documents with the complaint/referral they''re saved to and logs other attributes'
+      `,
+    );
+    await queryRunner.query(
+      `
+      ALTER TABLE
+        "alcs"."compliance_and_enforcement_document"
+      ADD CONSTRAINT
+        "FK_da7a7aac5231d436c65d48f206c"
+      FOREIGN KEY
+        ("type_code")
+      REFERENCES
+        "alcs"."document_code"("code")
+      ON DELETE NO ACTION ON UPDATE NO ACTION
+      `,
+    );
+    await queryRunner.query(
+      `
+      ALTER TABLE
+        "alcs"."compliance_and_enforcement_document"
+      ADD CONSTRAINT
+        "FK_742e4bd7ac2910362a1e9e57db7"
+      FOREIGN KEY
+        ("file_uuid")
+      REFERENCES
+        "alcs"."compliance_and_enforcement"("uuid")
+      ON DELETE NO ACTION ON UPDATE NO ACTION
+      `,
+    );
+    await queryRunner.query(
+      `
+      ALTER TABLE
+        "alcs"."compliance_and_enforcement_document"
+      ADD CONSTRAINT
+        "FK_8f67dae9787b42bef9122927167"
+      FOREIGN KEY
+        ("document_uuid")
+      REFERENCES
+        "alcs"."document"("uuid")
+      ON DELETE NO ACTION ON UPDATE NO ACTION
+      `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+      ALTER TABLE
+        "alcs"."compliance_and_enforcement_document"
+      DROP CONSTRAINT
+        "FK_8f67dae9787b42bef9122927167"
+      `,
+    );
+    await queryRunner.query(
+      `
+      ALTER TABLE
+        "alcs"."compliance_and_enforcement_document"
+      DROP CONSTRAINT
+        "FK_742e4bd7ac2910362a1e9e57db7"
+      `,
+    );
+    await queryRunner.query(
+      `
+      ALTER TABLE
+        "alcs"."compliance_and_enforcement_document"
+      DROP CONSTRAINT
+        "FK_da7a7aac5231d436c65d48f206c"
+      `,
+    );
+    await queryRunner.query(
+      `
+      COMMENT ON TABLE
+        "alcs"."compliance_and_enforcement_document"
+      IS NULL
+      `,
+    );
+    await queryRunner.query(
+      `
+      DROP TABLE
+        "alcs"."compliance_and_enforcement_document"
+      `,
+    );
+  }
+}

--- a/services/apps/alcs/src/providers/typeorm/migrations/1753386233493-add_section_column_to_c_and_e_docs.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1753386233493-add_section_column_to_c_and_e_docs.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSectionColumnToCAndEDocs1753386233493 implements MigrationInterface {
+  name = 'AddSectionColumnToCAndEDocs1753386233493';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "alcs"."compliance_and_enforcement_document_section_enum" AS ENUM('Submission')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alcs"."compliance_and_enforcement_document" ADD "section" "alcs"."compliance_and_enforcement_document_section_enum" NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alcs"."compliance_and_enforcement_document" DROP COLUMN "section"`);
+    await queryRunner.query(`DROP TYPE "alcs"."compliance_and_enforcement_document_section_enum"`);
+  }
+}


### PR DESCRIPTION
- Backend
  - Create C&E docs table/entity (to be reused for other C&E docs)
  - Add DTO's, controller, service
- Frontend
  - Add DTO's, service for new C&E docs
  - Create new general-purpose C&E documents table (to be used for other documents sections)
  - Update document upload component to accommodate new table component
  - Add documents table to C&E draft