### PR TITLE
2967: Make buttons type "button"

### DIFF
--- a/alcs-frontend/src/app/features/search/file-type-filter-drop-down/file-type-filter-drop-down.component.html
+++ b/alcs-frontend/src/app/features/search/file-type-filter-drop-down/file-type-filter-drop-down.component.html
@@ -8,7 +8,7 @@
     [matAutocomplete]="auto"
     onkeydown="return false;"
     [formControl]="componentTypeControl"
-    />
+  />
   @if (hasItemsSelected) {
     <button
       matSuffix
@@ -29,7 +29,7 @@
     <mat-option disabled>Please select an item from below</mat-option>
     <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
       <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
-        <button mat-icon-button disabled></button>
+        <button type="button" mat-icon-button disabled></button>
         <mat-checkbox
           class="checklist-leaf-node"
           [checked]="checklistSelection.isSelected(node)"
@@ -39,7 +39,7 @@
       </mat-tree-node>
 
       <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
-        <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.filename">
+        <button type="button" mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.filename">
           <mat-icon class="mat-icon-rtl-mirror">
             {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
           </mat-icon>
@@ -48,7 +48,7 @@
           [checked]="descendantsAllSelected(node)"
           [indeterminate]="descendantsPartiallySelected(node)"
           (change)="itemSelectionToggle(node)"
-          >
+        >
           {{ node.item?.label ?? node.item }}
         </mat-checkbox>
       </mat-tree-node>

--- a/portal-frontend/src/app/features/public/search/file-type-filter-drop-down/file-type-filter-drop-down.component.html
+++ b/portal-frontend/src/app/features/public/search/file-type-filter-drop-down/file-type-filter-drop-down.component.html
@@ -19,7 +19,7 @@
     <mat-option disabled>Please select an item from below</mat-option>
     <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
       <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
-        <button mat-icon-button disabled></button>
+        <button type="button" mat-icon-button disabled></button>
         <mat-checkbox
           class="checklist-leaf-node"
           [checked]="checklistSelection.isSelected(node)"
@@ -30,7 +30,7 @@
         </mat-tree-node>
 
         <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
-          <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.filename">
+          <button type="button" mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.filename">
             <mat-icon class="mat-icon-rtl-mirror">
               {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
             </mat-icon>


### PR DESCRIPTION
By default buttons are `type="submit"`. This will submit any enclosing form. This doesn't happen on a lot of buttons, because the `(click)` handler overrides its default behaviour.