### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/alcs-frontend/Dockerfile
+++ b/alcs-frontend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Copy the source code to the /app directory
 COPY . .

--- a/portal-frontend/Dockerfile
+++ b/portal-frontend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Copy the source code to the /app directory
 COPY . .

--- a/services/Dockerfile
+++ b/services/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /opt/app-root/
 
 COPY --chown=node:node package*.json ./
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY --chown=node:node . .
 
@@ -32,7 +32,7 @@ COPY --chown=node:node . .
 
 RUN npm run build ${NEST_APP}
 
-RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --ignore-scripts --only=production && npm cache clean --force
 
 USER node
 

--- a/services/Dockerfile.local
+++ b/services/Dockerfile.local
@@ -5,7 +5,7 @@ RUN chown node:node /opt/app-root/
 
 COPY --chown=node:node package*.json ./
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 COPY --chown=node:node . .
 

--- a/services/Dockerfile.migrate
+++ b/services/Dockerfile.migrate
@@ -13,7 +13,7 @@ RUN npm config set cache $/opt/app-root/.npm
 
 COPY package*.json ./
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 ARG environment=production
 


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv