### PR TITLE
2522: Add chronology ETL and obfuscation

### DIFF
--- a/bin/migrate-nris-data/ce_files/sql/obfuscate_get_rows.sql
+++ b/bin/migrate-nris-data/ce_files/sql/obfuscate_get_rows.sql
@@ -1,4 +1,5 @@
 select
-    ace.uuid
+    ace.uuid,
+    ace.intake_notes
 from
     alcs.compliance_and_enforcement ace;

--- a/bin/migrate-nris-data/chronology/__init__.py
+++ b/bin/migrate-nris-data/chronology/__init__.py
@@ -1,0 +1,1 @@
+from .chronology import *

--- a/bin/migrate-nris-data/chronology/chronology.py
+++ b/bin/migrate-nris-data/chronology/chronology.py
@@ -1,24 +1,34 @@
 from pathlib import Path
 
 from common.etl_logger import setup_and_get_logger
-from db import batch_read_write
+import config
+from db import batch_read_write, run_script
 from faker import Faker
 
 REL_PATH = Path(__file__).parent
 
 
 def etl(batch_size):
-    logger = setup_and_get_logger("ce-file-etl")
+    logger = setup_and_get_logger("chronology-etl")
 
-    logger.info("Inserting C&E files...")
+    logger.info("Create chronology author...")
+    run_script(
+        logger,
+        REL_PATH / "sql/create_author.sql",
+        values=(config.AUTHOR_UUID,),
+    )
+    logger.info("Chronology author created.")
+
+    logger.info("Inserting chronology entries...")
     batch_read_write(
         logger,
         batch_size,
         REL_PATH / "sql/count.sql",
         REL_PATH / "sql/et.sql",
         REL_PATH / "sql/l.sql",
+        row_processor=set_author_uuid,
     )
-    logger.info("C&E file insert complete.")
+    logger.info("Chronology entry insert complete.")
 
     logger.info("Closing C&E files...")
     batch_read_write(
@@ -31,8 +41,15 @@ def etl(batch_size):
     logger.info("C&E file closure complete.")
 
 
+def set_author_uuid(row):
+    if row["author_uuid"] is None:
+        row["author_uuid"] = config.AUTHOR_UUID
+
+    return row
+
+
 def obfuscate(batch_size):
-    logger = setup_and_get_logger("ce-file-obfuscation")
+    logger = setup_and_get_logger("chronology-obfuscation")
 
     batch_read_write(
         logger,
@@ -48,8 +65,8 @@ def row_obfuscator():
     faker = Faker("la")
 
     def obfuscate_row(row):
-        if row["intake_notes"] != "":
-            row["intake_notes"] = "\n\n".join(faker.paragraphs())
+        if row["description"] is not None:
+            row["description"] = "\n\n".join(faker.paragraphs())
 
         return row
 

--- a/bin/migrate-nris-data/chronology/sql/close_count.sql
+++ b/bin/migrate-nris-data/chronology/sql/close_count.sql
@@ -1,0 +1,6 @@
+select
+    count(*)
+from
+    alcs.compliance_and_enforcement ace
+where
+    ace.date_closed is not null;

--- a/bin/migrate-nris-data/chronology/sql/close_et.sql
+++ b/bin/migrate-nris-data/chronology/sql/close_et.sql
@@ -1,0 +1,7 @@
+select
+    ace.uuid,
+    ace.date_closed as chronology_closed_at
+from
+    alcs.compliance_and_enforcement ace
+where
+    ace.date_closed is not null;

--- a/bin/migrate-nris-data/chronology/sql/close_l.sql
+++ b/bin/migrate-nris-data/chronology/sql/close_l.sql
@@ -1,8 +1,8 @@
 update
     alcs.compliance_and_enforcement as ace
 set 
-    intake_notes = v.intake_notes
+    chronology_closed_at = v.chronology_closed_at
 from
-    (values %s) as v(uuid, intake_notes)
+    (values %s) as v(uuid, chronology_closed_at)
 where
     ace.uuid::text = v.uuid::text;

--- a/bin/migrate-nris-data/chronology/sql/count.sql
+++ b/bin/migrate-nris-data/chronology/sql/count.sql
@@ -1,0 +1,5 @@
+select
+    count(*)
+from
+    nris.inspection ni
+    join alcs.compliance_and_enforcement ace on ace.file_number::text = ni.related_records::text;

--- a/bin/migrate-nris-data/chronology/sql/create_author.sql
+++ b/bin/migrate-nris-data/chronology/sql/create_author.sql
@@ -1,0 +1,15 @@
+insert into
+    alcs.user (
+        uuid,
+        audit_created_by,
+        display_name,
+        identity_provider,
+        preferred_username
+    )
+values (
+    %s,
+    'nris_etl',
+    'NRIS ETL',
+    'idir',
+    'nris_etl'
+);

--- a/bin/migrate-nris-data/chronology/sql/create_author.sql
+++ b/bin/migrate-nris-data/chronology/sql/create_author.sql
@@ -4,12 +4,16 @@ insert into
         audit_created_by,
         display_name,
         identity_provider,
-        preferred_username
+        preferred_username,
+        name,
+        client_roles
     )
 values (
     %s,
     'nris_etl',
     'NRIS ETL',
     'idir',
-    'nris_etl'
+    'nris_etl',
+    'NRIS ETL',
+    '{C&E}'
 );

--- a/bin/migrate-nris-data/chronology/sql/et.sql
+++ b/bin/migrate-nris-data/chronology/sql/et.sql
@@ -1,0 +1,11 @@
+select distinct
+    'nris_etl' as audit_created_by,
+    ni.date::timestamptz as date,
+    au.uuid as author_uuid,
+    ''''||ni.reason||''' inspection (NRIS '||ni.record_id||'), please consult LAN folder for record' as description,
+    ace.uuid as file_uuid,
+    ni.record_id as nris_inspection_id
+from
+    nris.inspection ni
+    join alcs.compliance_and_enforcement ace on ace.file_number::text = ni.related_records::text
+    left join alcs.user au on lower(au.idir_user_name) = lower(split_part(ni.c_e_officer, '/', 2));

--- a/bin/migrate-nris-data/chronology/sql/l.sql
+++ b/bin/migrate-nris-data/chronology/sql/l.sql
@@ -1,0 +1,10 @@
+insert into
+    alcs.compliance_and_enforcement_chronology_entry (
+        audit_created_by,
+        date,
+        author_uuid,
+        description,
+        file_uuid,
+        nris_inspection_id
+    )
+values %s;

--- a/bin/migrate-nris-data/chronology/sql/obfuscate_count.sql
+++ b/bin/migrate-nris-data/chronology/sql/obfuscate_count.sql
@@ -1,0 +1,4 @@
+select
+    count(*)
+from
+    alcs.compliance_and_enforcement_chronology_entry acece;

--- a/bin/migrate-nris-data/chronology/sql/obfuscate_get_rows.sql
+++ b/bin/migrate-nris-data/chronology/sql/obfuscate_get_rows.sql
@@ -1,0 +1,5 @@
+select
+    acece.uuid,
+    acece.description
+from
+    alcs.compliance_and_enforcement_chronology_entry acece;

--- a/bin/migrate-nris-data/chronology/sql/obfuscate_update.sql
+++ b/bin/migrate-nris-data/chronology/sql/obfuscate_update.sql
@@ -1,0 +1,8 @@
+update
+    alcs.compliance_and_enforcement_chronology_entry as acece
+set 
+    description = v.description
+from
+    (values %s) as v(uuid, description)
+where
+    acece.uuid::text = v.uuid::text;

--- a/bin/migrate-nris-data/complaint/complaint.py
+++ b/bin/migrate-nris-data/complaint/complaint.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 from common.etl_logger import setup_and_get_logger
-from config import ABS_PATH
 import db
+
+REL_PATH = Path(__file__).parent
 
 
 def create_table():
@@ -10,7 +13,7 @@ def create_table():
 
     db.run_script(
         logger,
-        ABS_PATH / "complaint/sql/create_table.sql",
+        REL_PATH / "sql/create_table.sql",
     )
 
     logger.info("Complaint table created.")

--- a/bin/migrate-nris-data/config.py
+++ b/bin/migrate-nris-data/config.py
@@ -1,3 +1,4 @@
 from pathlib import Path
 
-ABS_PATH = Path(__file__).parent.resolve()
+ABS_PATH = Path(__file__).parent
+AUTHOR_UUID = "4ddb545a-bb6a-4249-992e-7f3666da966a"

--- a/bin/migrate-nris-data/db.py
+++ b/bin/migrate-nris-data/db.py
@@ -37,13 +37,14 @@ def run_script(
     conn,
     logger,
     sql_file,
+    values=None,
 ):
     sql = load_sql(sql_file)
 
     with conn:
         with conn.cursor() as cursor:
             try:
-                cursor.execute(sql)
+                cursor.execute(sql, values)
 
             except Exception as err:
                 logger.exception(err)

--- a/bin/migrate-nris-data/inspection/inspection.py
+++ b/bin/migrate-nris-data/inspection/inspection.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 from common.etl_logger import setup_and_get_logger
-from config import ABS_PATH
 import db
+
+REL_PATH = Path(__file__).parent
 
 
 def create_table():
@@ -10,7 +13,7 @@ def create_table():
 
     db.run_script(
         logger,
-        ABS_PATH / "inspection/sql/create_table.sql",
+        REL_PATH / "sql/create_table.sql",
     )
 
     logger.info("Inspection table created.")
@@ -29,7 +32,7 @@ def reduce_related_records():
 
     db.run_script(
         logger,
-        ABS_PATH / "inspection/sql/reduce_related_records.sql",
+        REL_PATH / "sql/reduce_related_records.sql",
     )
 
     logger.info("Related records reduced.")
@@ -42,7 +45,7 @@ def relate_inspections_to_complaints():
 
     db.run_script(
         logger,
-        ABS_PATH / "inspection/sql/relate_inspections_to_complaints.sql",
+        REL_PATH / "sql/relate_inspections_to_complaints.sql",
     )
 
     logger.info("Inspections related to complaints.")

--- a/bin/migrate-nris-data/migrate.py
+++ b/bin/migrate-nris-data/migrate.py
@@ -3,6 +3,7 @@ from rich.console import Console
 
 from common.constants import BATCH_UPLOAD_SIZE
 import ce_files
+import chronology
 import complaint
 import inspection
 import properties
@@ -63,6 +64,7 @@ def etl(ctx, batch_size):
         ctx.invoke(etl_submitters)
         ctx.invoke(etl_responsible_parties)
         ctx.invoke(etl_properties)
+        ctx.invoke(etl_chronology)
 
 
 @etl.command("ce-files")
@@ -97,6 +99,14 @@ def etl_properties(ctx):
     console.log("Property ETL complete.")
 
 
+@etl.command("chronology")
+@click.pass_context
+def etl_chronology(ctx):
+    console.log("Start chronology ETL...")
+    chronology.etl(batch_size=ctx.parent.params["batch_size"])
+    console.log("Chronology ETL complete.")
+
+
 @etl.result_callback()
 def etl_cleanup(results, batch_size):
     console.log("ETL complete. Cleaning up...")
@@ -125,6 +135,7 @@ def obfuscate(ctx, batch_size):
         ctx.invoke(obfuscate_submitters)
         ctx.invoke(obfuscate_responsible_parties)
         ctx.invoke(obfuscate_properties)
+        ctx.invoke(obfuscate_chronology)
 
 
 @obfuscate.command("ce-files")
@@ -157,6 +168,14 @@ def obfuscate_properties(ctx):
     console.log("Start obfuscating properties...")
     properties.obfuscate(batch_size=ctx.parent.params["batch_size"])
     console.log("Property obfuscation complete.")
+
+
+@obfuscate.command("chronology")
+@click.pass_context
+def obfuscate_chronology(ctx):
+    console.log("Start obfuscating chronology...")
+    chronology.obfuscate(batch_size=ctx.parent.params["batch_size"])
+    console.log("Chronology obfuscation complete.")
 
 
 @obfuscate.result_callback()

--- a/bin/migrate-nris-data/properties/properties.py
+++ b/bin/migrate-nris-data/properties/properties.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 from common.etl_logger import setup_and_get_logger
-from config import ABS_PATH
 from db import batch_read_write
 from faker import Faker
+
+REL_PATH = Path(__file__).parent
 
 
 def etl(batch_size):
@@ -10,9 +13,9 @@ def etl(batch_size):
     batch_read_write(
         logger,
         batch_size,
-        ABS_PATH / "properties/sql/count.sql",
-        ABS_PATH / "properties/sql/et.sql",
-        ABS_PATH / "properties/sql/l.sql",
+        REL_PATH / "sql/count.sql",
+        REL_PATH / "sql/et.sql",
+        REL_PATH / "sql/l.sql",
     )
 
 
@@ -22,9 +25,9 @@ def obfuscate(batch_size):
     batch_read_write(
         logger,
         batch_size,  # Obfuscation can be done in smaller batches to reduce transaction size.
-        ABS_PATH / "properties/sql/obfuscate_count.sql",
-        ABS_PATH / "properties/sql/obfuscate_get_rows.sql",
-        ABS_PATH / "properties/sql/obfuscate_update.sql",
+        REL_PATH / "sql/obfuscate_count.sql",
+        REL_PATH / "sql/obfuscate_get_rows.sql",
+        REL_PATH / "sql/obfuscate_update.sql",
         row_processor=row_obfuscator(),
     )
 
@@ -33,7 +36,8 @@ def row_obfuscator():
     faker = Faker("la")
 
     def obfuscate_row(row):
-        row["alc_history"] = "\n\n".join(faker.paragraphs())
+        if row["alc_history"] != "":
+            row["alc_history"] = "\n\n".join(faker.paragraphs())
 
         return row
 

--- a/bin/migrate-nris-data/properties/sql/obfuscate_get_rows.sql
+++ b/bin/migrate-nris-data/properties/sql/obfuscate_get_rows.sql
@@ -1,4 +1,5 @@
 select
-    aces.uuid
+    aces.uuid,
+    aces.alc_history
 from
     alcs.compliance_and_enforcement_property aces;

--- a/bin/migrate-nris-data/properties/sql/obfuscate_update.sql
+++ b/bin/migrate-nris-data/properties/sql/obfuscate_update.sql
@@ -1,10 +1,7 @@
 update
     alcs.compliance_and_enforcement_property as acep
 set 
-    alc_history = case
-        when acep.alc_history <> '' then v.alc_history
-        else acep.alc_history
-    end
+    alc_history = v.alc_history
 from
     (values %s) as v(
         uuid,

--- a/bin/migrate-nris-data/responsible_parties/responsible_parties.py
+++ b/bin/migrate-nris-data/responsible_parties/responsible_parties.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 from common.etl_logger import setup_and_get_logger
-from config import ABS_PATH
 from db import batch_read_write
 from faker import Faker
+
+REL_PATH = Path(__file__).parent
 
 
 def etl(batch_size):
@@ -10,9 +13,9 @@ def etl(batch_size):
     batch_read_write(
         logger,
         batch_size,
-        ABS_PATH / "responsible_parties/sql/count.sql",
-        ABS_PATH / "responsible_parties/sql/et.sql",
-        ABS_PATH / "responsible_parties/sql/l.sql",
+        REL_PATH / "sql/count.sql",
+        REL_PATH / "sql/et.sql",
+        REL_PATH / "sql/l.sql",
     )
 
 
@@ -22,9 +25,9 @@ def obfuscate(batch_size):
     batch_read_write(
         logger,
         batch_size,
-        ABS_PATH / "responsible_parties/sql/obfuscate_count.sql",
-        ABS_PATH / "responsible_parties/sql/obfuscate_get_rows.sql",
-        ABS_PATH / "responsible_parties/sql/obfuscate_update.sql",
+        REL_PATH / "sql/obfuscate_count.sql",
+        REL_PATH / "sql/obfuscate_get_rows.sql",
+        REL_PATH / "sql/obfuscate_update.sql",
         row_processor=row_obfuscator(),
     )
 
@@ -33,7 +36,8 @@ def row_obfuscator():
     faker = Faker("la")
 
     def obfuscate_row(row):
-        row["individual_name"] = faker.name()
+        if row["individual_name"] is not None or row["individual_name"] != "":
+            row["individual_name"] = faker.name()
 
         return row
 

--- a/bin/migrate-nris-data/responsible_parties/sql/obfuscate_get_rows.sql
+++ b/bin/migrate-nris-data/responsible_parties/sql/obfuscate_get_rows.sql
@@ -1,4 +1,5 @@
 select
-    acerp.uuid
+    acerp.uuid,
+    acerp.individual_name
 from
     alcs.compliance_and_enforcement_responsible_party acerp;

--- a/bin/migrate-nris-data/responsible_parties/sql/obfuscate_update.sql
+++ b/bin/migrate-nris-data/responsible_parties/sql/obfuscate_update.sql
@@ -1,10 +1,7 @@
 update
     alcs.compliance_and_enforcement_responsible_party as acerp
 set 
-    individual_name = case
-        when acerp.individual_name is not null or acerp.individual_name <> '' then v.individual_name
-        else acerp.individual_name
-    end
+    individual_name = v.individual_name
 from
     (values %s) as v(
         uuid,

--- a/bin/migrate-nris-data/submitters/sql/obfuscate_get_rows.sql
+++ b/bin/migrate-nris-data/submitters/sql/obfuscate_get_rows.sql
@@ -1,4 +1,9 @@
 select
-    aces.uuid
+    aces.uuid,
+    aces.name,
+    aces.email,
+    aces.telephone_number,
+    aces.affiliation,
+    aces.additional_contact_information
 from
     alcs.compliance_and_enforcement_submitter aces;

--- a/bin/migrate-nris-data/submitters/sql/obfuscate_update.sql
+++ b/bin/migrate-nris-data/submitters/sql/obfuscate_update.sql
@@ -1,26 +1,11 @@
 update
     alcs.compliance_and_enforcement_submitter as aces
 set 
-    name = case
-        when aces.name <> '' then v.name
-        else aces.name
-    end,
-    email = case
-        when aces.email <> '' then v.email
-        else aces.email
-    end,
-    telephone_number = case
-        when aces.telephone_number <> '' then v.telephone_number
-        else aces.telephone_number
-    end,
-    affiliation = case
-        when aces.affiliation <> '' then v.affiliation
-        else aces.affiliation
-    end,
-    additional_contact_information = case
-        when aces.additional_contact_information <> '' then v.additional_contact_information
-        else aces.additional_contact_information
-    end
+    name = v.name,
+    email = v.email,
+    telephone_number = v.telephone_number,
+    affiliation = v.affiliation,
+    additional_contact_information = v.additional_contact_information
 from
     (values %s) as v(
         uuid,

--- a/bin/migrate-nris-data/submitters/submitters.py
+++ b/bin/migrate-nris-data/submitters/submitters.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 from common.etl_logger import setup_and_get_logger
-from config import ABS_PATH
 from db import batch_read_write
 from faker import Faker
+
+REL_PATH = Path(__file__).parent
 
 
 def etl(batch_size):
@@ -10,9 +13,9 @@ def etl(batch_size):
     batch_read_write(
         logger,
         batch_size,
-        ABS_PATH / "submitters/sql/count.sql",
-        ABS_PATH / "submitters/sql/et.sql",
-        ABS_PATH / "submitters/sql/l.sql",
+        REL_PATH / "sql/count.sql",
+        REL_PATH / "sql/et.sql",
+        REL_PATH / "sql/l.sql",
     )
 
 
@@ -22,9 +25,9 @@ def obfuscate(batch_size):
     batch_read_write(
         logger,
         batch_size,
-        ABS_PATH / "submitters/sql/obfuscate_count.sql",
-        ABS_PATH / "submitters/sql/obfuscate_get_rows.sql",
-        ABS_PATH / "submitters/sql/obfuscate_update.sql",
+        REL_PATH / "sql/obfuscate_count.sql",
+        REL_PATH / "sql/obfuscate_get_rows.sql",
+        REL_PATH / "sql/obfuscate_update.sql",
         row_processor=row_obfuscator(),
     )
 
@@ -33,11 +36,20 @@ def row_obfuscator():
     faker = Faker("la")
 
     def obfuscate_row(row):
-        row["name"] = faker.name()
-        row["email"] = faker.email()
-        row["telephone_number"] = faker.numerify("###-###-####")
-        row["affiliation"] = "\n\n".join(faker.paragraphs())
-        row["additional_contact_information"] = "\n\n".join(faker.paragraphs())
+        if row["name"] != "":
+            row["name"] = faker.name()
+
+        if row["email"] != "":
+            row["email"] = faker.email()
+
+        if row["telephone_number"] != "":
+            row["telephone_number"] = faker.numerify("###-###-####")
+
+        if row["affiliation"] != "":
+            row["affiliation"] = "\n\n".join(faker.paragraphs())
+
+        if row["additional_contact_information"] != "":
+            row["additional_contact_information"] = "\n\n".join(faker.paragraphs())
 
         return row
 


### PR DESCRIPTION
- Added chronology ETL/obfuscation
  - Chronology entry author is required, so I added a script to add a user to the user table
- Moved obfuscation conditionals from SQL to row processor function—this is more flexible and easier to understand
- Made paths to SQL relative to make modules more reusable
