### PR TITLE
2516: ETL base C&E file QA 1

### DIFF
--- a/bin/migrate-nris-data/ce_files/sql/et.sql
+++ b/bin/migrate-nris-data/ce_files/sql/et.sql
@@ -33,7 +33,7 @@ select distinct
                     regexp_split_to_table(nc.activity, '\s*,\s*') as nc (activity)
             ) activities
     )::alcs._compliance_and_enforcement_alleged_activity_enum as alleged_activity,
-    coalesce(nc.internal_notes || '; ' || nc.description_and_comments, '') as intake_notes,
+    coalesce(concat_ws('; ', nc.internal_notes, nc.description_and_comments), '') as intake_notes,
     au.uuid as assignee_uuid
 from
     nris.complaint nc


### PR DESCRIPTION
- Wasn't getting value from `internal_notes` or `description_and_comments`
if either was `null`.