### PR TITLE
2849: Add file path to C&E overview

### DIFF
--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/chronology.component.spec.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/chronology.component.spec.ts
@@ -66,6 +66,7 @@ describe('ComplianceAndEnforcementChronologyComponent', () => {
     chronologyClosedAt: 0,
     chronologyClosedBy: mockUser,
     assignee: mockUser,
+    filePath: '',
   };
   const mockUpdateChronologyEntryDto: UpdateComplianceAndEnforcementChronologyEntryDto = {
     isDraft: true,

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/entry/inspection/inspection.component.spec.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/entry/inspection/inspection.component.spec.ts
@@ -68,6 +68,7 @@ describe('ComplianceAndEnforcementChronologyComponent', () => {
     chronologyClosedAt: 0,
     chronologyClosedBy: mockUser,
     assignee: mockUser,
+    filePath: '',
   };
   const mockUpdateChronologyEntryDto: UpdateComplianceAndEnforcementChronologyEntryDto = {
     isDraft: true,

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/entry/notice/notice.component.spec.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/entry/notice/notice.component.spec.ts
@@ -71,6 +71,7 @@ describe('ComplianceAndEnforcementChronologyComponent', () => {
     chronologyClosedAt: 0,
     chronologyClosedBy: mockUser,
     assignee: mockUser,
+    filePath: '',
   };
   const mockUpdateChronologyEntryDto: UpdateComplianceAndEnforcementChronologyEntryDto = {
     isDraft: true,

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/entry/order/order.component.spec.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/chronology/entry/order/order.component.spec.ts
@@ -71,6 +71,7 @@ describe('ComplianceAndEnforcementChronologyComponent', () => {
     chronologyClosedAt: 0,
     chronologyClosedBy: mockUser,
     assignee: mockUser,
+    filePath: '',
   };
   const mockUpdateChronologyEntryDto: UpdateComplianceAndEnforcementChronologyEntryDto = {
     isDraft: true,

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.html
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.html
@@ -5,14 +5,14 @@
     @if (!isEditingStatus) {
       <div class="status-display">
         @if (!status.value) {
-          <a (click)="startEdit()" class="add">Set status</a>
+          <a (click)="startEditStatus()" class="add">Set status</a>
         }
         <span>
           {{ status.value }}
         </span>
         @if (userProfile()?.clientRoles?.includes(ROLES.C_AND_E) && status.value) {
-          <button class="edit-button" mat-icon-button (click)="startEdit()">
-            <mat-icon class="edit-icon">edit</mat-icon>
+          <button class="action-button" mat-icon-button (click)="startEditStatus()">
+            <mat-icon class="action-icon">edit</mat-icon>
           </button>
         }
       </div>
@@ -24,8 +24,49 @@
         <mat-button-toggle value="Closed">Closed</mat-button-toggle>
       </mat-button-toggle-group>
       <div class="button-container">
-        <button mat-button (click)="endEdit()">Cancel</button>
+        <button mat-button (click)="cancelEditStatus()">Cancel</button>
         <button mat-button class="save" (click)="saveStatus()">Save</button>
+      </div>
+    }
+  </div>
+</section>
+
+<section>
+  <h5>File Path</h5>
+
+  <div class="file-path-container">
+    @if (!isEditingFilePath) {
+      <div class="status-display">
+        <span>
+          {{ filePath.value }}
+        </span>
+
+        @if (filePath.value) {
+          @if (userProfile()?.clientRoles?.includes(ROLES.C_AND_E)) {
+            <button type="button" mat-icon-button class="action-button" (click)="startEditFilePath()">
+              <mat-icon class="action-icon">edit</mat-icon>
+            </button>
+          }
+
+          <button type="button" mat-icon-button class="action-button" (click)="copyFilePath()">
+            <mat-icon class="action-icon">copy</mat-icon>
+          </button>
+        } @else {
+          @if (userProfile()?.clientRoles?.includes(ROLES.C_AND_E)) {
+            <a (click)="startEditFilePath()">Add Path</a>
+          }
+        }
+      </div>
+    }
+
+    @if (isEditingFilePath) {
+      <mat-form-field appearance="outline">
+        <textarea matInput [formControl]="filePath" maxlength="4000" rows="4"></textarea>
+      </mat-form-field>
+
+      <div class="button-container">
+        <button mat-stroked-button (click)="cancelEditFilePath()">Cancel</button>
+        <button mat-stroked-button class="save" (click)="saveFilePath()">Save</button>
       </div>
     }
   </div>

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.scss
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.scss
@@ -16,23 +16,25 @@ section {
 
 .button-container {
   button:not(:last-child) {
-    margin-right: 2px !important;
+    margin-right: 12px !important;
   }
 
-  .save {
+  .save:not(:disabled) {
     color: colors.$primary-color;
   }
 }
 
-.edit-button {
+.action-button {
   height: 24px;
   width: 24px;
   padding: 0;
-  display: flex;
-  align-items: center;
+
+  ::ng-deep .mat-mdc-button-touch-target {
+    display: none !important;
+  }
 }
 
-.edit-icon {
+.action-icon {
   font-size: inherit;
   line-height: 22px;
 }
@@ -44,4 +46,10 @@ section {
 .status-display {
   display: flex;
   align-items: center;
+}
+
+.file-path-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.spec.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.spec.ts
@@ -1,7 +1,7 @@
-import { DetailsOverviewComponent } from './details-overview.component';
-import { ComplianceAndEnforcementService } from '../../../../services/compliance-and-enforcement/compliance-and-enforcement.service';
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { ComplianceAndEnforcementService } from '../../../../services/compliance-and-enforcement/compliance-and-enforcement.service';
+import { DetailsOverviewComponent } from './details-overview.component';
 
 describe('DetailsOverviewComponent', () => {
   let component: DetailsOverviewComponent;
@@ -30,16 +30,16 @@ describe('DetailsOverviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set isEditingStatus to true on startEdit', () => {
+  it('should set isEditingStatus to true on startEditStatus', () => {
     component.isEditingStatus = false;
-    component.startEdit();
+    component.startEditStatus();
 
     expect(component.isEditingStatus).toBe(true);
   });
 
-  it('should set isEditingStatus to false on endEdit', () => {
+  it('should set isEditingStatus to false on endEditStatus', () => {
     component.isEditingStatus = true;
-    component.endEdit();
+    component.endEditStatus();
 
     expect(component.isEditingStatus).toBe(false);
   });

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/details/overview/details-overview.component.ts
@@ -9,6 +9,7 @@ import {
   Status,
   statusFromFile,
 } from '../../../../services/compliance-and-enforcement/compliance-and-enforcement.service';
+import { ToastService } from '../../../../services/toast/toast.service';
 import { UserService } from '../../../../services/user/user.service';
 
 @Component({
@@ -21,10 +22,12 @@ export class DetailsOverviewComponent implements OnInit, OnDestroy {
   $destroy = new Subject<void>();
 
   isEditingStatus = false;
+  isEditingFilePath = false;
 
   fileNumber?: string;
 
   status = new FormControl<Status | null>(null);
+  filePath = new FormControl<string | null>(null);
 
   ROLES = ROLES;
   readonly userProfile = toSignal(this.userService.$userProfile);
@@ -32,6 +35,7 @@ export class DetailsOverviewComponent implements OnInit, OnDestroy {
   constructor(
     private readonly service: ComplianceAndEnforcementService,
     private readonly userService: UserService,
+    private readonly toastService: ToastService,
   ) {}
 
   ngOnInit(): void {
@@ -39,16 +43,37 @@ export class DetailsOverviewComponent implements OnInit, OnDestroy {
       if (file) {
         this.fileNumber = file.fileNumber;
         this.status.setValue(statusFromFile(file));
+        this.filePath.setValue(file.filePath);
       }
     });
   }
 
-  startEdit() {
+  startEditStatus() {
     this.isEditingStatus = true;
   }
 
-  endEdit() {
+  endEditStatus() {
     this.isEditingStatus = false;
+  }
+
+  cancelEditStatus() {
+    if (this.service.$file.value) {
+      this.status.setValue(statusFromFile(this.service.$file.value));
+    }
+    this.endEditStatus();
+  }
+
+  startEditFilePath() {
+    this.isEditingFilePath = true;
+  }
+
+  endEditFilePath() {
+    this.isEditingFilePath = false;
+  }
+
+  cancelEditFilePath() {
+    this.filePath.setValue(this.service.$file.value?.filePath ?? null);
+    this.endEditFilePath();
   }
 
   async saveStatus() {
@@ -59,7 +84,28 @@ export class DetailsOverviewComponent implements OnInit, OnDestroy {
     await this.service.setStatus(this.fileNumber, this.status.value, { idType: 'fileNumber' });
     this.service.loadFile(this.fileNumber, DEFAULT_C_AND_E_FETCH_OPTIONS);
 
-    this.endEdit();
+    this.endEditStatus();
+  }
+
+  async saveFilePath() {
+    if (!this.fileNumber || this.filePath.value === undefined || this.filePath.value === null) {
+      return;
+    }
+
+    await this.service.setFilePath(this.fileNumber, this.filePath.value, { idType: 'fileNumber' });
+    this.service.loadFile(this.fileNumber, DEFAULT_C_AND_E_FETCH_OPTIONS);
+
+    this.endEditFilePath();
+  }
+
+  async copyFilePath() {
+    if (!this.filePath.value) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(this.filePath.value);
+
+    this.toastService.showSuccessToast('File path copied to clipboard');
   }
 
   async ngOnDestroy() {

--- a/alcs-frontend/src/app/features/compliance-and-enforcement/overview/overview.component.spec.ts
+++ b/alcs-frontend/src/app/features/compliance-and-enforcement/overview/overview.component.spec.ts
@@ -1,21 +1,20 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormGroup } from '@angular/forms';
-import { StartOfDayPipe } from '../../../shared/pipes/startOfDay.pipe';
-import { OverviewComponent } from '../overview/overview.component';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import moment from 'moment';
 import {
-  ComplianceAndEnforcementDto,
   AllegedActivity,
+  ComplianceAndEnforcementDto,
   InitialSubmissionType,
 } from '../../../services/compliance-and-enforcement/compliance-and-enforcement.dto';
-import moment from 'moment';
-import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { ComplianceAndEnforcementService } from '../../../services/compliance-and-enforcement/compliance-and-enforcement.service';
 import { ToastService } from '../../../services/toast/toast.service';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { UserDto } from '../../../services/user/user.dto';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { StartOfDayPipe } from '../../../shared/pipes/startOfDay.pipe';
+import { OverviewComponent } from '../overview/overview.component';
 
 describe('OverviewComponent', () => {
   const mockUser: UserDto = {
@@ -47,6 +46,7 @@ describe('OverviewComponent', () => {
     chronologyClosedAt: 0,
     chronologyClosedBy: mockUser,
     assignee: null,
+    filePath: '',
   };
   let mockComplianceAndEnforcementService: DeepMocked<ComplianceAndEnforcementService>;
   let mockToastService: DeepMocked<ToastService>;
@@ -56,30 +56,30 @@ describe('OverviewComponent', () => {
     mockToastService = createMock();
 
     await TestBed.configureTestingModule({
-    declarations: [OverviewComponent, StartOfDayPipe],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [],
-    providers: [
+      declarations: [OverviewComponent, StartOfDayPipe],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [],
+      providers: [
         {
-            provide: ComplianceAndEnforcementService,
-            useValue: mockComplianceAndEnforcementService,
+          provide: ComplianceAndEnforcementService,
+          useValue: mockComplianceAndEnforcementService,
         },
         {
-            provide: ToastService,
-            useValue: mockToastService,
+          provide: ToastService,
+          useValue: mockToastService,
         },
         {
-            provide: ActivatedRoute,
-            useValue: {
-                snapshot: {
-                    paramMap: convertToParamMap({ fileNumber: '12345' }),
-                },
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: convertToParamMap({ fileNumber: '12345' }),
             },
+          },
         },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-    ]
-}).compileComponents();
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(OverviewComponent);
     component = fixture.componentInstance;
@@ -189,6 +189,7 @@ describe('OverviewComponent', () => {
       chronologyClosedAt: 0,
       chronologyClosedBy: mockUser,
       assignee: null,
+      filePath: '',
     };
 
     expect(component.form.value.dateSubmitted).toBeNull();

--- a/alcs-frontend/src/app/features/home/home.component.spec.ts
+++ b/alcs-frontend/src/app/features/home/home.component.spec.ts
@@ -118,6 +118,7 @@ describe('HomeComponent', () => {
         chronologyClosedAt: 0,
         chronologyClosedBy: mockUser,
         assignee: null,
+        filePath: '',
       });
 
       await component.createComplianceAndEnforcementFile();
@@ -153,6 +154,7 @@ describe('HomeComponent', () => {
         chronologyClosedAt: 0,
         chronologyClosedBy: mockUser,
         assignee: null,
+        filePath: '',
       };
 
       mockComplianceAndEnforcementService.create.mockResolvedValue(responseDto);

--- a/alcs-frontend/src/app/services/compliance-and-enforcement/compliance-and-enforcement.dto.ts
+++ b/alcs-frontend/src/app/services/compliance-and-enforcement/compliance-and-enforcement.dto.ts
@@ -34,6 +34,7 @@ export interface ComplianceAndEnforcementDto {
   chronologyClosedAt: number | null;
   chronologyClosedBy: UserDto | null;
   assignee: UserDto | null;
+  filePath: string;
 }
 
 export interface UpdateComplianceAndEnforcementDto {

--- a/alcs-frontend/src/app/services/compliance-and-enforcement/compliance-and-enforcement.service.ts
+++ b/alcs-frontend/src/app/services/compliance-and-enforcement/compliance-and-enforcement.service.ts
@@ -84,6 +84,18 @@ export class ComplianceAndEnforcementService {
     );
   }
 
+  async setFilePath(
+    id: string,
+    filePath: string,
+    options: { idType: string } = { idType: 'uuid' },
+  ): Promise<ComplianceAndEnforcementDto> {
+    return await firstValueFrom(
+      this.http.patch<ComplianceAndEnforcementDto>(`${this.url}/${id}/file-path?idType=${options.idType}`, {
+        filePath,
+      }),
+    );
+  }
+
   async delete(uuid: string): Promise<UpdateComplianceAndEnforcementDto> {
     return await firstValueFrom(this.http.delete<ComplianceAndEnforcementDto>(`${this.url}/${uuid}`));
   }

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.automapper.profile.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.automapper.profile.ts
@@ -92,6 +92,12 @@ export class ComplianceAndEnforcementProfile extends AutomapperProfile {
             return entity.assignee ? this.mapper.map(entity.assignee, User, UserDto) : entity.assignee;
           }),
         ),
+        forMember(
+          (dto) => dto.filePath,
+          mapFrom((entity) => {
+            return entity.filePath;
+          }),
+        ),
       );
 
       createMap(
@@ -153,6 +159,10 @@ export class ComplianceAndEnforcementProfile extends AutomapperProfile {
               ? new Date(dto.chronologyClosedAt)
               : dto.chronologyClosedAt,
           ),
+        ),
+        forMember(
+          (entity) => entity.filePath,
+          mapFrom((dto) => dto.filePath),
         ),
       );
     };

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.controller.spec.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.controller.spec.ts
@@ -56,6 +56,7 @@ describe('ComplianceAndEnforcementController', () => {
           allegedActivity: [],
           intakeNotes: '',
           chronologyClosedAt: 0,
+          filePath: '',
         },
         {
           uuid: '2',
@@ -68,6 +69,7 @@ describe('ComplianceAndEnforcementController', () => {
           allegedActivity: [],
           intakeNotes: '',
           chronologyClosedAt: 0,
+          filePath: '',
         },
       ];
       mockComplianceAndEnforcementService.fetchAll.mockResolvedValue(result);
@@ -89,6 +91,7 @@ describe('ComplianceAndEnforcementController', () => {
         allegedActivity: [],
         intakeNotes: '',
         chronologyClosedAt: 0,
+        filePath: '',
       };
       mockComplianceAndEnforcementService.fetchById.mockResolvedValue(result);
       expect(await controller.fetchByFileNumber('1', true)).toEqual(result);
@@ -110,6 +113,7 @@ describe('ComplianceAndEnforcementController', () => {
         allegedActivity: [],
         intakeNotes: '',
         chronologyClosedAt: 0,
+        filePath: '',
       };
       mockComplianceAndEnforcementService.create.mockResolvedValue(resultDto);
       expect(await controller.create(createDto, true)).toEqual(resultDto);
@@ -141,6 +145,7 @@ describe('ComplianceAndEnforcementController', () => {
         allegedActivity: [],
         intakeNotes: '',
         chronologyClosedAt: 0,
+        filePath: '',
       };
       mockComplianceAndEnforcementService.update.mockResolvedValue(resultDto);
       expect(await controller.update('1', updateDto)).toEqual(resultDto);

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.controller.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.controller.ts
@@ -1,12 +1,12 @@
 import { Body, Controller, Delete, Get, Param, ParseBoolPipe, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiOAuth2 } from '@nestjs/swagger';
 import * as config from 'config';
+import { DeleteResult } from 'typeorm';
+import { AUTH_ROLE, ROLES_ALLOWED_APPLICATIONS } from '../../common/authorization/roles';
 import { RolesGuard } from '../../common/authorization/roles-guard.service';
 import { UserRoles } from '../../common/authorization/roles.decorator';
-import { AUTH_ROLE, ROLES_ALLOWED_APPLICATIONS } from '../../common/authorization/roles';
-import { ComplianceAndEnforcementService, Status } from './compliance-and-enforcement.service';
 import { ComplianceAndEnforcementDto, UpdateComplianceAndEnforcementDto } from './compliance-and-enforcement.dto';
-import { DeleteResult } from 'typeorm';
+import { ComplianceAndEnforcementService, Status } from './compliance-and-enforcement.service';
 
 @Controller('compliance-and-enforcement')
 @ApiOAuth2(config.get<string[]>('KEYCLOAK.SCOPES'))
@@ -59,6 +59,16 @@ export class ComplianceAndEnforcementController {
     @Query('idType') idType: string = 'uuid',
   ): Promise<ComplianceAndEnforcementDto> {
     return await this.service.setStatus(id, status, { idType });
+  }
+
+  @Patch('/:id/file-path')
+  @UserRoles(AUTH_ROLE.ADMIN, AUTH_ROLE.C_AND_E)
+  async setFilePath(
+    @Param('id') id: string,
+    @Body() filePath: { filePath: string },
+    @Query('idType') idType: string = 'uuid',
+  ): Promise<ComplianceAndEnforcementDto> {
+    return await this.service.setFilePath(id, filePath.filePath, { idType });
   }
 
   @Post('/:id/submit')

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.dto.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.dto.ts
@@ -51,6 +51,9 @@ export class ComplianceAndEnforcementDto {
 
   @AutoMap()
   assignee?: UserDto;
+
+  @AutoMap()
+  filePath: string;
 }
 
 export class UpdateComplianceAndEnforcementDto {
@@ -99,4 +102,8 @@ export class UpdateComplianceAndEnforcementDto {
   @IsOptional()
   @IsString()
   assigneeUuid?: string | null;
+
+  @IsOptional()
+  @IsString()
+  filePath?: string;
 }

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.entity.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.entity.ts
@@ -92,4 +92,8 @@ export class ComplianceAndEnforcement extends Base {
   @AutoMap()
   @ManyToOne(() => User, { nullable: true })
   assignee: User | null;
+
+  @AutoMap()
+  @Column({ type: 'text', default: '' })
+  filePath: string;
 }

--- a/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.service.ts
+++ b/services/apps/alcs/src/alcs/compliance-and-enforcement/compliance-and-enforcement.service.ts
@@ -1,23 +1,23 @@
 import { Injectable } from '@nestjs/common';
-import { DeleteResult, In, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ComplianceAndEnforcement } from './compliance-and-enforcement.entity';
-import { ComplianceAndEnforcementDto, UpdateComplianceAndEnforcementDto } from './compliance-and-enforcement.dto';
-import { InjectMapper } from 'automapper-nestjs';
 import { Mapper } from 'automapper-core';
+import { InjectMapper } from 'automapper-nestjs';
+import { DeleteResult, In, Repository } from 'typeorm';
 import {
   ServiceConflictException,
   ServiceNotFoundException,
   ServiceValidationException,
 } from '../../../../../libs/common/src/exceptions/base.exception';
-import { ComplianceAndEnforcementSubmitterService } from './submitter/submitter.service';
-import { ComplianceAndEnforcementPropertyService } from './property/property.service';
-import { ComplianceAndEnforcementDocument } from './document/document.entity';
+import { UserService } from '../../user/user.service';
 import {
   ComplianceAndEnforcementValidatorService,
   ValidatedComplianceAndEnforcement,
 } from './compliance-and-enforcement-validator.service';
-import { UserService } from '../../user/user.service';
+import { ComplianceAndEnforcementDto, UpdateComplianceAndEnforcementDto } from './compliance-and-enforcement.dto';
+import { ComplianceAndEnforcement } from './compliance-and-enforcement.entity';
+import { ComplianceAndEnforcementDocument } from './document/document.entity';
+import { ComplianceAndEnforcementPropertyService } from './property/property.service';
+import { ComplianceAndEnforcementSubmitterService } from './submitter/submitter.service';
 
 export enum Status {
   OPEN = 'Open',
@@ -166,6 +166,21 @@ export class ComplianceAndEnforcementService {
         updateDto.dateOpened = new Date().getTime();
       }
     }
+
+    return this.update(id, updateDto, options);
+  }
+
+  async setFilePath(
+    id: string,
+    filePath: string,
+    options: { idType: string } = { idType: 'uuid' },
+  ): Promise<ComplianceAndEnforcementDto> {
+    const entity = await this.repository.findOneBy({ [options.idType]: id });
+    if (entity === null) {
+      throw new ServiceConflictException('A C&E file with this UUID does not exist. Unable to update.');
+    }
+
+    const updateDto: UpdateComplianceAndEnforcementDto = { filePath };
 
     return this.update(id, updateDto, options);
   }

--- a/services/apps/alcs/src/providers/typeorm/migrations/1786474625115-add_c_and_e_file_path_column.ts
+++ b/services/apps/alcs/src/providers/typeorm/migrations/1786474625115-add_c_and_e_file_path_column.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCAndEFilePathColumn1786474625115 implements MigrationInterface {
+  name = 'AddCAndEFilePathColumn1786474625115';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alcs"."compliance_and_enforcement" ADD "file_path" text NOT NULL DEFAULT ''`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alcs"."compliance_and_enforcement" DROP COLUMN "file_path"`);
+  }
+}


### PR DESCRIPTION
- Add editable field for file path
- Fix bug with status where cancelling a changed status causes change to persist in UI even though it hasn't been saved