### PR TITLE
Add case for to handle access to non-government BCeID's apps

### DIFF
--- a/services/apps/alcs/src/portal/application-submission-review/application-submission-review.controller.ts
+++ b/services/apps/alcs/src/portal/application-submission-review/application-submission-review.controller.ts
@@ -100,11 +100,7 @@ export class ApplicationSubmissionReviewController {
       ? await this.applicationSubmissionService.getForNonGovernmentBusinessByFileId(fileNumber, req.user.entity)
       : await this.applicationSubmissionService.getByFileNumber(fileNumber, req.user.entity);
 
-    const applicationSubmission =
-      await this.applicationSubmissionService.getByFileNumber(
-        fileNumber,
-        req.user.entity,
-      );
+    const applicationReview = await this.applicationSubmissionReviewService.getByFileNumber(fileNumber);
 
     if (!applicationSubmission) {
       throw new NotFoundException(

--- a/services/apps/alcs/src/portal/application-submission-review/application-submission-review.controller.ts
+++ b/services/apps/alcs/src/portal/application-submission-review/application-submission-review.controller.ts
@@ -96,8 +96,9 @@ export class ApplicationSubmissionReviewController {
       );
     }
 
-    const applicationReview =
-      await this.applicationSubmissionReviewService.getByFileNumber(fileNumber);
+    const applicationSubmission = req.user.entity.bceidBusinessGuid
+      ? await this.applicationSubmissionService.getForNonGovernmentBusinessByFileId(fileNumber, req.user.entity)
+      : await this.applicationSubmissionService.getByFileNumber(fileNumber, req.user.entity);
 
     const applicationSubmission =
       await this.applicationSubmissionService.getByFileNumber(

--- a/services/apps/alcs/src/portal/application-submission/application-submission.service.ts
+++ b/services/apps/alcs/src/portal/application-submission/application-submission.service.ts
@@ -425,6 +425,41 @@ export class ApplicationSubmissionService {
     return existingApplication;
   }
 
+  async getForNonGovernmentBusinessByFileId(fileNumber: string, user: User) {
+    if (!user.bceidBusinessGuid) {
+      throw new Error('Must be business BCeID');
+    }
+
+    const existingApplication = await this.applicationSubmissionRepository.findOne({
+      where: [
+        //Owns
+        {
+          fileNumber,
+          createdBy: {
+            bceidBusinessGuid: user.bceidBusinessGuid,
+          },
+          isDraft: false,
+        },
+      ],
+      order: {
+        auditUpdatedAt: 'DESC',
+        owners: {
+          firstName: 'ASC',
+          parcels: {
+            purchasedDate: 'ASC',
+          },
+        },
+      },
+      relations: { ...this.DEFAULT_RELATIONS, createdBy: true },
+    });
+
+    if (!existingApplication) {
+      throw new ServiceNotFoundException(`Failed to load application with File ID ${fileNumber}`);
+    }
+
+    return existingApplication;
+  }
+
   async getByFileNumber(fileNumber: string, user: User) {
     return await this.applicationSubmissionRepository.findOne({
       where: {
@@ -482,6 +517,8 @@ export class ApplicationSubmissionService {
       const localGovernment = await this.localGovernmentService.getByGuid(user.bceidBusinessGuid);
       if (localGovernment) {
         return await this.getForGovernmentByFileId(fileId, localGovernment);
+      } else {
+        return await this.getForNonGovernmentBusinessByFileId(fileId, user);
       }
     }
 

--- a/services/apps/alcs/src/portal/application-submission/application-submission.service.ts
+++ b/services/apps/alcs/src/portal/application-submission/application-submission.service.ts
@@ -427,7 +427,7 @@ export class ApplicationSubmissionService {
 
   async getForNonGovernmentBusinessByFileId(fileNumber: string, user: User) {
     if (!user.bceidBusinessGuid) {
-      throw new Error('Must be business BCeID');
+      throw new Error('Must have business BCeID GUID to access this submission');
     }
 
     const existingApplication = await this.applicationSubmissionRepository.findOne({


### PR DESCRIPTION
- Was only checking for gov business BCeID's and then defaulting to single user account
- I added a case to handle non-gov business BCeID's
- It checks if there is a gov:
  - If there is, handle as it does now
  - If not, use the user's business BCeID in query for submission
- Fixing the submission revealed that the same problem applied to L/FNG reviews
  - Was able to reuse same function to fix review